### PR TITLE
feat(terminal): render markdown tables

### DIFF
--- a/internal/terminal/markdown.go
+++ b/internal/terminal/markdown.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/extension"
+	extast "github.com/yuin/goldmark/extension/ast"
 	goldtext "github.com/yuin/goldmark/text"
 )
 
@@ -68,6 +69,8 @@ func (renderer *markdownRenderer) renderBlock(node ast.Node, indent string) {
 		renderer.renderList(typed, indent)
 	case *ast.ThematicBreak:
 		renderer.appendLine(indent+strings.Repeat(markdownRule, max(3, renderer.width-runeLen(indent))), colorDim)
+	case *extast.Table:
+		renderer.renderTable(typed, indent)
 	default:
 		renderer.renderFallback(node, indent)
 	}

--- a/internal/terminal/markdown_table.go
+++ b/internal/terminal/markdown_table.go
@@ -1,0 +1,192 @@
+package terminal
+
+import (
+	"strings"
+
+	"github.com/gdamore/tcell/v3"
+	"github.com/yuin/goldmark/ast"
+	extast "github.com/yuin/goldmark/extension/ast"
+)
+
+const (
+	markdownTableHorizontal  = "─"
+	markdownTableVertical    = "│"
+	markdownTableTopLeft     = "╭"
+	markdownTableTopJoin     = "┬"
+	markdownTableTopRight    = "╮"
+	markdownTableMidLeft     = "├"
+	markdownTableMidJoin     = "┼"
+	markdownTableMidRight    = "┤"
+	markdownTableBottomLeft  = "╰"
+	markdownTableBottomJoin  = "┴"
+	markdownTableBottomRight = "╯"
+)
+
+type markdownTableCell struct {
+	text      string
+	alignment extast.Alignment
+	header    bool
+}
+
+type markdownTableRow struct {
+	cells  []markdownTableCell
+	header bool
+}
+
+func (renderer *markdownRenderer) renderTable(table *extast.Table, indent string) {
+	rows := renderer.markdownTableRows(table)
+	if len(rows) == 0 {
+		return
+	}
+	columnWidths := markdownTableColumnWidths(rows)
+	if len(columnWidths) == 0 {
+		return
+	}
+
+	borderStyle := renderer.theme.style(colorBorderMuted)
+	renderer.lines = append(renderer.lines, newStyledLine(borderStyle, indent+markdownTableBorderLine(
+		markdownTableTopLeft,
+		markdownTableTopJoin,
+		markdownTableTopRight,
+		columnWidths,
+	)))
+	for index, row := range rows {
+		renderer.lines = append(renderer.lines, renderer.markdownTableStyledRow(indent, row, columnWidths))
+		if row.header && index < len(rows)-1 {
+			renderer.lines = append(renderer.lines, newStyledLine(borderStyle, indent+markdownTableBorderLine(
+				markdownTableMidLeft,
+				markdownTableMidJoin,
+				markdownTableMidRight,
+				columnWidths,
+			)))
+		}
+	}
+	renderer.lines = append(renderer.lines, newStyledLine(borderStyle, indent+markdownTableBorderLine(
+		markdownTableBottomLeft,
+		markdownTableBottomJoin,
+		markdownTableBottomRight,
+		columnWidths,
+	)))
+}
+
+func (renderer *markdownRenderer) markdownTableRows(table *extast.Table) []markdownTableRow {
+	rows := []markdownTableRow{}
+	for child := table.FirstChild(); child != nil; child = child.NextSibling() {
+		switch typed := child.(type) {
+		case *extast.TableHeader:
+			rows = append(rows, renderer.markdownTableRow(typed, true))
+		case *extast.TableRow:
+			rows = append(rows, renderer.markdownTableRow(typed, false))
+		}
+	}
+
+	return rows
+}
+
+func (renderer *markdownRenderer) markdownTableRow(row ast.Node, header bool) markdownTableRow {
+	cells := []markdownTableCell{}
+	for child := row.FirstChild(); child != nil; child = child.NextSibling() {
+		cell, ok := child.(*extast.TableCell)
+		if !ok {
+			continue
+		}
+		cells = append(cells, markdownTableCell{
+			text:      strings.TrimSpace(renderer.inlineText(cell)),
+			alignment: cell.Alignment,
+			header:    header,
+		})
+	}
+
+	return markdownTableRow{cells: cells, header: header}
+}
+
+func markdownTableColumnWidths(rows []markdownTableRow) []int {
+	columnCount := 0
+	for _, row := range rows {
+		columnCount = max(columnCount, len(row.cells))
+	}
+	widths := make([]int, columnCount)
+	for _, row := range rows {
+		for index, cell := range row.cells {
+			widths[index] = max(widths[index], terminalTextWidth(cell.text))
+		}
+	}
+	for index := range widths {
+		widths[index] = max(1, widths[index])
+	}
+
+	return widths
+}
+
+func markdownTableBorderLine(left, join, right string, widths []int) string {
+	parts := make([]string, 0, len(widths))
+	for _, width := range widths {
+		parts = append(parts, strings.Repeat(markdownTableHorizontal, width+2))
+	}
+
+	return left + strings.Join(parts, join) + right
+}
+
+func (renderer *markdownRenderer) markdownTableStyledRow(
+	indent string,
+	row markdownTableRow,
+	widths []int,
+) styledLine {
+	borderStyle := renderer.theme.style(colorBorderMuted)
+	line := newStyledLine(borderStyle, "")
+	if indent != "" {
+		appendMarkdownTableSpan(&line, indent, borderStyle)
+	}
+	appendMarkdownTableSpan(&line, markdownTableVertical, borderStyle)
+	for index, width := range widths {
+		cell := emptyMarkdownTableCell()
+		if index < len(row.cells) {
+			cell = row.cells[index]
+		}
+		style := renderer.markdownTableCellStyle(cell)
+		appendMarkdownTableSpan(&line, " ", style)
+		appendMarkdownTableSpan(&line, markdownTableAlignedText(cell.text, width, cell.alignment), style)
+		appendMarkdownTableSpan(&line, " ", style)
+		appendMarkdownTableSpan(&line, markdownTableVertical, borderStyle)
+	}
+
+	return line
+}
+
+func (renderer *markdownRenderer) markdownTableCellStyle(cell markdownTableCell) tcell.Style {
+	style := renderer.theme.style(colorText)
+	if cell.header {
+		style = renderer.theme.style(colorAccent).Bold(true)
+	}
+
+	return style
+}
+
+func appendMarkdownTableSpan(line *styledLine, text string, style tcell.Style) {
+	line.Text += text
+	line.Spans = append(line.Spans, styledSpan{Style: style, Text: text})
+}
+
+func emptyMarkdownTableCell() markdownTableCell {
+	return markdownTableCell{
+		text:      "",
+		alignment: extast.AlignNone,
+		header:    false,
+	}
+}
+
+func markdownTableAlignedText(text string, width int, alignment extast.Alignment) string {
+	text = terminalTextFit(text, width)
+	padding := max(0, width-terminalTextWidth(text))
+	switch alignment {
+	case extast.AlignRight:
+		return strings.Repeat(" ", padding) + text
+	case extast.AlignCenter:
+		left := padding / 2
+		return strings.Repeat(" ", left) + text + strings.Repeat(" ", padding-left)
+	case extast.AlignLeft, extast.AlignNone:
+		return text + strings.Repeat(" ", padding)
+	}
+
+	return text + strings.Repeat(" ", padding)
+}

--- a/internal/terminal/markdown_test.go
+++ b/internal/terminal/markdown_test.go
@@ -88,6 +88,68 @@ func TestRenderMarkdownListContinuationDoesNotRepeatBullet(t *testing.T) {
 	}
 }
 
+func TestRenderMarkdownTableUsesRichBoxDrawing(t *testing.T) {
+	t.Parallel()
+
+	app := newRenderTestApp(t)
+	lines := app.renderMarkdown("| Name | Count |\n| :--- | ---: |\n| apples | 12 |\n| pears | 3 |", 80)
+	texts := lineTexts(lines)
+
+	assertLineContains(t, texts, "╭────────┬───────╮")
+	assertLineContains(t, texts, "│ Name   │ Count │")
+	assertLineContains(t, texts, "├────────┼───────┤")
+	assertLineContains(t, texts, "│ apples │    12 │")
+	assertLineContains(t, texts, "╰────────┴───────╯")
+}
+
+func TestRenderMarkdownTableStylesHeaderAndBorders(t *testing.T) {
+	t.Parallel()
+
+	app := newRenderTestApp(t)
+	lines := app.renderMarkdown("| Name | Count |\n| --- | --- |\n| apples | 12 |", 80)
+	header := findLineContaining(t, lines, "Name")
+
+	if len(header.Spans) == 0 {
+		t.Fatalf("table header has no styled spans: %#v", header)
+	}
+	if header.Spans[0].Text != markdownIndent ||
+		header.Spans[0].Style.GetForeground() != app.theme.colors[colorBorderMuted] {
+		t.Fatalf("indent span = %#v, want muted border", header.Spans[0])
+	}
+	if header.Spans[1].Text != "│" || header.Spans[1].Style.GetForeground() != app.theme.colors[colorBorderMuted] {
+		t.Fatalf("first table border span = %#v, want muted border", header.Spans[1])
+	}
+	if !lineHasForeground(header, app.theme.colors[colorAccent]) {
+		t.Fatalf("table header does not include accent style: %#v", header.Spans)
+	}
+}
+
+func TestRenderMarkdownTableBordersAlignWithWideCells(t *testing.T) {
+	t.Parallel()
+
+	app := newRenderTestApp(t)
+	lines := app.renderMarkdown("| 项目 | Count |\n| :--- | ---: |\n| apples | 12 |", 80)
+	app.frame = newCellBuffer(80, len(lines), tcell.StyleDefault)
+	for row, line := range lines {
+		app.writeStyledLine(row, 80, line)
+	}
+	text := frameText(app.frame)
+
+	if !strings.Contains(text, "│ 项 目    │ Count │") {
+		t.Fatalf("wide table cell borders are not aligned, frame = %q", text)
+	}
+}
+
+func assertLineContains(t *testing.T, lines []string, needle string) {
+	t.Helper()
+	for _, line := range lines {
+		if strings.Contains(line, needle) {
+			return
+		}
+	}
+	t.Fatalf("line containing %q not found in %#v", needle, lines)
+}
+
 func findLineContaining(t *testing.T, lines []styledLine, needle string) styledLine {
 	t.Helper()
 	for _, line := range lines {

--- a/internal/terminal/ui_text.go
+++ b/internal/terminal/ui_text.go
@@ -227,9 +227,13 @@ func writeTextSegment(
 	if len(runes) > 0 {
 		mainRune = runes[0]
 	}
-	screen.SetContent(column, row, mainRune, nil, style)
+	combining := []rune(nil)
+	if len(runes) > 1 {
+		combining = runes[1:]
+	}
+	screen.SetContent(column, row, mainRune, combining, style)
 	for offset := 1; offset < segment.Width; offset++ {
-		screen.SetContent(column+offset, row, ' ', nil, style)
+		screen.SetContent(column+offset, row, 0, nil, style)
 	}
 
 	return segment.Width


### PR DESCRIPTION
## Summary
- render GFM markdown tables as boxed terminal tables
- support header styling and column alignment
- fix border alignment with styled and wide-cell rendering

## Validation
- mise exec -- go test ./...
- mise exec -- task build
- mise exec -- task ci