### PR TITLE
docs: add project status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,4 +340,4 @@ The release workflow cross-compiles Linux, macOS, and Windows binaries, archives
 
 MIT — see [`LICENSE.txt`](LICENSE.txt).
 
-<a href="https://sonarcloud.io/summary/new_code?id=omarluq_librecode"><img src="https://img.shields.io/sonar/quality_gate/omarluq_librecode?server=https%3A%2F%2Fsonarcloud.io&style=flat&labelColor=24292e&logo=sonarqube&logoColor=white" alt="SonarCloud Quality Gate"></a>
+<a href="https://sonarcloud.io/summary/new_code?id=omarluq_librecode"><img src="https://sonarcloud.io/images/project_badges/sonarcloud-dark.svg" alt="SonarCloud Quality Gate"></a>

--- a/README.md
+++ b/README.md
@@ -7,11 +7,16 @@
 </p>
 
 <p align="center">
-  <a href="https://pkg.go.dev/github.com/omarluq/librecode"><img src="https://img.shields.io/badge/reference-007d9c?style=flat&labelColor=24292e&logo=go&logoColor=white" alt="Go Reference"></a>
+  <a href="https://pkg.go.dev/librecode.sh"><img src="https://img.shields.io/badge/reference-007d9c?style=flat&labelColor=24292e&logo=go&logoColor=white" alt="Go Reference"></a>
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go-%3E%3D1.26-00ADD8?style=flat&labelColor=24292e&logo=go&logoColor=white" alt="Go Version"></a>
   <a href="https://github.com/omarluq/librecode/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/omarluq/librecode/ci.yml?style=flat&labelColor=24292e&label=CI&logo=github&logoColor=white" alt="CI"></a>
   <a href="https://github.com/omarluq/librecode/releases"><img src="https://img.shields.io/github/v/release/omarluq/librecode?style=flat&labelColor=24292e&color=28a745&label=Version&logo=semver&logoColor=white" alt="Version"></a>
   <a href="LICENSE.txt"><img src="https://img.shields.io/badge/License-MIT-blue?style=flat&labelColor=24292e&logo=opensourceinitiative&logoColor=white" alt="License: MIT"></a>
+  <br/>
+  <a href="https://sonarcloud.io/summary/new_code?id=omarluq_librecode"><img src="https://sonarcloud.io/images/project_badges/sonarcloud-dark.svg" alt="SonarCloud Quality Gate"></a>
+  <a href="https://codecov.io/gh/omarluq/librecode"><img src="https://img.shields.io/codecov/c/github/omarluq/librecode?style=flat&labelColor=24292e&logo=codecov&logoColor=white" alt="Codecov"></a>
+  <a href="https://coderabbit.ai"><img src="https://img.shields.io/coderabbit/prs/github/omarluq/librecode?utm_source=oss&utm_medium=github&utm_campaign=omarluq%2Flibrecode&style=flat&labelColor=24292e&color=FF570A&label=CodeRabbit+Reviews" alt="CodeRabbit Reviews"></a>
+  <a href="https://deepwiki.com/omarluq/librecode"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 </p>
 
 **librecode** is a free and open source terminal agent harness with a small core and room for extension. One binary. Terminal interface. Local sessions. Built-in tools. Provider auth by OAuth or API key. Lua at the edges.

--- a/README.md
+++ b/README.md
@@ -336,10 +336,8 @@ git push origin v0.1.0
 
 The release workflow cross-compiles Linux, macOS, and Windows binaries, archives them, generates checksums, and publishes a GitHub release.
 
-<p align="center">
-  <a href="https://sonarcloud.io/summary/new_code?id=omarluq_librecode"><img src="https://img.shields.io/sonar/quality_gate/omarluq_librecode?server=https%3A%2F%2Fsonarcloud.io&style=flat&labelColor=24292e&logo=sonarqube&logoColor=white" alt="SonarCloud Quality Gate"></a>
-</p>
-
 ## License
 
 MIT — see [`LICENSE.txt`](LICENSE.txt).
+
+<a href="https://sonarcloud.io/summary/new_code?id=omarluq_librecode"><img src="https://img.shields.io/sonar/quality_gate/omarluq_librecode?server=https%3A%2F%2Fsonarcloud.io&style=flat&labelColor=24292e&logo=sonarqube&logoColor=white" alt="SonarCloud Quality Gate"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
   <a href="https://github.com/omarluq/librecode/releases"><img src="https://img.shields.io/github/v/release/omarluq/librecode?style=flat&labelColor=24292e&color=28a745&label=Version&logo=semver&logoColor=white" alt="Version"></a>
   <a href="LICENSE.txt"><img src="https://img.shields.io/badge/License-MIT-blue?style=flat&labelColor=24292e&logo=opensourceinitiative&logoColor=white" alt="License: MIT"></a>
   <br/>
-  <a href="https://sonarcloud.io/summary/new_code?id=omarluq_librecode"><img src="https://sonarcloud.io/images/project_badges/sonarcloud-dark.svg" alt="SonarCloud Quality Gate"></a>
   <a href="https://codecov.io/gh/omarluq/librecode"><img src="https://img.shields.io/codecov/c/github/omarluq/librecode?style=flat&labelColor=24292e&logo=codecov&logoColor=white" alt="Codecov"></a>
   <a href="https://coderabbit.ai"><img src="https://img.shields.io/coderabbit/prs/github/omarluq/librecode?utm_source=oss&utm_medium=github&utm_campaign=omarluq%2Flibrecode&style=flat&labelColor=24292e&color=FF570A&label=CodeRabbit+Reviews" alt="CodeRabbit Reviews"></a>
   <a href="https://deepwiki.com/omarluq/librecode"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
@@ -336,6 +335,10 @@ git push origin v0.1.0
 ```
 
 The release workflow cross-compiles Linux, macOS, and Windows binaries, archives them, generates checksums, and publishes a GitHub release.
+
+<p align="center">
+  <a href="https://sonarcloud.io/summary/new_code?id=omarluq_librecode"><img src="https://sonarcloud.io/images/project_badges/sonarcloud-dark.svg" alt="SonarCloud Quality Gate"></a>
+</p>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <a href="https://pkg.go.dev/librecode.sh"><img src="https://img.shields.io/badge/reference-007d9c?style=flat&labelColor=24292e&logo=go&logoColor=white" alt="Go Reference"></a>
+  <a href="https://pkg.go.dev/github.com/omarluq/librecode"><img src="https://img.shields.io/badge/reference-007d9c?style=flat&labelColor=24292e&logo=go&logoColor=white" alt="Go Reference"></a>
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go-%3E%3D1.26-00ADD8?style=flat&labelColor=24292e&logo=go&logoColor=white" alt="Go Version"></a>
   <a href="https://github.com/omarluq/librecode/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/omarluq/librecode/ci.yml?style=flat&labelColor=24292e&label=CI&logo=github&logoColor=white" alt="CI"></a>
   <a href="https://github.com/omarluq/librecode/releases"><img src="https://img.shields.io/github/v/release/omarluq/librecode?style=flat&labelColor=24292e&color=28a745&label=Version&logo=semver&logoColor=white" alt="Version"></a>
@@ -337,7 +337,7 @@ git push origin v0.1.0
 The release workflow cross-compiles Linux, macOS, and Windows binaries, archives them, generates checksums, and publishes a GitHub release.
 
 <p align="center">
-  <a href="https://sonarcloud.io/summary/new_code?id=omarluq_librecode"><img src="https://sonarcloud.io/images/project_badges/sonarcloud-dark.svg" alt="SonarCloud Quality Gate"></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=omarluq_librecode"><img src="https://img.shields.io/sonar/quality_gate/omarluq_librecode?server=https%3A%2F%2Fsonarcloud.io&style=flat&labelColor=24292e&logo=sonarqube&logoColor=white" alt="SonarCloud Quality Gate"></a>
 </p>
 
 ## License


### PR DESCRIPTION
## Summary\n- add SonarCloud, Codecov, CodeRabbit, and DeepWiki badges to README\n- update Go reference badge to librecode.sh vanity module path\n\n## Validation\n- mise exec -- task ci