### PR TITLE
feat(extension): add explicit source config

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,29 @@ Inside chat, `/skill` lists discovered skills. Use `/skill my-skill` or `/skill:
 
 Extensions are trusted local code. librecode follows the Unix philosophy here: extensions are powerful, low-level, and allowed to footgun if you ask them to. Lua is the first supported extension runtime; the host is designed so additional runtimes can be added later.
 
-Default extension roots come from `extensions.paths` in config, defaulting to:
+Extensions are declared with `extensions.use` in config. The default source is:
 
-- `.librecode/extensions`
+```yaml
+extensions:
+  enabled: true
+  use:
+    - path:.librecode/extensions
+```
+
+The extension manager interface supports source strings and object entries with versions:
+
+```yaml
+extensions:
+  use:
+    - official:vim-mode
+    - github:example/librecode-extension
+    - github:example/monorepo//extensions/fancy
+    - path:.librecode/extensions/local-dev
+    - source: github:example/librecode-extension
+      version: v1.2.3
+```
+
+Startup loads only entries declared in `extensions.use`; extra directories on disk are ignored. `path:` sources load from disk today, while `official:` and `github:` sources are installed and pinned by the extension manager.
 
 The default chat UI is Go-owned and extensions are optional customization. Use `--no-extensions` to disable configured extensions for a single run.
 
@@ -228,15 +248,22 @@ For architecture, roadmap, and API details, see:
 - [`docs/adr/0001-programmable-runtime.md`](docs/adr/0001-programmable-runtime.md)
 - [`docs/runtime-architecture.md`](docs/runtime-architecture.md)
 - [`docs/extension-runtime.md`](docs/extension-runtime.md)
+- [`docs/extension-manager.md`](docs/extension-manager.md)
 - [`docs/extension-roadmap.md`](docs/extension-roadmap.md)
 - [`docs/extension-api.md`](docs/extension-api.md)
 - [`docs/rendering-boundary.md`](docs/rendering-boundary.md)
 - [`docs/skills.md`](docs/skills.md)
 
-Inspect loaded extensions:
+Inspect and manage extensions:
 
 ```bash
 librecode extension list
+librecode extension add <source> [--version vX.Y.Z]
+librecode extension remove <source-or-name>
+librecode extension install
+librecode extension update
+librecode extension tidy
+librecode extension doctor
 librecode extension run <command> [args...]
 ```
 
@@ -275,6 +302,12 @@ librecode skill validate
 librecode tool list
 librecode tool run <name> [json-args|-] [--cwd path]
 librecode extension list
+librecode extension add <source> [--version vX.Y.Z]
+librecode extension remove <source-or-name>
+librecode extension install
+librecode extension update
+librecode extension tidy
+librecode extension doctor
 librecode extension run <command> [args...]
 librecode config show
 librecode config validate

--- a/cmd/librecode/config.go
+++ b/cmd/librecode/config.go
@@ -129,7 +129,7 @@ func configEntries(cfg *config.Config) []configEntry {
 		{key: "database.max_idle_conns", value: fmt.Sprint(cfg.Database.MaxIdleConns)},
 		{key: "database.conn_max_lifetime", value: cfg.Database.ConnMaxLifetime.String()},
 		{key: "extensions.enabled", value: fmt.Sprint(cfg.Extensions.Enabled)},
-		{key: "extensions.paths", value: strings.Join(cfg.Extensions.Paths, ",")},
+		{key: "extensions.use", value: strings.Join(extensionUseSources(cfg.Extensions.Use), ",")},
 		{key: "assistant.provider", value: cfg.Assistant.Provider},
 		{key: "assistant.model", value: cfg.Assistant.Model},
 		{key: "assistant.thinking_level", value: cfg.Assistant.ThinkingLevel},
@@ -144,6 +144,16 @@ func configEntries(cfg *config.Config) []configEntry {
 // resolveEnv returns the environment label, falling back to the provided default.
 func resolveEnv(env, fallback string) string {
 	return mo.EmptyableToOption(env).OrElse(fallback)
+}
+
+func extensionUseSources(entries []config.ExtensionUse) []string {
+	return lo.Map(entries, func(entry config.ExtensionUse, _ int) string {
+		if entry.Version == "" {
+			return entry.Source
+		}
+
+		return fmt.Sprintf("%s@%s", entry.Source, entry.Version)
+	})
 }
 
 // upperEnvKeys returns config keys uppercased with a given prefix (e.g. "LIBRECODE_APP_NAME").

--- a/cmd/librecode/extension.go
+++ b/cmd/librecode/extension.go
@@ -29,14 +29,15 @@ func newExtensionCmd() *cobra.Command {
 func newExtensionListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   listUse,
-		Short: "List loaded workflow extensions, commands, and tools",
+		Short: "List configured and loaded workflow extensions",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return withContainer(cmd.Context(), func(container *di.Container) error {
-				manager := di.MustInvoke[*di.ExtensionService](container).Manager
-				extensions := manager.Extensions()
-				for index := range extensions {
-					if err := printExtension(cmd, &extensions[index]); err != nil {
+				service := di.MustInvoke[*di.ExtensionService](container)
+				loadedByPath := loadedExtensionsByPath(service.Manager.Extensions())
+				for index := range service.State.Configured {
+					configuredExtension := &service.State.Configured[index]
+					if err := printConfiguredExtension(cmd, configuredExtension, loadedByPath); err != nil {
 						return err
 					}
 				}
@@ -66,12 +67,25 @@ func newExtensionRunCmd() *cobra.Command {
 	}
 }
 
-func printExtension(cmd *cobra.Command, loadedExtension *extension.LoadedExtension) error {
+func printConfiguredExtension(
+	cmd *cobra.Command,
+	configuredExtension *extension.ResolvedSource,
+	loadedByPath map[string]extension.LoadedExtension,
+) error {
+	loadedExtension, loaded := loadedByPath[configuredExtension.LoadPath]
+	status := configuredExtension.Status
+	if loaded {
+		status = "loaded"
+	}
+
 	_, err := fmt.Fprintf(
 		cmd.OutOrStdout(),
-		"%s\t%s\tcommands=%s\ttools=%s\tkeymaps=%s\thandlers=%s\ttimers=%d\tduration=%s\n",
-		loadedExtension.Name,
-		loadedExtension.Path,
+		"%s\t%s\t%s\tversion=%s\tpath=%s\tcommands=%s\ttools=%s\tkeymaps=%s\thandlers=%s\ttimers=%d\tduration=%s\n",
+		configuredExtension.Name,
+		configuredExtension.Ref.Key(),
+		status,
+		configuredExtension.Lock.Version,
+		configuredExtension.LoadPath,
 		strings.Join(loadedExtension.Commands, ","),
 		strings.Join(loadedExtension.Tools, ","),
 		strings.Join(loadedExtension.Keymaps, ","),
@@ -84,4 +98,14 @@ func printExtension(cmd *cobra.Command, loadedExtension *extension.LoadedExtensi
 	}
 
 	return nil
+}
+
+func loadedExtensionsByPath(loadedExtensions []extension.LoadedExtension) map[string]extension.LoadedExtension {
+	loadedByPath := make(map[string]extension.LoadedExtension, len(loadedExtensions))
+	for index := range loadedExtensions {
+		loadedExtension := loadedExtensions[index]
+		loadedByPath[loadedExtension.Path] = loadedExtension
+	}
+
+	return loadedByPath
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -19,8 +19,21 @@ database:
 
 extensions:
   enabled: true
-  paths:
-    - .librecode/extensions
+  # Extension sources use scheme:value syntax. Startup loads only entries listed
+  # here; extra directories on disk are ignored unless explicitly declared.
+  use:
+    # Shorthand string form.
+    - path:.librecode/extensions
+    - official:vim-mode
+    - github:example/librecode-extension
+    - github:example/monorepo//extensions/fancy
+    - path:/absolute/or/relative/extension
+
+    # Object form with version pinning.
+    - source: official:vim-mode
+      version: v0.1.0
+    - source: github:example/librecode-extension
+      version: v1.2.3
 
 assistant:
   provider: openai-codex

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -16,32 +16,63 @@ See also:
 
 ## Loading model
 
-Extensions are trusted local Lua files loaded from configured `extensions.paths`.
+Extensions are trusted local Lua files loaded from configured `extensions.use` sources.
 
-By default, configured extension paths are:
+Default config:
 
-- `.librecode/extensions`
+```yaml
+extensions:
+  enabled: true
+  use:
+    - path:.librecode/extensions
+```
+
+Supported source declaration forms:
+
+```yaml
+extensions:
+  use:
+    # shorthand string form
+    - official:vim-mode
+    - github:example/librecode-extension
+    - github:example/monorepo//extensions/fancy
+    - path:.librecode/extensions/my-extension
+    - path:/absolute/or/relative/extension
+
+    # object form with version pinning
+    - source: official:vim-mode
+      version: v0.1.0
+    - source: github:example/librecode-extension
+      version: v1.2.3
+```
+
+Startup loads only entries declared in `extensions.use`; extra directories on disk are ignored. `path:` sources load from disk today. `official:` and `github:` sources are installed and pinned by the extension manager. Unknown schemes are configuration errors.
 
 librecode does not auto-load a bundled `extensions/` directory. The stock chat UI is implemented in Go; Lua extensions are optional customization. Use `--no-extensions` to skip configured extensions for one command.
 
-Each Lua file runs in its own Lua state.
-
-Lua helper modules can live under a `lua/` subdirectory inside any configured extension root, or next to a loaded extension file. The extension manager adds those roots to `package.path` and skips `lua/` helper directories when discovering top-level extension files.
-
-Example:
+Each Lua file or directory extension entry runs in its own Lua state. Directory extensions use a small manifest plus entry file:
 
 ```text
-.librecode/extensions/
-  my-workflow.lua
-  lua/
-    my_workflow/
-      helpers.lua
+.librecode/extensions/my-workflow/
+  init.lua
+  workflow.lua
+  helpers.lua
 ```
 
-Then extensions can do:
+```lua
+-- init.lua
+return {
+  name = "my-workflow",
+  version = "0.1.0",
+  api_version = "v1alpha1",
+  entry = "workflow.lua",
+}
+```
+
+The extension root is added to `package.path`, so entry files can require sibling modules:
 
 ```lua
-local helpers = require("my_workflow.helpers")
+local helpers = require("helpers")
 ```
 
 Helper modules are convenience wrappers over primitive APIs. They are not a separate Go host API family.

--- a/docs/extension-manager.md
+++ b/docs/extension-manager.md
@@ -1,0 +1,293 @@
+# Extension manager architecture
+
+This document defines the extension manager we want to build. It is the stable architecture contract for installing, locking, loading, updating, and diagnosing librecode extensions.
+
+The core decision:
+
+> Extensions are explicit dependencies, not arbitrary files that happen to exist on disk.
+
+The stock librecode UI remains Go-owned and fast. Extensions are trusted optional code loaded only when the user/project explicitly declares them.
+
+## Goals
+
+- Make extension loading predictable and reproducible.
+- Support first-party, GitHub-hosted, and local development extensions.
+- Keep Lua as one runtime adapter behind a runtime-neutral extension host.
+- Avoid embedding official extensions in the binary.
+- Avoid auto-executing random directories under `.librecode/extensions`.
+- Provide commands that feel like a package manager, not a manual copy workflow.
+
+## Non-goals
+
+- Sandboxing extension code.
+- Moving the stock chat UI into Lua.
+- Auto-loading every extension present on disk.
+- Designing a Lua-only architecture that blocks future shell/toolbox/MCP/mvm-style runtimes.
+
+## Configuration
+
+Extensions are configured through `extensions.use`.
+
+```yaml
+extensions:
+  enabled: true
+  use:
+    - official:vim-mode
+    - github:example/librecode-extension
+    - github:example/monorepo//extensions/fancy
+    - path:.librecode/extensions/local-dev
+
+    - source: official:vim-mode
+      version: v0.1.0
+    - source: github:example/librecode-extension
+      version: v1.2.3
+```
+
+Supported forms:
+
+- string source: `official:vim-mode`
+- object source: `{ source: github:user/ext, version: v1.2.3 }`
+
+Supported schemes:
+
+- `official:<name>` — first-party extension alias.
+- `github:<owner>/<repo>` — extension at repository root.
+- `github:<owner>/<repo>//<subdir>` — extension inside a repository subdirectory.
+- `path:<path>` — local extension directory or Lua file.
+
+No `local:` scheme is supported. Use `path:` for local filesystem extensions.
+
+## Explicit loading rule
+
+At app startup, librecode loads only entries declared in `extensions.use`.
+
+It must not recursively auto-load all directories under:
+
+- `./.librecode/extensions`
+- `~/.librecode/extensions`
+- any installed extension cache directory
+
+This rule prevents stale clones, experimental worktrees, or removed extensions from executing unexpectedly.
+
+## Install locations
+
+Global extension manager state lives under librecode home:
+
+```text
+~/.librecode/
+  config.yaml
+  extensions-lock.yaml
+  extensions/
+    store/
+      github.com/<owner>/<repo>/...
+      official/<name>/...
+```
+
+Project-local extension config and lock can live under:
+
+```text
+./.librecode/
+  config.yaml
+  extensions-lock.yaml
+  extensions/
+    local-dev-extension/
+```
+
+Project config wins over global config when it is present, matching the broader librecode config model.
+
+## Lockfile
+
+The lockfile pins resolved extension versions/tags. It is human-readable and version-first, not commit-first.
+
+Recommended shape:
+
+```yaml
+extensions:
+  official:vim-mode:
+    resolved: github:omarluq/librecode//extensions/vim-mode
+    version: v0.1.0
+
+  github:example/librecode-extension:
+    version: v1.2.3
+```
+
+Field meanings:
+
+- key: original configured source.
+- `resolved`: canonical source when the configured source is an alias like `official:*`.
+- `version`: resolved tag/version to install.
+
+The initial implementation should not require commit hashes. A future implementation may add a checksum or commit for verification, but the primary user-facing lock should stay tag/version based.
+
+## Commands
+
+The core command set:
+
+```bash
+librecode extension list
+librecode extension add <source> [--version vX.Y.Z]
+librecode extension remove <source-or-name>
+librecode extension install
+librecode extension update
+librecode extension tidy
+librecode extension doctor
+```
+
+### `list`
+
+Shows configured, installed, loaded, errored, and disabled extensions.
+
+Expected columns:
+
+- name
+- source
+- version
+- status
+- runtime
+- entry
+- diagnostics/errors
+
+### `add`
+
+Adds an entry to `extensions.use`, installs it immediately, and updates the lockfile.
+
+Example:
+
+```bash
+librecode extension add official:vim-mode
+librecode extension add github:example/librecode-extension --version v1.2.3
+```
+
+### `remove`
+
+Removes an entry from `extensions.use`, runs tidy immediately, and updates the lockfile.
+
+Example:
+
+```bash
+librecode extension remove vim-mode
+librecode extension remove official:vim-mode
+```
+
+### `install`
+
+Reconciles config + lock into installed extension files.
+
+Rules:
+
+- honor existing lockfile versions when present;
+- install missing locked extensions;
+- resolve and lock missing versions for configured entries;
+- never update already locked versions unless `update` is requested.
+
+### `update`
+
+Resolves newer versions/tags for configured non-`path:` entries, installs them, and rewrites the lockfile.
+
+Initial implementation can update all extensions. Later, support:
+
+```bash
+librecode extension update vim-mode
+```
+
+### `tidy`
+
+Removes installed extension directories that are no longer referenced by config or lock.
+
+### `doctor`
+
+Validates extension config, lockfile, installed directories, manifests, runtime compatibility, and load errors.
+
+## Official registry
+
+Official extensions are aliases resolved by librecode.
+
+Initial registry:
+
+```yaml
+official:
+  vim-mode:
+    source: github:omarluq/librecode//extensions/vim-mode
+    version: v0.1.0
+```
+
+The registry can start as a small Go map. Later it may be fetched from `librecode.sh` or from release metadata.
+
+Official extensions are not embedded into the binary. They are installed like any other extension.
+
+## Directory extension format
+
+A directory extension has an `init.lua` manifest.
+
+```text
+my-extension/
+  init.lua
+  main.lua
+  helpers.lua
+```
+
+Manifest:
+
+```lua
+return {
+  name = "my-extension",
+  version = "0.1.0",
+  api_version = "v1alpha1",
+  description = "Example extension.",
+  entry = "main.lua",
+}
+```
+
+The manifest should stay small and declarative. Behavior belongs in the entry file and sibling modules.
+
+## Runtime adapter boundary
+
+The extension manager installs and resolves extensions. The extension host loads them through runtime adapters.
+
+Current runtime:
+
+- Lua adapter
+
+Future runtimes:
+
+- shell hooks
+- toolbox executables
+- MCP-backed tool collections
+- experimental Go-like runtime adapter
+
+The manager should not know about Lua internals beyond manifest/runtime selection. Runtime-specific loading belongs in the adapter.
+
+## Startup flow
+
+1. Load config.
+2. If extensions are disabled or `--no-extensions` is set, skip extension loading.
+3. Read `extensions.use`.
+4. Resolve each source:
+   - `path:` directly to filesystem;
+   - `official:` through the official registry and lock;
+   - `github:` through install store and lock.
+5. Load only resolved entries.
+6. Report load diagnostics through `extension list` and logs.
+
+## Failure policy
+
+Extensions are trusted, but failures should not silently corrupt the app.
+
+- Invalid config should fail validation with a clear message.
+- Missing installed remote extensions should tell the user to run `librecode extension install`.
+- Invalid manifests should show in `extension doctor` and `extension list`.
+- Runtime errors should disable that extension for the current load and keep librecode usable.
+
+## Acceptance criteria
+
+The extension manager is ready when:
+
+- `extensions.use` is the only source of loaded extensions.
+- `path:`, `official:`, and `github:` parse consistently in string and object forms.
+- `librecode extension add/remove/install/update/tidy/doctor/list` exist.
+- `add` installs immediately and updates config + lock.
+- `remove` tidies immediately and updates config + lock.
+- `install` is deterministic from config + lock.
+- `update` updates versions/tags intentionally.
+- official `vim-mode` can be installed without embedding it in the binary.
+- extension loading remains off the hot render path unless an extension is explicitly active.

--- a/docs/extension-roadmap.md
+++ b/docs/extension-roadmap.md
@@ -65,6 +65,44 @@ The previous render-loop slowdown came from rebuilding too much transcript text 
 
 They are useful names and roles, but they should not become special host APIs.
 
+## Phase 0: explicit extension manager
+
+Status: planned; see [`docs/extension-manager.md`](extension-manager.md).
+
+Goal: make extension dependencies explicit, installable, lockable, and reproducible without embedding official extensions in the binary.
+
+Planned interface:
+
+```yaml
+extensions:
+  enabled: true
+  use:
+    - official:vim-mode
+    - github:user/ext
+    - source: github:user/ext
+      version: v1.2.3
+    - path:.librecode/extensions/local-dev
+```
+
+Planned commands:
+
+- `librecode extension list`
+- `librecode extension add <source> [--version vX.Y.Z]`
+- `librecode extension remove <source-or-name>`
+- `librecode extension install`
+- `librecode extension update`
+- `librecode extension tidy`
+- `librecode extension doctor`
+
+Design constraints:
+
+- startup loads only entries declared in `extensions.use`
+- extra directories on disk are ignored unless explicitly declared
+- `add` installs immediately and updates config + lock
+- `remove` tidies immediately and updates config + lock
+- lockfiles pin human-readable versions/tags first
+- official extensions are installed through the manager, not embedded into the binary
+
 ## Phase 1: generic structured buffers
 
 Status: implemented for the current runtime surface.

--- a/docs/extension-runtime.md
+++ b/docs/extension-runtime.md
@@ -66,24 +66,35 @@ That means users should be able to:
 
 ## Loader
 
-Extensions are loaded by `internal/extension.Manager`.
-
-Default roots today come from configured `extensions.paths` entries.
+Extensions are loaded by `internal/extension.Manager` from configured `extensions.use` entries.
 
 Configured defaults currently come from `config/loader.go`:
 
-- `.librecode/extensions`
+```yaml
+extensions:
+  enabled: true
+  use:
+    - path:.librecode/extensions
+```
+
+Source schemes:
+
+- `path:<path>` loads extension files or directories from disk today.
+- `official:<name>` names first-party extensions for the extension manager.
+- `github:<owner>/<repo>` and `github:<owner>/<repo>//<subdir>` reserve the remote install/update interface.
 
 No bundled extension root is prepended automatically. Passing `--no-extensions` disables configured Lua extensions for the current command without changing config.
 
 The loader:
 
-- resolves each configured file or directory
-- recursively discovers `*.lua`
-- creates a dedicated Lua state per file
+- resolves configured sources only
+- resolves `path:` sources directly today
+- resolves future `official:` and `github:` entries through the extension manager install store and lockfile
+- discovers Lua files and directory manifests
+- creates a dedicated Lua state per extension entry
 - opens trusted standard libraries
 - installs the `librecode` Lua module/API table
-- executes the file
+- executes the entry file
 - records registered commands, tools, keymaps, and handlers
 
 ## Runtime model

--- a/internal/assistant/client.go
+++ b/internal/assistant/client.go
@@ -68,7 +68,7 @@ type CompletionResult struct {
 	Text       string           `json:"text"`
 	Thinking   []string         `json:"thinking,omitempty"`
 	ToolEvents []ToolEvent      `json:"tool_events,omitempty"`
-	Usage      model.TokenUsage `json:"usage,omitempty"`
+	Usage      model.TokenUsage `json:"usage"`
 }
 
 // ToolEvent captures one tool call for persistence and TUI rendering.

--- a/internal/assistant/runtime.go
+++ b/internal/assistant/runtime.go
@@ -90,7 +90,7 @@ type PromptResponse struct {
 	Text             string           `json:"text"`
 	Thinking         []string         `json:"thinking,omitempty"`
 	ToolEvents       []ToolEvent      `json:"tool_events,omitempty"`
-	Usage            model.TokenUsage `json:"usage,omitempty"`
+	Usage            model.TokenUsage `json:"usage"`
 	Cached           bool             `json:"cached"`
 }
 

--- a/internal/assistant/runtime_test.go
+++ b/internal/assistant/runtime_test.go
@@ -523,8 +523,8 @@ func testConfig() *config.Config {
 			ConnMaxLifetime: time.Minute,
 		},
 		Extensions: config.ExtensionsConfig{
+			Use:     []config.ExtensionUse{},
 			Enabled: true,
-			Paths:   []string{},
 		},
 		Assistant: config.AssistantConfig{
 			Retry: config.RetryConfig{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,6 +178,9 @@ func (config *Config) validateExtensions() error {
 		if extensionUse.Source == "" {
 			return fmt.Errorf("config: extensions.use source is required")
 		}
+		if _, err := extension.ParseSourceRef(extensionUse.Source, extensionUse.Version); err != nil {
+			return fmt.Errorf("config: invalid extensions.use source %q: %w", extensionUse.Source, err)
+		}
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,8 @@ package config
 import (
 	"fmt"
 	"time"
+
+	"github.com/omarluq/librecode/internal/extension"
 )
 
 // Config is the fully resolved application configuration.
@@ -46,9 +48,12 @@ type DatabaseConfig struct {
 
 // ExtensionsConfig controls workflow extension discovery and execution.
 type ExtensionsConfig struct {
-	Paths   []string `json:"paths" mapstructure:"paths" yaml:"paths"`
-	Enabled bool     `json:"enabled" mapstructure:"enabled" yaml:"enabled"`
+	Use     []ExtensionUse `json:"use" mapstructure:"use" yaml:"use"`
+	Enabled bool           `json:"enabled" mapstructure:"enabled" yaml:"enabled"`
 }
+
+// ExtensionUse declares one extension source.
+type ExtensionUse = extension.ConfiguredSource
 
 // AssistantConfig controls the assistant runtime defaults.
 type AssistantConfig struct {
@@ -103,6 +108,7 @@ func (config *Config) Validate() error {
 		config.validateApp,
 		config.validateLogging,
 		config.validateDatabase,
+		config.validateExtensions,
 		config.validateAssistant,
 		config.validateCache,
 		config.validateKSQL,
@@ -162,6 +168,16 @@ func (config *Config) validateDatabase() error {
 	}
 	if config.Database.ConnMaxLifetime < 0 {
 		return fmt.Errorf("config: database.conn_max_lifetime cannot be negative")
+	}
+
+	return nil
+}
+
+func (config *Config) validateExtensions() error {
+	for _, extensionUse := range config.Extensions.Use {
+		if extensionUse.Source == "" {
+			return fmt.Errorf("config: extensions.use source is required")
+		}
 	}
 
 	return nil

--- a/internal/config/extensions.go
+++ b/internal/config/extensions.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/spf13/viper"
+)
+
+const defaultLocalExtensionSource = "path:.librecode/extensions"
+
+func unmarshalConfig(viperInstance *viper.Viper, cfg *Config) error {
+	settings := viperInstance.AllSettings()
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: decodeExtensionUseHook,
+		Result:     cfg,
+		TagName:    "mapstructure",
+	})
+	if err != nil {
+		return fmt.Errorf("config: create decoder: %w", err)
+	}
+	if err := decoder.Decode(settings); err != nil {
+		return fmt.Errorf("config: unmarshal: %w", err)
+	}
+
+	return nil
+}
+
+func decodeExtensionUseHook(_, to reflect.Type, data any) (any, error) {
+	if to != reflect.TypeOf(ExtensionUse{Source: "", Version: ""}) {
+		return data, nil
+	}
+
+	switch value := data.(type) {
+	case string:
+		return ExtensionUse{Source: strings.TrimSpace(value), Version: ""}, nil
+	case map[string]any:
+		return decodeExtensionUseMap(value), nil
+	case map[any]any:
+		converted := make(map[string]any, len(value))
+		for key, mapValue := range value {
+			converted[fmt.Sprint(key)] = mapValue
+		}
+		return decodeExtensionUseMap(converted), nil
+	default:
+		return data, nil
+	}
+}
+
+func decodeExtensionUseMap(value map[string]any) ExtensionUse {
+	return ExtensionUse{
+		Source:  extensionUseString(value["source"]),
+		Version: extensionUseString(value["version"]),
+	}
+}
+
+func extensionUseString(value any) string {
+	if value == nil {
+		return ""
+	}
+
+	return strings.TrimSpace(fmt.Sprint(value))
+}

--- a/internal/config/extensions.go
+++ b/internal/config/extensions.go
@@ -14,9 +14,12 @@ const defaultLocalExtensionSource = "path:.librecode/extensions"
 func unmarshalConfig(viperInstance *viper.Viper, cfg *Config) error {
 	settings := viperInstance.AllSettings()
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		DecodeHook: decodeExtensionUseHook,
-		Result:     cfg,
-		TagName:    "mapstructure",
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			mapstructure.StringToTimeDurationHookFunc(),
+			decodeExtensionUseHook,
+		),
+		Result:  cfg,
+		TagName: "mapstructure",
 	})
 	if err != nil {
 		return fmt.Errorf("config: create decoder: %w", err)

--- a/internal/config/extensions.go
+++ b/internal/config/extensions.go
@@ -29,7 +29,7 @@ func unmarshalConfig(viperInstance *viper.Viper, cfg *Config) error {
 }
 
 func decodeExtensionUseHook(_, to reflect.Type, data any) (any, error) {
-	if to != reflect.TypeOf(ExtensionUse{Source: "", Version: ""}) {
+	if to != reflect.TypeFor[ExtensionUse]() {
 		return data, nil
 	}
 

--- a/internal/config/extensions_test.go
+++ b/internal/config/extensions_test.go
@@ -1,0 +1,61 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/config"
+)
+
+func TestLoadParsesExtensionUseStringForm(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadExtensionConfigFromContent(t, `extensions:
+  use:
+    - " path:.librecode/extensions "
+`)
+
+	require.Len(t, cfg.Extensions.Use, 1)
+	assert.Equal(t, config.ExtensionUse{Source: "path:.librecode/extensions", Version: ""}, cfg.Extensions.Use[0])
+}
+
+func TestLoadParsesExtensionUseObjectForm(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadExtensionConfigFromContent(t, `extensions:
+  use:
+    - source: " official:vim-mode "
+      version: " v0.1.0 "
+`)
+
+	require.Len(t, cfg.Extensions.Use, 1)
+	assert.Equal(t, config.ExtensionUse{Source: "official:vim-mode", Version: "v0.1.0"}, cfg.Extensions.Use[0])
+}
+
+func TestLoadParsesExtensionUseInlineObjectForm(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadExtensionConfigFromContent(t, `extensions:
+  use:
+    - {source: "github:owner/repo", version: "v1.0.0"}
+`)
+
+	require.Len(t, cfg.Extensions.Use, 1)
+	assert.Equal(t, config.ExtensionUse{Source: "github:owner/repo", Version: "v1.0.0"}, cfg.Extensions.Use[0])
+}
+
+func loadExtensionConfigFromContent(t *testing.T, content string) *config.Config {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	loaded := config.Load(path)
+	require.True(t, loaded.IsOk(), "config load failed: %v", loaded.Error())
+
+	return loaded.MustGet()
+}

--- a/internal/config/extensions_test.go
+++ b/internal/config/extensions_test.go
@@ -11,41 +11,51 @@ import (
 	"github.com/omarluq/librecode/internal/config"
 )
 
-func TestLoadParsesExtensionUseStringForm(t *testing.T) {
+func TestLoadParsesExtensionUseDecodeForms(t *testing.T) {
 	t.Parallel()
 
-	cfg := loadExtensionConfigFromContent(t, `extensions:
+	tests := []struct {
+		name     string
+		input    string
+		expected config.ExtensionUse
+	}{
+		{
+			name: "string form",
+			input: `extensions:
   use:
     - " path:.librecode/extensions "
-`)
-
-	require.Len(t, cfg.Extensions.Use, 1)
-	assert.Equal(t, config.ExtensionUse{Source: "path:.librecode/extensions", Version: ""}, cfg.Extensions.Use[0])
-}
-
-func TestLoadParsesExtensionUseObjectForm(t *testing.T) {
-	t.Parallel()
-
-	cfg := loadExtensionConfigFromContent(t, `extensions:
+`,
+			expected: config.ExtensionUse{Source: "path:.librecode/extensions", Version: ""},
+		},
+		{
+			name: "object form",
+			input: `extensions:
   use:
     - source: " official:vim-mode "
       version: " v0.1.0 "
-`)
-
-	require.Len(t, cfg.Extensions.Use, 1)
-	assert.Equal(t, config.ExtensionUse{Source: "official:vim-mode", Version: "v0.1.0"}, cfg.Extensions.Use[0])
-}
-
-func TestLoadParsesExtensionUseInlineObjectForm(t *testing.T) {
-	t.Parallel()
-
-	cfg := loadExtensionConfigFromContent(t, `extensions:
+`,
+			expected: config.ExtensionUse{Source: "official:vim-mode", Version: "v0.1.0"},
+		},
+		{
+			name: "inline object form",
+			input: `extensions:
   use:
     - {source: "github:owner/repo", version: "v1.0.0"}
-`)
+`,
+			expected: config.ExtensionUse{Source: "github:owner/repo", Version: "v1.0.0"},
+		},
+	}
 
-	require.Len(t, cfg.Extensions.Use, 1)
-	assert.Equal(t, config.ExtensionUse{Source: "github:owner/repo", Version: "v1.0.0"}, cfg.Extensions.Use[0])
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := loadExtensionConfigFromContent(t, testCase.input)
+
+			require.Len(t, cfg.Extensions.Use, 1)
+			assert.Equal(t, testCase.expected, cfg.Extensions.Use[0])
+		})
+	}
 }
 
 func loadExtensionConfigFromContent(t *testing.T, content string) *config.Config {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -15,6 +15,22 @@ import (
 
 // Load resolves configuration from defaults, environment variables, and an optional file.
 func Load(path string) mo.Result[*Config] {
+	loaded, err := LoadResolved(path)
+	if err != nil {
+		return mo.Err[*Config](err)
+	}
+
+	return mo.Ok(loaded.Config)
+}
+
+// LoadedConfig contains the resolved config and the file path it came from, if any.
+type LoadedConfig struct {
+	Config *Config
+	Path   string
+}
+
+// LoadResolved resolves configuration and reports the file path used, if any.
+func LoadResolved(path string) (LoadedConfig, error) {
 	viperInstance := viper.New()
 	setDefaults(viperInstance)
 
@@ -35,20 +51,20 @@ func Load(path string) mo.Result[*Config] {
 	if err := viperInstance.ReadInConfig(); err != nil {
 		var notFoundErr viper.ConfigFileNotFoundError
 		if !errors.As(err, &notFoundErr) || path != "" {
-			return mo.Err[*Config](fmt.Errorf("config: read: %w", err))
+			return LoadedConfig{}, fmt.Errorf("config: read: %w", err)
 		}
 	}
 
 	var cfg Config
 	if err := unmarshalConfig(viperInstance, &cfg); err != nil {
-		return mo.Err[*Config](err)
+		return LoadedConfig{}, err
 	}
 
 	if err := cfg.Validate(); err != nil {
-		return mo.Err[*Config](err)
+		return LoadedConfig{}, err
 	}
 
-	return mo.Ok(&cfg)
+	return LoadedConfig{Config: &cfg, Path: viperInstance.ConfigFileUsed()}, nil
 }
 
 func defaultConfigPaths() []string {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -40,8 +40,8 @@ func Load(path string) mo.Result[*Config] {
 	}
 
 	var cfg Config
-	if err := viperInstance.Unmarshal(&cfg); err != nil {
-		return mo.Err[*Config](fmt.Errorf("config: unmarshal: %w", err))
+	if err := unmarshalConfig(viperInstance, &cfg); err != nil {
+		return mo.Err[*Config](err)
 	}
 
 	if err := cfg.Validate(); err != nil {
@@ -72,7 +72,7 @@ func setDefaults(viperInstance *viper.Viper) {
 	viperInstance.SetDefault("database.max_idle_conns", 1)
 	viperInstance.SetDefault("database.conn_max_lifetime", 30*time.Minute)
 	viperInstance.SetDefault("extensions.enabled", true)
-	viperInstance.SetDefault("extensions.paths", []string{".librecode/extensions"})
+	viperInstance.SetDefault("extensions.use", []string{defaultLocalExtensionSource})
 	viperInstance.SetDefault("assistant.provider", "openai-codex")
 	viperInstance.SetDefault("assistant.model", "gpt-5.5")
 	viperInstance.SetDefault("assistant.thinking_level", "off")

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -109,6 +109,23 @@ func TestLoadRejectsEmptyExtensionUseObject(t *testing.T) {
 	assert.ErrorContains(t, result.Error(), "extensions.use source is required")
 }
 
+func TestLoadRejectsInvalidExtensionUseSource(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("LIBRECODE_HOME", filepath.Join(home, ".librecode"))
+	t.Chdir(cwd)
+
+	writeConfig(t, filepath.Join(cwd, ".librecode", "config.yaml"), `extensions:
+  use:
+    - github:owner
+`)
+
+	result := config.Load("")
+	assert.True(t, result.IsError())
+	assert.ErrorContains(t, result.Error(), `config: invalid extensions.use source "github:owner"`)
+}
+
 func writeConfig(t *testing.T, path, content string) {
 	t.Helper()
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -61,7 +61,17 @@ func TestLoadParsesExtensionUseForms(t *testing.T) {
 	t.Setenv("LIBRECODE_HOME", filepath.Join(home, ".librecode"))
 	t.Chdir(cwd)
 
-	writeConfig(t, filepath.Join(cwd, ".librecode", "config.yaml"), `extensions:
+	writeConfig(t, filepath.Join(cwd, ".librecode", "config.yaml"), `database:
+  conn_max_lifetime: 45s
+cache:
+  ttl: 2m
+ksql:
+  timeout: 3s
+assistant:
+  retry:
+    base_delay: 4s
+    max_delay: 8s
+extensions:
   use:
     - official:vim-mode
     - github:example/librecode-extension
@@ -75,6 +85,11 @@ func TestLoadParsesExtensionUseForms(t *testing.T) {
 	assert.Equal(t, "github:example/librecode-extension", cfg.Extensions.Use[1].Source)
 	assert.Equal(t, "github:example/another-extension", cfg.Extensions.Use[2].Source)
 	assert.Equal(t, "v1.2.3", cfg.Extensions.Use[2].Version)
+	assert.Equal(t, "45s", cfg.Database.ConnMaxLifetime.String())
+	assert.Equal(t, "2m0s", cfg.Cache.TTL.String())
+	assert.Equal(t, "3s", cfg.KSQL.Timeout.String())
+	assert.Equal(t, "4s", cfg.Assistant.Retry.BaseDelay.String())
+	assert.Equal(t, "8s", cfg.Assistant.Retry.MaxDelay.String())
 }
 
 func TestLoadRejectsEmptyExtensionUseObject(t *testing.T) {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -110,20 +110,31 @@ func TestLoadRejectsEmptyExtensionUseObject(t *testing.T) {
 }
 
 func TestLoadRejectsInvalidExtensionUseSource(t *testing.T) {
-	home := t.TempDir()
-	cwd := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("LIBRECODE_HOME", filepath.Join(home, ".librecode"))
-	t.Chdir(cwd)
+	testCases := []struct {
+		name   string
+		source string
+	}{
+		{name: "invalid github shorthand", source: "github:owner"},
+		{name: "unsupported scheme", source: "npm:package"},
+		{name: "github traversal", source: "github:owner/repo//../bad"},
+	}
 
-	writeConfig(t, filepath.Join(cwd, ".librecode", "config.yaml"), `extensions:
-  use:
-    - github:owner
-`)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			home := t.TempDir()
+			cwd := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("LIBRECODE_HOME", filepath.Join(home, ".librecode"))
+			t.Chdir(cwd)
 
-	result := config.Load("")
-	assert.True(t, result.IsError())
-	assert.ErrorContains(t, result.Error(), `config: invalid extensions.use source "github:owner"`)
+			content := "extensions:\n  use:\n    - " + testCase.source + "\n"
+			writeConfig(t, filepath.Join(cwd, ".librecode", "config.yaml"), content)
+
+			result := config.Load("")
+			assert.True(t, result.IsError())
+			assert.ErrorContains(t, result.Error(), `config: invalid extensions.use source`)
+		})
+	}
 }
 
 func writeConfig(t *testing.T, path, content string) {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -54,6 +54,46 @@ func TestLoadIgnoresRootAndXDGConfig(t *testing.T) {
 	assert.Equal(t, "development", cfg.App.Env)
 }
 
+func TestLoadParsesExtensionUseForms(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("LIBRECODE_HOME", filepath.Join(home, ".librecode"))
+	t.Chdir(cwd)
+
+	writeConfig(t, filepath.Join(cwd, ".librecode", "config.yaml"), `extensions:
+  use:
+    - official:vim-mode
+    - github:example/librecode-extension
+    - source: github:example/another-extension
+      version: v1.2.3
+`)
+
+	cfg := config.Load("").MustGet()
+	require.Len(t, cfg.Extensions.Use, 3)
+	assert.Equal(t, "official:vim-mode", cfg.Extensions.Use[0].Source)
+	assert.Equal(t, "github:example/librecode-extension", cfg.Extensions.Use[1].Source)
+	assert.Equal(t, "github:example/another-extension", cfg.Extensions.Use[2].Source)
+	assert.Equal(t, "v1.2.3", cfg.Extensions.Use[2].Version)
+}
+
+func TestLoadRejectsEmptyExtensionUseObject(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("LIBRECODE_HOME", filepath.Join(home, ".librecode"))
+	t.Chdir(cwd)
+
+	writeConfig(t, filepath.Join(cwd, ".librecode", "config.yaml"), `extensions:
+  use:
+    - version: v1.2.3
+`)
+
+	result := config.Load("")
+	assert.True(t, result.IsError())
+	assert.ErrorContains(t, result.Error(), "extensions.use source is required")
+}
+
 func writeConfig(t *testing.T, path, content string) {
 	t.Helper()
 

--- a/internal/di/config_service.go
+++ b/internal/di/config_service.go
@@ -19,26 +19,33 @@ type ConfigOverrides struct {
 
 // ConfigService provides access to the resolved application configuration.
 type ConfigService struct {
-	cfg *config.Config
+	cfg  *config.Config
+	path string
 }
 
 // NewConfigService loads configuration from the injector's configured path.
 func NewConfigService(injector do.Injector) (*ConfigService, error) {
 	path := do.MustInvokeNamed[string](injector, ConfigPathKey)
 
-	cfg, err := config.Load(path).Get()
+	loaded, err := config.LoadResolved(path)
 	if err != nil {
 		return nil, err
 	}
+	cfg := loaded.Config
 	overrides := do.MustInvokeNamed[ConfigOverrides](injector, ConfigOverridesKey)
 	if overrides.DisableExtensions {
 		cfg.Extensions.Enabled = false
 	}
 
-	return &ConfigService{cfg: cfg}, nil
+	return &ConfigService{cfg: cfg, path: loaded.Path}, nil
 }
 
 // Get returns the resolved application configuration.
 func (s *ConfigService) Get() *config.Config {
 	return s.cfg
+}
+
+// Path returns the config file path used to load configuration, if any.
+func (s *ConfigService) Path() string {
+	return s.path
 }

--- a/internal/di/config_service_test.go
+++ b/internal/di/config_service_test.go
@@ -24,3 +24,17 @@ func TestNewContainer_DisableExtensionsOverride(t *testing.T) {
 	cfg := di.MustInvoke[*di.ConfigService](container).Get()
 	assert.False(t, cfg.Extensions.Enabled)
 }
+
+func TestConfigServiceTracksLoadedPath(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("app:\n  env: test\n"), 0o600))
+
+	container, err := di.NewContainer(configPath, di.ConfigOverrides{DisableExtensions: false})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.True(t, container.ShutdownWithContext(t.Context()).Succeed) })
+
+	configService := di.MustInvoke[*di.ConfigService](container)
+	assert.Equal(t, configPath, configService.Path())
+}

--- a/internal/di/export_test.go
+++ b/internal/di/export_test.go
@@ -6,3 +6,8 @@ import "github.com/omarluq/librecode/internal/extension"
 func ExtensionLoadPathsForTest(resolvedSources []extension.ResolvedSource) []string {
 	return extensionLoadPaths(resolvedSources)
 }
+
+// ExtensionLockPathForTest exposes extension lockfile resolution to external tests.
+func ExtensionLockPathForTest(configPath, home string) string {
+	return extensionLockPath(configPath, home)
+}

--- a/internal/di/export_test.go
+++ b/internal/di/export_test.go
@@ -1,0 +1,8 @@
+package di
+
+import "github.com/omarluq/librecode/internal/extension"
+
+// ExtensionLoadPathsForTest exposes extension load-path deduplication to external tests.
+func ExtensionLoadPathsForTest(resolvedSources []extension.ResolvedSource) []string {
+	return extensionLoadPaths(resolvedSources)
+}

--- a/internal/di/extension_service.go
+++ b/internal/di/extension_service.go
@@ -19,13 +19,14 @@ type ExtensionService struct {
 
 // NewExtensionService loads configured Lua extensions.
 func NewExtensionService(injector do.Injector) (*ExtensionService, error) {
-	cfg := do.MustInvoke[*ConfigService](injector).Get()
+	configService := do.MustInvoke[*ConfigService](injector)
+	cfg := configService.Get()
 	logger := do.MustInvoke[*LoggerService](injector).SlogLogger
 	manager := extension.NewManager(logger)
 	state := extension.ManagerState{Configured: []extension.ResolvedSource{}, Loaded: []extension.LoadedExtension{}}
 
 	if cfg.Extensions.Enabled {
-		resolvedSources, err := resolveExtensionSources(cfg.Extensions.Use)
+		resolvedSources, err := resolveExtensionSources(cfg.Extensions.Use, configService.Path())
 		if err != nil {
 			return nil, oops.In("extension").Code("extension_sources").Wrapf(err, "resolve extension sources")
 		}
@@ -46,12 +47,15 @@ func (service *ExtensionService) Shutdown() {
 	service.Manager.Shutdown()
 }
 
-func resolveExtensionSources(configuredSources []extension.ConfiguredSource) ([]extension.ResolvedSource, error) {
+func resolveExtensionSources(
+	configuredSources []extension.ConfiguredSource,
+	configPath string,
+) ([]extension.ResolvedSource, error) {
 	home, err := core.LibrecodeHome()
 	if err != nil {
 		return nil, err
 	}
-	lockPath := filepath.Join(home, extension.LockFileName)
+	lockPath := extensionLockPath(configPath, home)
 	lockFile, err := extension.ReadLockFile(lockPath)
 	if err != nil {
 		return nil, err
@@ -59,6 +63,14 @@ func resolveExtensionSources(configuredSources []extension.ConfiguredSource) ([]
 	installRoot := filepath.Join(home, "extensions", "store")
 
 	return extension.ResolveConfiguredSources(configuredSources, lockFile, installRoot)
+}
+
+func extensionLockPath(configPath, home string) string {
+	if configPath != "" && filepath.Base(filepath.Dir(configPath)) == core.ConfigDirName {
+		return filepath.Join(filepath.Dir(configPath), extension.LockFileName)
+	}
+
+	return filepath.Join(home, extension.LockFileName)
 }
 
 func extensionLoadPaths(resolvedSources []extension.ResolvedSource) []string {

--- a/internal/di/extension_service.go
+++ b/internal/di/extension_service.go
@@ -75,12 +75,32 @@ func extensionLockPath(configPath, home string) string {
 
 func extensionLoadPaths(resolvedSources []extension.ResolvedSource) []string {
 	paths := make([]string, 0, len(resolvedSources))
+	seen := map[string]struct{}{}
 	for index := range resolvedSources {
-		if resolvedSources[index].LoadPath == "" {
+		path := resolvedSources[index].LoadPath
+		if path == "" {
 			continue
 		}
-		paths = append(paths, resolvedSources[index].LoadPath)
+		key := extensionLoadPathKey(path)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		paths = append(paths, path)
 	}
 
 	return paths
+}
+
+func extensionLoadPathKey(path string) string {
+	cleanPath := filepath.Clean(path)
+	absolutePath, err := filepath.Abs(cleanPath)
+	if err != nil {
+		return cleanPath
+	}
+	if realPath, err := filepath.EvalSymlinks(absolutePath); err == nil {
+		return realPath
+	}
+
+	return absolutePath
 }

--- a/internal/di/extension_service.go
+++ b/internal/di/extension_service.go
@@ -2,16 +2,19 @@ package di
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/samber/do/v2"
 	"github.com/samber/oops"
 
+	"github.com/omarluq/librecode/internal/core"
 	"github.com/omarluq/librecode/internal/extension"
 )
 
 // ExtensionService owns the Lua extension manager.
 type ExtensionService struct {
 	Manager *extension.Manager
+	State   extension.ManagerState
 }
 
 // NewExtensionService loads configured Lua extensions.
@@ -19,18 +22,53 @@ func NewExtensionService(injector do.Injector) (*ExtensionService, error) {
 	cfg := do.MustInvoke[*ConfigService](injector).Get()
 	logger := do.MustInvoke[*LoggerService](injector).SlogLogger
 	manager := extension.NewManager(logger)
+	state := extension.ManagerState{Configured: []extension.ResolvedSource{}, Loaded: []extension.LoadedExtension{}}
 
 	if cfg.Extensions.Enabled {
-		paths := extension.DefaultLoadPaths(cfg.Extensions.Paths)
+		resolvedSources, err := resolveExtensionSources(cfg.Extensions.Use)
+		if err != nil {
+			return nil, oops.In("extension").Code("extension_sources").Wrapf(err, "resolve extension sources")
+		}
+		state.Configured = resolvedSources
+
+		paths := extensionLoadPaths(resolvedSources)
 		if err := manager.LoadPaths(context.Background(), paths); err != nil {
 			return nil, oops.In("extension").Code("load_extensions").Wrapf(err, "load lua extensions")
 		}
+		state.Loaded = manager.Extensions()
 	}
 
-	return &ExtensionService{Manager: manager}, nil
+	return &ExtensionService{Manager: manager, State: state}, nil
 }
 
 // Shutdown closes loaded Lua runtimes.
 func (service *ExtensionService) Shutdown() {
 	service.Manager.Shutdown()
+}
+
+func resolveExtensionSources(configuredSources []extension.ConfiguredSource) ([]extension.ResolvedSource, error) {
+	home, err := core.LibrecodeHome()
+	if err != nil {
+		return nil, err
+	}
+	lockPath := filepath.Join(home, extension.LockFileName)
+	lockFile, err := extension.ReadLockFile(lockPath)
+	if err != nil {
+		return nil, err
+	}
+	installRoot := filepath.Join(home, "extensions", "store")
+
+	return extension.ResolveConfiguredSources(configuredSources, lockFile, installRoot)
+}
+
+func extensionLoadPaths(resolvedSources []extension.ResolvedSource) []string {
+	paths := make([]string, 0, len(resolvedSources))
+	for index := range resolvedSources {
+		if resolvedSources[index].LoadPath == "" {
+			continue
+		}
+		paths = append(paths, resolvedSources[index].LoadPath)
+	}
+
+	return paths
 }

--- a/internal/di/extension_service_test.go
+++ b/internal/di/extension_service_test.go
@@ -1,0 +1,44 @@
+package di_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/di"
+	"github.com/omarluq/librecode/internal/extension"
+)
+
+func TestExtensionServiceUsesProjectLockfile(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("LIBRECODE_HOME", filepath.Join(home, ".librecode"))
+	t.Chdir(cwd)
+
+	projectConfig := filepath.Join(cwd, ".librecode", "config.yaml")
+	projectLock := filepath.Join(cwd, ".librecode", extension.LockFileName)
+	writeDIFile(t, projectConfig, []byte("extensions:\n  use:\n    - github:owner/repo\n"))
+	lockFile := extension.LockFile{Extensions: map[string]extension.LockedExtension{
+		"github:owner/repo": {Resolved: "", Version: "v9.9.9"},
+	}}
+	require.NoError(t, extension.WriteLockFile(projectLock, lockFile))
+
+	container, err := di.NewContainer("", di.ConfigOverrides{DisableExtensions: false})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = container.ShutdownWithContext(t.Context()).Succeed })
+
+	state := di.MustInvoke[*di.ExtensionService](container).State
+	require.Len(t, state.Configured, 1)
+	assert.Equal(t, "v9.9.9", state.Configured[0].Lock.Version)
+}
+
+func writeDIFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+}

--- a/internal/di/extension_service_test.go
+++ b/internal/di/extension_service_test.go
@@ -36,6 +36,34 @@ func TestExtensionServiceUsesProjectLockfile(t *testing.T) {
 	assert.Equal(t, "v9.9.9", state.Configured[0].Lock.Version)
 }
 
+func TestExtensionLoadPathsDeduplicatesCanonicalPaths(t *testing.T) {
+	t.Parallel()
+
+	extensionDir := t.TempDir()
+	symlinkPath := filepath.Join(t.TempDir(), "extension")
+	require.NoError(t, os.Symlink(extensionDir, symlinkPath))
+
+	paths := di.ExtensionLoadPathsForTest([]extension.ResolvedSource{
+		newResolvedSourceForTest(extensionDir),
+		newResolvedSourceForTest(symlinkPath),
+		newResolvedSourceForTest(extensionDir),
+	})
+
+	require.Len(t, paths, 1)
+	assert.Equal(t, extensionDir, paths[0])
+}
+
+func newResolvedSourceForTest(loadPath string) extension.ResolvedSource {
+	return extension.ResolvedSource{
+		Configured: extension.ConfiguredSource{Source: "path:" + loadPath, Version: ""},
+		Ref:        extension.SourceRef{Scheme: "path", Value: loadPath, Version: ""},
+		Lock:       extension.LockedExtension{Resolved: "", Version: ""},
+		Name:       loadPath,
+		LoadPath:   loadPath,
+		Status:     "path",
+	}
+}
+
 func writeDIFile(t *testing.T, path string, content []byte) {
 	t.Helper()
 

--- a/internal/di/extension_service_test.go
+++ b/internal/di/extension_service_test.go
@@ -1,8 +1,10 @@
 package di_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,11 +31,24 @@ func TestExtensionServiceUsesProjectLockfile(t *testing.T) {
 
 	container, err := di.NewContainer("", di.ConfigOverrides{DisableExtensions: false})
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = container.ShutdownWithContext(t.Context()).Succeed })
+	t.Cleanup(func() {
+		report := container.ShutdownWithContext(context.Background())
+		assert.True(t, report.Succeed, report.Error())
+	})
 
 	state := di.MustInvoke[*di.ExtensionService](container).State
 	require.Len(t, state.Configured, 1)
 	assert.Equal(t, "v9.9.9", state.Configured[0].Lock.Version)
+}
+
+func TestExtensionLockPathUsesGlobalPathWhenConfigPathIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+
+	path := di.ExtensionLockPathForTest("", home)
+
+	assert.Equal(t, filepath.Join(home, extension.LockFileName), path)
 }
 
 func TestExtensionLoadPathsDeduplicatesCanonicalPaths(t *testing.T) {
@@ -41,7 +56,7 @@ func TestExtensionLoadPathsDeduplicatesCanonicalPaths(t *testing.T) {
 
 	extensionDir := t.TempDir()
 	symlinkPath := filepath.Join(t.TempDir(), "extension")
-	require.NoError(t, os.Symlink(extensionDir, symlinkPath))
+	createSymlinkOrSkip(t, extensionDir, symlinkPath)
 
 	paths := di.ExtensionLoadPathsForTest([]extension.ResolvedSource{
 		newResolvedSourceForTest(extensionDir),
@@ -62,6 +77,15 @@ func newResolvedSourceForTest(loadPath string) extension.ResolvedSource {
 		LoadPath:   loadPath,
 		Status:     "path",
 	}
+}
+
+func createSymlinkOrSkip(t *testing.T, oldname, newname string) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping symlink test on Windows: symlinks require elevated privileges")
+	}
+	require.NoError(t, os.Symlink(oldname, newname))
 }
 
 func writeDIFile(t *testing.T, path string, content []byte) {

--- a/internal/extension/lockfile.go
+++ b/internal/extension/lockfile.go
@@ -1,0 +1,66 @@
+package extension
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LockFileName is the filename used for extension version locks.
+const LockFileName = "extensions-lock.yaml"
+
+// LockFile pins resolved extension versions.
+type LockFile struct {
+	Extensions map[string]LockedExtension `json:"extensions" yaml:"extensions"`
+}
+
+// LockedExtension pins one configured extension source.
+type LockedExtension struct {
+	Resolved string `json:"resolved,omitempty" yaml:"resolved,omitempty"`
+	Version  string `json:"version,omitempty" yaml:"version,omitempty"`
+}
+
+// ReadLockFile loads an extension lockfile. Missing files return an empty lock.
+func ReadLockFile(path string) (LockFile, error) {
+	content, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- user-selected librecode lockfile path.
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return LockFile{Extensions: map[string]LockedExtension{}}, nil
+		}
+		return LockFile{}, fmt.Errorf("extension: read lockfile: %w", err)
+	}
+
+	lockFile := LockFile{Extensions: map[string]LockedExtension{}}
+	if err := yaml.Unmarshal(content, &lockFile); err != nil {
+		return LockFile{}, fmt.Errorf("extension: parse lockfile: %w", err)
+	}
+	if lockFile.Extensions == nil {
+		lockFile.Extensions = map[string]LockedExtension{}
+	}
+
+	return lockFile, nil
+}
+
+// WriteLockFile writes an extension lockfile atomically enough for normal CLI use.
+func WriteLockFile(path string, lockFile LockFile) error {
+	if lockFile.Extensions == nil {
+		lockFile.Extensions = map[string]LockedExtension{}
+	}
+	content, err := yaml.Marshal(lockFile)
+	if err != nil {
+		return fmt.Errorf("extension: marshal lockfile: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("extension: create lockfile dir: %w", err)
+	}
+	cleanPath := filepath.Clean(path)
+	// #nosec G304 -- user-selected librecode lockfile path.
+	if err := os.WriteFile(cleanPath, content, 0o600); err != nil {
+		return fmt.Errorf("extension: write lockfile: %w", err)
+	}
+
+	return nil
+}

--- a/internal/extension/lockfile.go
+++ b/internal/extension/lockfile.go
@@ -44,7 +44,7 @@ func ReadLockFile(path string) (LockFile, error) {
 	return lockFile, nil
 }
 
-// WriteLockFile writes an extension lockfile atomically enough for normal CLI use.
+// WriteLockFile writes an extension lockfile atomically.
 func WriteLockFile(path string, lockFile LockFile) error {
 	if lockFile.Extensions == nil {
 		lockFile.Extensions = map[string]LockedExtension{}
@@ -53,14 +53,44 @@ func WriteLockFile(path string, lockFile LockFile) error {
 	if err != nil {
 		return fmt.Errorf("extension: marshal lockfile: %w", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return fmt.Errorf("extension: create lockfile dir: %w", err)
-	}
+
 	cleanPath := filepath.Clean(path)
-	// #nosec G304 -- user-selected librecode lockfile path.
-	if err := os.WriteFile(cleanPath, content, 0o600); err != nil {
-		return fmt.Errorf("extension: write lockfile: %w", err)
+	dir := filepath.Dir(cleanPath)
+	if mkdirErr := os.MkdirAll(dir, 0o700); mkdirErr != nil {
+		return fmt.Errorf("extension: create lockfile dir: %w", mkdirErr)
 	}
+
+	tempPattern := "." + filepath.Base(cleanPath) + "-*.tmp"
+	tempFile, err := os.CreateTemp(dir, tempPattern) // #nosec G304 -- user-selected librecode lockfile path.
+	if err != nil {
+		return fmt.Errorf("extension: create temporary lockfile: %w", err)
+	}
+	tempPath := tempFile.Name()
+	removeTempFile := true
+	defer func() {
+		if removeTempFile {
+			removeErr := os.Remove(tempPath)
+			_ = removeErr
+		}
+	}()
+
+	if _, err := tempFile.Write(content); err != nil {
+		closeErr := tempFile.Close()
+		_ = closeErr
+		return fmt.Errorf("extension: write temporary lockfile: %w", err)
+	}
+	if err := tempFile.Chmod(0o600); err != nil {
+		closeErr := tempFile.Close()
+		_ = closeErr
+		return fmt.Errorf("extension: chmod temporary lockfile: %w", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("extension: close temporary lockfile: %w", err)
+	}
+	if err := os.Rename(tempPath, cleanPath); err != nil {
+		return fmt.Errorf("extension: replace lockfile: %w", err)
+	}
+	removeTempFile = false
 
 	return nil
 }

--- a/internal/extension/lockfile_test.go
+++ b/internal/extension/lockfile_test.go
@@ -1,0 +1,82 @@
+package extension_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/extension"
+)
+
+func TestReadLockFileMissingReturnsEmptyLock(t *testing.T) {
+	t.Parallel()
+
+	lockFile, err := extension.ReadLockFile(filepath.Join(t.TempDir(), extension.LockFileName))
+
+	require.NoError(t, err)
+	assert.Empty(t, lockFile.Extensions)
+}
+
+func TestReadLockFileRejectsInvalidYAML(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), extension.LockFileName)
+	require.NoError(t, os.WriteFile(path, []byte("extensions: ["), 0o600))
+
+	_, err := extension.ReadLockFile(path)
+
+	assert.ErrorContains(t, err, "parse lockfile")
+}
+
+func TestReadLockFileNormalizesNilExtensions(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), extension.LockFileName)
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+
+	lockFile, err := extension.ReadLockFile(path)
+
+	require.NoError(t, err)
+	assert.NotNil(t, lockFile.Extensions)
+	assert.Empty(t, lockFile.Extensions)
+}
+
+func TestReadLockFileReportsReadErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := extension.ReadLockFile(t.TempDir())
+
+	assert.ErrorContains(t, err, "read lockfile")
+}
+
+func TestWriteLockFileInitializesNilExtensionsAndSetsPrivateMode(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), extension.LockFileName)
+
+	require.NoError(t, extension.WriteLockFile(path, extension.LockFile{Extensions: nil}))
+
+	loaded, err := extension.ReadLockFile(path)
+	require.NoError(t, err)
+	assert.Empty(t, loaded.Extensions)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestWriteLockFileFailsWhenParentIsFile(t *testing.T) {
+	t.Parallel()
+
+	parentPath := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(parentPath, []byte("file"), 0o600))
+
+	path := filepath.Join(parentPath, extension.LockFileName)
+
+	err := extension.WriteLockFile(path, extension.LockFile{Extensions: nil})
+
+	assert.ErrorContains(t, err, "create lockfile dir")
+}

--- a/internal/extension/lockfile_test.go
+++ b/internal/extension/lockfile_test.go
@@ -3,6 +3,7 @@ package extension_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,72 +12,154 @@ import (
 	"github.com/omarluq/librecode/internal/extension"
 )
 
-func TestReadLockFileMissingReturnsEmptyLock(t *testing.T) {
-	t.Parallel()
-
-	lockFile, err := extension.ReadLockFile(filepath.Join(t.TempDir(), extension.LockFileName))
-
-	require.NoError(t, err)
-	assert.Empty(t, lockFile.Extensions)
+type lockFileCase struct {
+	setup  func(t *testing.T, dir string) string
+	run    func(path string) (extension.LockFile, error)
+	assert func(t *testing.T, path string, lockFile extension.LockFile, err error)
+	name   string
 }
 
-func TestReadLockFileRejectsInvalidYAML(t *testing.T) {
+func TestLockFileReadWrite(t *testing.T) {
 	t.Parallel()
 
-	path := filepath.Join(t.TempDir(), extension.LockFileName)
-	require.NoError(t, os.WriteFile(path, []byte("extensions: ["), 0o600))
+	for _, testCase := range lockFileCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, err := extension.ReadLockFile(path)
+			path := testCase.setup(t, t.TempDir())
+			lockFile, err := testCase.run(path)
 
-	assert.ErrorContains(t, err, "parse lockfile")
+			testCase.assert(t, path, lockFile, err)
+		})
+	}
 }
 
-func TestReadLockFileNormalizesNilExtensions(t *testing.T) {
-	t.Parallel()
-
-	path := filepath.Join(t.TempDir(), extension.LockFileName)
-	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
-
-	lockFile, err := extension.ReadLockFile(path)
-
-	require.NoError(t, err)
-	assert.NotNil(t, lockFile.Extensions)
-	assert.Empty(t, lockFile.Extensions)
+func lockFileCases() []lockFileCase {
+	return []lockFileCase{
+		missingLockFileCase(),
+		invalidLockFileCase(),
+		nilExtensionsLockFileCase(),
+		readErrorLockFileCase(),
+		writeLockFileCase(),
+		writeParentFileLockFileCase(),
+	}
 }
 
-func TestReadLockFileReportsReadErrors(t *testing.T) {
-	t.Parallel()
-
-	_, err := extension.ReadLockFile(t.TempDir())
-
-	assert.ErrorContains(t, err, "read lockfile")
+func missingLockFileCase() lockFileCase {
+	return lockFileCase{
+		name:  "missing file returns empty",
+		setup: lockFilePath,
+		run:   extension.ReadLockFile,
+		assert: func(t *testing.T, _ string, lockFile extension.LockFile, err error) {
+			t.Helper()
+			require.NoError(t, err)
+			assert.Empty(t, lockFile.Extensions)
+		},
+	}
 }
 
-func TestWriteLockFileInitializesNilExtensionsAndSetsPrivateMode(t *testing.T) {
-	t.Parallel()
+func invalidLockFileCase() lockFileCase {
+	return lockFileCase{
+		name: "rejects invalid YAML",
+		setup: func(t *testing.T, dir string) string {
+			t.Helper()
+			path := lockFilePath(t, dir)
+			require.NoError(t, os.WriteFile(path, []byte("extensions: ["), 0o600))
+			return path
+		},
+		run: extension.ReadLockFile,
+		assert: func(t *testing.T, _ string, _ extension.LockFile, err error) {
+			t.Helper()
+			assert.ErrorContains(t, err, "parse lockfile")
+		},
+	}
+}
 
-	path := filepath.Join(t.TempDir(), extension.LockFileName)
+func nilExtensionsLockFileCase() lockFileCase {
+	return lockFileCase{
+		name: "normalizes nil extensions",
+		setup: func(t *testing.T, dir string) string {
+			t.Helper()
+			path := lockFilePath(t, dir)
+			require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+			return path
+		},
+		run: extension.ReadLockFile,
+		assert: func(t *testing.T, _ string, lockFile extension.LockFile, err error) {
+			t.Helper()
+			require.NoError(t, err)
+			assert.NotNil(t, lockFile.Extensions)
+			assert.Empty(t, lockFile.Extensions)
+		},
+	}
+}
 
-	require.NoError(t, extension.WriteLockFile(path, extension.LockFile{Extensions: nil}))
+func readErrorLockFileCase() lockFileCase {
+	return lockFileCase{
+		name: "reports read errors",
+		setup: func(t *testing.T, dir string) string {
+			t.Helper()
+			return dir
+		},
+		run: extension.ReadLockFile,
+		assert: func(t *testing.T, _ string, _ extension.LockFile, err error) {
+			t.Helper()
+			assert.ErrorContains(t, err, "read lockfile")
+		},
+	}
+}
 
-	loaded, err := extension.ReadLockFile(path)
-	require.NoError(t, err)
-	assert.Empty(t, loaded.Extensions)
+func writeLockFileCase() lockFileCase {
+	return lockFileCase{
+		name:  "write initializes nil extensions and sets private mode",
+		setup: lockFilePath,
+		run: func(path string) (extension.LockFile, error) {
+			if err := extension.WriteLockFile(path, extension.LockFile{Extensions: nil}); err != nil {
+				return extension.LockFile{}, err
+			}
+			return extension.ReadLockFile(path)
+		},
+		assert: func(t *testing.T, path string, lockFile extension.LockFile, err error) {
+			t.Helper()
+			require.NoError(t, err)
+			assert.Empty(t, lockFile.Extensions)
+			assertLockFileMode(t, path)
+		},
+	}
+}
+
+func writeParentFileLockFileCase() lockFileCase {
+	return lockFileCase{
+		name: "write fails when parent is file",
+		setup: func(t *testing.T, dir string) string {
+			t.Helper()
+			parentPath := filepath.Join(dir, "not-a-dir")
+			require.NoError(t, os.WriteFile(parentPath, []byte("file"), 0o600))
+			return filepath.Join(parentPath, extension.LockFileName)
+		},
+		run: func(path string) (extension.LockFile, error) {
+			return extension.LockFile{}, extension.WriteLockFile(path, extension.LockFile{Extensions: nil})
+		},
+		assert: func(t *testing.T, _ string, _ extension.LockFile, err error) {
+			t.Helper()
+			assert.ErrorContains(t, err, "create lockfile dir")
+		},
+	}
+}
+
+func lockFilePath(t *testing.T, dir string) string {
+	t.Helper()
+	return filepath.Join(dir, extension.LockFileName)
+}
+
+func assertLockFileMode(t *testing.T, path string) {
+	t.Helper()
 
 	info, err := os.Stat(path)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
-}
-
-func TestWriteLockFileFailsWhenParentIsFile(t *testing.T) {
-	t.Parallel()
-
-	parentPath := filepath.Join(t.TempDir(), "not-a-dir")
-	require.NoError(t, os.WriteFile(parentPath, []byte("file"), 0o600))
-
-	path := filepath.Join(parentPath, extension.LockFileName)
-
-	err := extension.WriteLockFile(path, extension.LockFile{Extensions: nil})
-
-	assert.ErrorContains(t, err, "create lockfile dir")
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+		return
+	}
+	assert.False(t, info.IsDir())
 }

--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -167,7 +167,7 @@ func (manager *Manager) LoadManifest(ctx context.Context, manifestPath string) e
 		name = extensionName(filepath.Dir(manifestPath))
 	}
 
-	return manager.loadLuaFile(ctx, entryPath, name, manifestPath)
+	return manager.loadLuaFile(ctx, entryPath, name, filepath.Dir(manifestPath))
 }
 
 // ReadManifest reads a directory-based Lua manifest without executing extension entry code.

--- a/internal/extension/manager_state.go
+++ b/internal/extension/manager_state.go
@@ -1,0 +1,7 @@
+package extension
+
+// ManagerState describes configured, resolved, and loaded extension state.
+type ManagerState struct {
+	Configured []ResolvedSource
+	Loaded     []LoadedExtension
+}

--- a/internal/extension/manager_test.go
+++ b/internal/extension/manager_test.go
@@ -15,13 +15,14 @@ import (
 )
 
 const (
-	testBufferComposer  = "composer"
-	testContextModeKey  = "mode"
-	testEventKey        = "key"
-	testEventStartup    = "startup"
-	testModeChat        = "chat"
-	testUserExtension   = ".librecode/extensions"
-	testRendererDefault = "default"
+	testBufferComposer      = "composer"
+	testContextModeKey      = "mode"
+	testEventKey            = "key"
+	testEventStartup        = "startup"
+	testModeChat            = "chat"
+	testUserExtension       = ".librecode/extensions"
+	testPathExtensionSource = "path:.librecode/extensions"
+	testRendererDefault     = "default"
 )
 
 func testLayout(windows map[string]extension.WindowState) extension.LayoutState {
@@ -417,17 +418,27 @@ end)
 	assert.Equal(t, "warning", result.UIDrawOps[5].Style.FG)
 }
 
-func TestDefaultLoadPathsDedupesConfiguredExtensions(t *testing.T) {
+func TestLocalLoadPathsParsesPathSources(t *testing.T) {
 	t.Parallel()
 
-	paths := extension.DefaultLoadPaths([]string{
-		testUserExtension,
-		"extensions",
-		" custom ",
-		testUserExtension,
+	paths, err := extension.LocalLoadPaths([]extension.ConfiguredSource{
+		{Source: " " + testPathExtensionSource + " ", Version: ""},
+		{Source: "path:./custom", Version: ""},
+		{Source: "official:vim-mode", Version: ""},
+		{Source: "github:example/extension", Version: "v1.2.3"},
+		{Source: testPathExtensionSource, Version: ""},
 	})
 
-	assert.Equal(t, []string{testUserExtension, "extensions", "custom"}, paths)
+	require.NoError(t, err)
+	assert.Equal(t, []string{".librecode/extensions", "./custom"}, paths)
+}
+
+func TestLocalLoadPathsRejectsUnknownScheme(t *testing.T) {
+	t.Parallel()
+
+	_, err := extension.LocalLoadPaths([]extension.ConfiguredSource{{Source: "npm:thing", Version: ""}})
+
+	assert.ErrorContains(t, err, "unsupported source scheme")
 }
 
 func TestManager_LoadsDirectoryManifestEntryWithRootModules(t *testing.T) {

--- a/internal/extension/manager_test.go
+++ b/internal/extension/manager_test.go
@@ -420,27 +420,49 @@ end)
 	assert.Equal(t, "warning", result.UIDrawOps[5].Style.FG)
 }
 
-func TestLocalLoadPathsParsesPathSources(t *testing.T) {
+func TestLocalLoadPaths(t *testing.T) {
 	t.Parallel()
 
-	paths, err := extension.LocalLoadPaths([]extension.ConfiguredSource{
-		{Source: " " + testPathExtensionSource + " ", Version: ""},
-		{Source: "path:./custom", Version: ""},
-		{Source: testManagerVimModeSource, Version: ""},
-		{Source: "github:example/extension", Version: "v1.2.3"},
-		{Source: testPathExtensionSource, Version: ""},
-	})
+	tests := []struct {
+		name     string
+		err      string
+		sources  []extension.ConfiguredSource
+		expected []string
+	}{
+		{
+			name: "parses path sources",
+			err:  "",
+			sources: []extension.ConfiguredSource{
+				{Source: " " + testPathExtensionSource + " ", Version: ""},
+				{Source: "path:./custom", Version: ""},
+				{Source: testManagerVimModeSource, Version: ""},
+				{Source: "github:example/extension", Version: "v1.2.3"},
+				{Source: testPathExtensionSource, Version: ""},
+			},
+			expected: []string{".librecode/extensions", "./custom"},
+		},
+		{
+			name:     "rejects unknown scheme",
+			err:      "unsupported source scheme",
+			sources:  []extension.ConfiguredSource{{Source: "npm:thing", Version: ""}},
+			expected: nil,
+		},
+	}
 
-	require.NoError(t, err)
-	assert.Equal(t, []string{".librecode/extensions", "./custom"}, paths)
-}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-func TestLocalLoadPathsRejectsUnknownScheme(t *testing.T) {
-	t.Parallel()
+			paths, err := extension.LocalLoadPaths(testCase.sources)
+			if testCase.err != "" {
+				assert.ErrorContains(t, err, testCase.err)
+				return
+			}
 
-	_, err := extension.LocalLoadPaths([]extension.ConfiguredSource{{Source: "npm:thing", Version: ""}})
-
-	assert.ErrorContains(t, err, "unsupported source scheme")
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expected, paths)
+		})
+	}
 }
 
 func TestManager_LoadsDirectoryManifestEntryWithRootModules(t *testing.T) {

--- a/internal/extension/manager_test.go
+++ b/internal/extension/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,14 +16,15 @@ import (
 )
 
 const (
-	testBufferComposer      = "composer"
-	testContextModeKey      = "mode"
-	testEventKey            = "key"
-	testEventStartup        = "startup"
-	testModeChat            = "chat"
-	testUserExtension       = ".librecode/extensions"
-	testPathExtensionSource = "path:.librecode/extensions"
-	testRendererDefault     = "default"
+	testBufferComposer       = "composer"
+	testContextModeKey       = "mode"
+	testEventKey             = "key"
+	testEventStartup         = "startup"
+	testModeChat             = "chat"
+	testUserExtension        = ".librecode/extensions"
+	testPathExtensionSource  = "path:.librecode/extensions"
+	testRendererDefault      = "default"
+	testManagerVimModeSource = "official:vim-mode"
 )
 
 func testLayout(windows map[string]extension.WindowState) extension.LayoutState {
@@ -424,7 +426,7 @@ func TestLocalLoadPathsParsesPathSources(t *testing.T) {
 	paths, err := extension.LocalLoadPaths([]extension.ConfiguredSource{
 		{Source: " " + testPathExtensionSource + " ", Version: ""},
 		{Source: "path:./custom", Version: ""},
-		{Source: "official:vim-mode", Version: ""},
+		{Source: testManagerVimModeSource, Version: ""},
 		{Source: "github:example/extension", Version: "v1.2.3"},
 		{Source: testPathExtensionSource, Version: ""},
 	})
@@ -496,7 +498,7 @@ func TestManager_LoadsSymlinkedDirectoryManifest(t *testing.T) {
   librecode.register_command("linked", "Linked command", function() return "ok" end)
 end`,
 	))
-	require.NoError(t, os.Symlink(realExtension, linkedExtension))
+	createManagerSymlinkOrSkip(t, realExtension, linkedExtension)
 
 	manager := extension.NewManager(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	t.Cleanup(manager.Shutdown)
@@ -625,6 +627,15 @@ func assertTerminalKeyExecution(t *testing.T, manager *extension.Manager) {
 	assert.Equal(t, 1, result.Buffers[testBufferComposer].Cursor)
 	assert.Equal(t, "normal", result.Buffers[testBufferComposer].Label)
 	assert.Equal(t, "vim", result.Buffers[testBufferComposer].Metadata[testContextModeKey])
+}
+
+func createManagerSymlinkOrSkip(t *testing.T, oldname, newname string) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping symlink test on Windows: symlinks require elevated privileges")
+	}
+	require.NoError(t, os.Symlink(oldname, newname))
 }
 
 func writeTestFile(path, content string) error {

--- a/internal/extension/paths.go
+++ b/internal/extension/paths.go
@@ -2,8 +2,23 @@ package extension
 
 import "strings"
 
-// DefaultLoadPaths returns configured extension roots with whitespace trimmed and duplicates removed.
-func DefaultLoadPaths(configuredPaths []string) []string {
+// LocalLoadPaths returns explicitly configured path: extension sources with duplicates removed.
+func LocalLoadPaths(configuredSources []ConfiguredSource) ([]string, error) {
+	paths := []string{}
+	for _, configuredSource := range configuredSources {
+		ref, err := ParseSourceRef(configuredSource.Source, configuredSource.Version)
+		if err != nil {
+			return nil, err
+		}
+		if path, ok := ref.LocalPath(); ok {
+			paths = append(paths, path)
+		}
+	}
+
+	return dedupePaths(paths), nil
+}
+
+func dedupePaths(configuredPaths []string) []string {
 	paths := make([]string, 0, len(configuredPaths))
 	seen := map[string]struct{}{}
 	for _, path := range configuredPaths {

--- a/internal/extension/resolver.go
+++ b/internal/extension/resolver.go
@@ -1,0 +1,108 @@
+package extension
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+const officialVimModeVersion = "v0.1.0"
+
+var officialExtensions = map[string]LockedExtension{
+	"vim-mode": {
+		Resolved: "github:omarluq/librecode//extensions/vim-mode",
+		Version:  officialVimModeVersion,
+	},
+}
+
+// ResolvedSource describes a configured extension after applying aliases and locks.
+type ResolvedSource struct {
+	Configured ConfiguredSource
+	Ref        SourceRef
+	Lock       LockedExtension
+	LoadPath   string
+	Name       string
+	Status     string
+}
+
+// ResolveConfiguredSources resolves configured extension entries using a lockfile.
+func ResolveConfiguredSources(
+	configuredSources []ConfiguredSource,
+	lockFile LockFile,
+	installRoot string,
+) ([]ResolvedSource, error) {
+	resolved := make([]ResolvedSource, 0, len(configuredSources))
+	for _, configuredSource := range configuredSources {
+		ref, err := ParseSourceRef(configuredSource.Source, configuredSource.Version)
+		if err != nil {
+			return nil, err
+		}
+
+		resolvedSource, err := resolveSource(configuredSource, ref, lockFile, installRoot)
+		if err != nil {
+			return nil, err
+		}
+		resolved = append(resolved, resolvedSource)
+	}
+
+	return resolved, nil
+}
+
+func resolveSource(
+	configuredSource ConfiguredSource,
+	ref SourceRef,
+	lockFile LockFile,
+	installRoot string,
+) (ResolvedSource, error) {
+	locked := lockFile.Extensions[ref.Key()]
+	if configuredSource.Version != "" {
+		locked.Version = configuredSource.Version
+	}
+
+	resolvedSource := ResolvedSource{
+		Configured: configuredSource,
+		Ref:        ref,
+		Lock:       locked,
+		LoadPath:   "",
+		Name:       ref.Value,
+		Status:     "configured",
+	}
+
+	switch ref.Scheme {
+	case sourceSchemePath:
+		resolvedSource.LoadPath = ref.Value
+		resolvedSource.Status = "path"
+		return resolvedSource, nil
+	case sourceSchemeOfficial:
+		return resolveOfficialSource(&resolvedSource, installRoot)
+	case sourceSchemeGitHub:
+		return resolveGitHubSource(&resolvedSource, installRoot), nil
+	default:
+		return ResolvedSource{}, fmt.Errorf("extension: unsupported source scheme %q", ref.Scheme)
+	}
+}
+
+func resolveOfficialSource(resolvedSource *ResolvedSource, installRoot string) (ResolvedSource, error) {
+	official, ok := officialExtensions[resolvedSource.Ref.Value]
+	if !ok {
+		return ResolvedSource{}, fmt.Errorf("extension: unknown official extension %q", resolvedSource.Ref.Value)
+	}
+	if resolvedSource.Lock.Resolved == "" {
+		resolvedSource.Lock.Resolved = official.Resolved
+	}
+	if resolvedSource.Lock.Version == "" {
+		resolvedSource.Lock.Version = official.Version
+	}
+	resolvedSource.LoadPath = filepath.Join(installRoot, "official", resolvedSource.Ref.Value)
+	resolvedSource.Status = "missing"
+	resolvedSource.Name = resolvedSource.Ref.Value
+
+	return *resolvedSource, nil
+}
+
+func resolveGitHubSource(resolvedSource *ResolvedSource, installRoot string) ResolvedSource {
+	resolvedSource.LoadPath = filepath.Join(installRoot, "github", filepath.FromSlash(resolvedSource.Ref.Value))
+	resolvedSource.Status = "missing"
+	resolvedSource.Name = resolvedSource.Ref.Value
+
+	return *resolvedSource
+}

--- a/internal/extension/resolver_test.go
+++ b/internal/extension/resolver_test.go
@@ -1,0 +1,116 @@
+package extension_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/extension"
+)
+
+const (
+	testResolverGitHubSource  = "github:owner/repo"
+	testResolverVimModeSource = "official:vim-mode"
+)
+
+func TestResolveConfiguredSourcesAppliesConfiguredVersionOverLock(t *testing.T) {
+	t.Parallel()
+
+	lockFile := extension.LockFile{Extensions: map[string]extension.LockedExtension{
+		testResolverGitHubSource: {Resolved: "", Version: "v1.0.0"},
+	}}
+
+	resolved, err := extension.ResolveConfiguredSources([]extension.ConfiguredSource{
+		{Source: testResolverGitHubSource, Version: "v2.0.0"},
+	}, lockFile, t.TempDir())
+
+	require.NoError(t, err)
+	require.Len(t, resolved, 1)
+	assert.Equal(t, "v2.0.0", resolved[0].Lock.Version)
+}
+
+func TestResolveConfiguredSourcesUsesGitHubStorePath(t *testing.T) {
+	t.Parallel()
+
+	installRoot := filepath.Join(t.TempDir(), "store")
+
+	resolved, err := extension.ResolveConfiguredSources([]extension.ConfiguredSource{
+		{Source: "github:owner/repo//extensions/demo", Version: ""},
+	}, extension.LockFile{Extensions: map[string]extension.LockedExtension{}}, installRoot)
+
+	require.NoError(t, err)
+	require.Len(t, resolved, 1)
+	assert.Equal(t, filepath.Join(installRoot, "github", "owner", "repo", "extensions", "demo"), resolved[0].LoadPath)
+	assert.Equal(t, "missing", resolved[0].Status)
+	assert.Equal(t, "owner/repo//extensions/demo", resolved[0].Name)
+}
+
+func TestResolveConfiguredSourcesRejectsUnknownOfficialExtension(t *testing.T) {
+	t.Parallel()
+
+	_, err := extension.ResolveConfiguredSources([]extension.ConfiguredSource{
+		{Source: "official:not-real", Version: ""},
+	}, extension.LockFile{Extensions: map[string]extension.LockedExtension{}}, t.TempDir())
+
+	assert.ErrorContains(t, err, "unknown official extension")
+}
+
+func TestResolveConfiguredSourcesUsesOfficialDefaults(t *testing.T) {
+	t.Parallel()
+
+	installRoot := filepath.Join(t.TempDir(), "store")
+
+	resolved, err := extension.ResolveConfiguredSources([]extension.ConfiguredSource{
+		{Source: testResolverVimModeSource, Version: ""},
+	}, extension.LockFile{Extensions: map[string]extension.LockedExtension{}}, installRoot)
+
+	require.NoError(t, err)
+	require.Len(t, resolved, 1)
+	assert.Equal(t, "vim-mode", resolved[0].Name)
+	assert.Equal(t, "github:omarluq/librecode//extensions/vim-mode", resolved[0].Lock.Resolved)
+	assert.Equal(t, "v0.1.0", resolved[0].Lock.Version)
+	assert.Equal(t, filepath.Join(installRoot, "official", "vim-mode"), resolved[0].LoadPath)
+	assert.Equal(t, "missing", resolved[0].Status)
+}
+
+func TestResolveConfiguredSourcesUsesLockedOfficialValues(t *testing.T) {
+	t.Parallel()
+
+	lockFile := extension.LockFile{Extensions: map[string]extension.LockedExtension{
+		testResolverVimModeSource: {Resolved: "github:fork/librecode//extensions/vim-mode", Version: "v9.9.9"},
+	}}
+
+	resolved, err := extension.ResolveConfiguredSources([]extension.ConfiguredSource{
+		{Source: testResolverVimModeSource, Version: ""},
+	}, lockFile, t.TempDir())
+
+	require.NoError(t, err)
+	require.Len(t, resolved, 1)
+	assert.Equal(t, "github:fork/librecode//extensions/vim-mode", resolved[0].Lock.Resolved)
+	assert.Equal(t, "v9.9.9", resolved[0].Lock.Version)
+}
+
+func TestResolveConfiguredSourcesUsesPathSource(t *testing.T) {
+	t.Parallel()
+
+	resolved, err := extension.ResolveConfiguredSources([]extension.ConfiguredSource{
+		{Source: "path:.librecode/extensions", Version: ""},
+	}, extension.LockFile{Extensions: map[string]extension.LockedExtension{}}, t.TempDir())
+
+	require.NoError(t, err)
+	require.Len(t, resolved, 1)
+	assert.Equal(t, ".librecode/extensions", resolved[0].LoadPath)
+	assert.Equal(t, "path", resolved[0].Status)
+}
+
+func TestResolveConfiguredSourcesRejectsInvalidConfiguredSource(t *testing.T) {
+	t.Parallel()
+
+	_, err := extension.ResolveConfiguredSources([]extension.ConfiguredSource{
+		{Source: "github:owner", Version: ""},
+	}, extension.LockFile{Extensions: map[string]extension.LockedExtension{}}, t.TempDir())
+
+	assert.ErrorContains(t, err, "github source")
+}

--- a/internal/extension/sources.go
+++ b/internal/extension/sources.go
@@ -1,0 +1,97 @@
+package extension
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	sourceSchemeOfficial = "official"
+	sourceSchemeGitHub   = "github"
+	sourceSchemePath     = "path"
+)
+
+// ConfiguredSource is one extension source entry from user configuration.
+type ConfiguredSource struct {
+	Source  string `json:"source" mapstructure:"source" yaml:"source"`
+	Version string `json:"version" mapstructure:"version" yaml:"version"`
+}
+
+// SourceRef describes one configured extension source.
+type SourceRef struct {
+	Scheme  string
+	Value   string
+	Version string
+}
+
+// ParseSourceRef parses extension source strings like official:vim-mode or github:user/repo.
+func ParseSourceRef(source, version string) (SourceRef, error) {
+	trimmed := strings.TrimSpace(source)
+	if trimmed == "" {
+		return SourceRef{}, fmt.Errorf("extension: source is required")
+	}
+
+	scheme, value, ok := strings.Cut(trimmed, ":")
+	if !ok || strings.TrimSpace(scheme) == "" || strings.TrimSpace(value) == "" {
+		return SourceRef{}, fmt.Errorf("extension: source %q must use scheme:value form", source)
+	}
+
+	ref := SourceRef{
+		Scheme:  strings.ToLower(strings.TrimSpace(scheme)),
+		Value:   strings.TrimSpace(value),
+		Version: strings.TrimSpace(version),
+	}
+	if err := ref.validate(); err != nil {
+		return SourceRef{}, err
+	}
+
+	return ref, nil
+}
+
+// Key returns the stable source key used in diagnostics and lockfiles.
+func (source SourceRef) Key() string {
+	return source.Scheme + ":" + source.Value
+}
+
+// LocalPath returns the local path for path source refs.
+func (source SourceRef) LocalPath() (string, bool) {
+	if source.Scheme == sourceSchemePath {
+		return source.Value, true
+	}
+
+	return "", false
+}
+
+func (source SourceRef) validate() error {
+	switch source.Scheme {
+	case sourceSchemeOfficial:
+		return validateOfficialSource(source.Value)
+	case sourceSchemeGitHub:
+		return validateGitHubSource(source.Value)
+	case sourceSchemePath:
+		return nil
+	default:
+		return fmt.Errorf("extension: unsupported source scheme %q", source.Scheme)
+	}
+}
+
+func validateOfficialSource(value string) error {
+	if strings.Contains(value, "/") {
+		return fmt.Errorf("extension: official source %q must be official:name", value)
+	}
+
+	return nil
+}
+
+func validateGitHubSource(value string) error {
+	repo, subdir, _ := strings.Cut(value, "//")
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return fmt.Errorf("extension: github source %q must be github:owner/repo or github:owner/repo//subdir", value)
+	}
+	if strings.Contains(subdir, "..") {
+		return fmt.Errorf("extension: github source %q has invalid subdir", value)
+	}
+
+	return nil
+}

--- a/internal/extension/sources.go
+++ b/internal/extension/sources.go
@@ -2,6 +2,7 @@ package extension
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -10,6 +11,8 @@ const (
 	sourceSchemeGitHub   = "github"
 	sourceSchemePath     = "path"
 )
+
+var githubPathPartPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
 // ConfiguredSource is one extension source entry from user configuration.
 type ConfiguredSource struct {
@@ -86,12 +89,30 @@ func validateOfficialSource(value string) error {
 func validateGitHubSource(value string) error {
 	repo, subdir, _ := strings.Cut(value, "//")
 	parts := strings.Split(repo, "/")
-	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+	if len(parts) != 2 || !validGitHubPathPart(parts[0]) || !validGitHubPathPart(parts[1]) {
 		return fmt.Errorf("extension: github source %q must be github:owner/repo or github:owner/repo//subdir", value)
 	}
-	if strings.Contains(subdir, "..") {
+	if invalidGitHubSubdir(subdir) {
 		return fmt.Errorf("extension: github source %q has invalid subdir", value)
 	}
 
 	return nil
+}
+
+func validGitHubPathPart(part string) bool {
+	trimmed := strings.TrimSpace(part)
+	return trimmed != "" && trimmed != "." && trimmed != ".." && githubPathPartPattern.MatchString(trimmed)
+}
+
+func invalidGitHubSubdir(subdir string) bool {
+	if subdir == "" {
+		return false
+	}
+	for _, part := range strings.Split(subdir, "/") {
+		if part == "" || part == "." || part == ".." {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/extension/sources_test.go
+++ b/internal/extension/sources_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	testGitHubSource       = "github:owner/repo"
 	testGitHubSubdirSource = "github:owner/repo//extensions/ext"
 	testPathSource         = "path:.librecode/extensions"
 	testVimModeSource      = "official:vim-mode"
@@ -26,7 +27,7 @@ func TestParseSourceRefValidatesSupportedSources(t *testing.T) {
 		key     string
 	}{
 		{name: "official", source: testVimModeSource, version: "", key: testVimModeSource},
-		{name: "github", source: "github:owner/repo", version: "v1.0.0", key: "github:owner/repo"},
+		{name: "github", source: testGitHubSource, version: "v1.0.0", key: testGitHubSource},
 		{name: "github subdir", source: testGitHubSubdirSource, version: "", key: testGitHubSubdirSource},
 		{name: "path", source: testPathSource, version: "", key: testPathSource},
 	}

--- a/internal/extension/sources_test.go
+++ b/internal/extension/sources_test.go
@@ -54,7 +54,10 @@ func TestParseSourceRefRejectsInvalidSources(t *testing.T) {
 		"official:owner/name",
 		"github:owner",
 		"github:/repo",
+		"github:../repo",
+		"github:owner/..",
 		"github:owner/repo//../bad",
+		"github:owner/repo//bad/../path",
 	}
 
 	for _, source := range testCases {

--- a/internal/extension/sources_test.go
+++ b/internal/extension/sources_test.go
@@ -1,0 +1,107 @@
+package extension_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/extension"
+)
+
+const (
+	testGitHubSubdirSource = "github:owner/repo//extensions/ext"
+	testPathSource         = "path:.librecode/extensions"
+	testVimModeSource      = "official:vim-mode"
+)
+
+func TestParseSourceRefValidatesSupportedSources(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		source  string
+		version string
+		key     string
+	}{
+		{name: "official", source: testVimModeSource, version: "", key: testVimModeSource},
+		{name: "github", source: "github:owner/repo", version: "v1.0.0", key: "github:owner/repo"},
+		{name: "github subdir", source: testGitHubSubdirSource, version: "", key: testGitHubSubdirSource},
+		{name: "path", source: testPathSource, version: "", key: testPathSource},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			ref, err := extension.ParseSourceRef(testCase.source, testCase.version)
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.key, ref.Key())
+			assert.Equal(t, testCase.version, ref.Version)
+		})
+	}
+}
+
+func TestParseSourceRefRejectsInvalidSources(t *testing.T) {
+	t.Parallel()
+
+	testCases := []string{
+		"",
+		"vim-mode",
+		"npm:thing",
+		"official:owner/name",
+		"github:owner",
+		"github:/repo",
+		"github:owner/repo//../bad",
+	}
+
+	for _, source := range testCases {
+		t.Run(source, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := extension.ParseSourceRef(source, "")
+
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestResolveConfiguredSourcesResolvesPathAndOfficialSources(t *testing.T) {
+	t.Parallel()
+
+	installRoot := filepath.Join(t.TempDir(), "store")
+	lockFile := extension.LockFile{Extensions: map[string]extension.LockedExtension{}}
+
+	resolved, err := extension.ResolveConfiguredSources([]extension.ConfiguredSource{
+		{Source: testPathSource, Version: ""},
+		{Source: testVimModeSource, Version: ""},
+	}, lockFile, installRoot)
+
+	require.NoError(t, err)
+	require.Len(t, resolved, 2)
+	assert.Equal(t, ".librecode/extensions", resolved[0].LoadPath)
+	assert.Equal(t, "path", resolved[0].Status)
+	assert.Equal(t, filepath.Join(installRoot, "official", "vim-mode"), resolved[1].LoadPath)
+	assert.Equal(t, "github:omarluq/librecode//extensions/vim-mode", resolved[1].Lock.Resolved)
+	assert.Equal(t, "v0.1.0", resolved[1].Lock.Version)
+}
+
+func TestLockFileRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), extension.LockFileName)
+	lockFile := extension.LockFile{Extensions: map[string]extension.LockedExtension{
+		testVimModeSource: {
+			Resolved: "github:omarluq/librecode//extensions/vim-mode",
+			Version:  "v0.1.0",
+		},
+	}}
+
+	require.NoError(t, extension.WriteLockFile(path, lockFile))
+	loaded, err := extension.ReadLockFile(path)
+
+	require.NoError(t, err)
+	assert.Equal(t, lockFile, loaded)
+}

--- a/internal/terminal/render_parity_test.go
+++ b/internal/terminal/render_parity_test.go
@@ -216,7 +216,7 @@ func renderParityConfig() *config.Config {
 			WorkingLoader: config.LoaderUI{Text: "Shenaniganing..."},
 		},
 		Logging:    config.LoggingConfig{Level: "info", Format: "pretty"},
-		Extensions: config.ExtensionsConfig{Paths: nil, Enabled: false},
+		Extensions: config.ExtensionsConfig{Use: nil, Enabled: false},
 		KSQL: config.KSQLConfig{
 			Endpoint: "",
 			Timeout:  0,


### PR DESCRIPTION
## Summary
- add explicit extensions.use source config parsing
- add version-first extension lockfile/resolver foundation
- make extension loading resolve configured sources only
- document extension manager architecture and commands

## Validation
- mise exec -- go test ./...
- mise exec -- task build
- mise exec -- task ci