### PR TITLE
feat(database): enrich session entry metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ For architecture, roadmap, and API details, see:
 
 - [`docs/adr/0001-programmable-runtime.md`](docs/adr/0001-programmable-runtime.md)
 - [`docs/runtime-architecture.md`](docs/runtime-architecture.md)
+- [`docs/session-context.md`](docs/session-context.md)
 - [`docs/extension-runtime.md`](docs/extension-runtime.md)
 - [`docs/extension-roadmap.md`](docs/extension-roadmap.md)
 - [`docs/extension-api.md`](docs/extension-api.md)

--- a/docs/session-context.md
+++ b/docs/session-context.md
@@ -1,0 +1,347 @@
+# Session Context and Compaction
+
+This document describes how librecode session history is stored, replayed, rendered, and sent to model providers today. It also explains why a SQLite database can contain many millions of persisted tokens while the assistant sees a much smaller active context.
+
+## Current summary
+
+- librecode persists every session entry in SQLite under `~/.librecode/librecode.db` by default.
+- The database stores both a tree of entries (`session_entries`) and a flat message index (`session_messages`).
+- The terminal transcript reloads from `session_messages`, so it can show the whole durable transcript.
+- Model requests are built from the active leaf branch in `session_entries`, then filtered to model-facing roles.
+- Tool results and thinking are stored for UI/history, but they are not sent to the model in the current request path.
+- Compaction data structures exist, but no automatic or manual compaction is implemented yet.
+
+## Why the DB can be huge while context is not
+
+The DB is an audit/history store. It can contain large tool outputs, thinking traces, repeated `/skill` listings, and old transcript entries.
+
+The model request path is narrower:
+
+1. Find the latest session leaf.
+2. Walk parent pointers back to the root to build the active branch.
+3. Apply branch entries into a `SessionContextEntity`.
+4. Filter to model-facing roles.
+5. Add the current system prompt and auto-activated skill content.
+6. Send the resulting messages to the provider-specific adapter.
+
+Today the model-facing filter includes only:
+
+- `user`
+- `assistant`
+
+It excludes:
+
+- `toolResult`
+- `thinking`
+- `custom`
+- `bashExecution`
+- `branchSummary`
+- `compactionSummary`
+
+That means a session DB with tens of millions of characters can still produce a much smaller request context.
+
+## Storage model
+
+```mermaid
+erDiagram
+    sessions ||--o{ session_entries : contains
+    sessions ||--o{ session_messages : indexes
+    session_entries ||--o| session_messages : normalizes
+    session_entries ||--o{ session_entries : parent_child
+
+    sessions {
+        text id PK
+        text cwd
+        text name
+        text parent_session
+        text created_at
+        text updated_at
+    }
+
+    session_entries {
+        text id PK
+        text session_id FK
+        text parent_id FK
+        text entry_type
+        text role
+        text content
+        text provider
+        text model
+        text custom_type
+        text data_json
+        text summary
+        text created_at
+        text tool_name
+        text tool_status
+        text tool_args_json
+        int token_estimate
+        int model_facing
+        int display
+        text compaction_first_kept_entry_id
+        int compaction_tokens_before
+        text branch_from_entry_id
+    }
+
+    session_messages {
+        text id PK
+        text session_id FK
+        text entry_id FK
+        text sender
+        text role
+        text content
+        text provider
+        text model
+        text created_at
+    }
+```
+
+### `session_entries`
+
+`session_entries` is the source of truth for the session tree. Every entry has:
+
+- an `id`
+- a `session_id`
+- an optional `parent_id`
+- an `entry_type`
+- optional message-like fields: `role`, `content`, `provider`, `model`
+- optional metadata in `data_json`
+- optional summary text in `summary`
+
+Current entry types include:
+
+- `message`
+- `custom`
+- `custom_message`
+- `compaction`
+- `branch_summary`
+- `label`
+- `model_change`
+- `session_info`
+- `thinking_level_change`
+
+Session entries also carry typed metadata columns so context accounting and future compaction do not need to parse every entry body:
+
+- `tool_name`, `tool_status`, `tool_args_json` for tool result entries.
+- `token_estimate` for cheap context and storage-size accounting.
+- `model_facing` to indicate whether an entry participates in model context reconstruction.
+- `display` to indicate whether the entry should normally render in the transcript.
+- `compaction_first_kept_entry_id` and `compaction_tokens_before` for future compaction coverage.
+- `branch_from_entry_id` for branch summary provenance.
+
+The migration that introduced these columns backfills existing rows using conservative heuristics from `entry_type`, `role`, `content`, `summary`, and `data_json`. New writes compute the same metadata before insertion.
+
+### `session_messages`
+
+`session_messages` is a normalized flat index of entries with a non-empty role. It exists to efficiently reload the UI transcript and support message-centric queries.
+
+It mirrors message content from `session_entries`, but it does not define the active branch by itself.
+
+## Write path today
+
+```mermaid
+flowchart TD
+    A[User submits prompt] --> B[Append user message entry]
+    B --> C[Build model request]
+    C --> D[Provider streams response]
+    D --> E[Append assistant message entry]
+    D --> F[Append thinking/tool result entries]
+    E --> G[session_entries]
+    F --> G
+    G --> H[appendEntryMessage]
+    H --> I[session_messages]
+
+    subgraph Durable SQLite
+        G
+        I
+    end
+```
+
+For any entry whose `Message.Role` is non-empty, `appendEntry` also writes a matching row to `session_messages` in the same transaction.
+
+## UI reload path
+
+The terminal uses the flat message index for transcript replay.
+
+```mermaid
+flowchart TD
+    A[Start/resume session] --> B[SessionRepository.Messages]
+    B --> C[SELECT * FROM session_messages ORDER BY created_at]
+    C --> D[append chatMessage to terminal state]
+    D --> E[Render transcript]
+    E --> F[Warm render row cache incrementally]
+```
+
+Important detail: this path is for display/history, not for model context.
+
+## Model context path
+
+```mermaid
+flowchart TD
+    A[Prompt execution] --> B[LeafEntry]
+    B --> C[BuildContext sessionID + leafID]
+    C --> D[Branch: walk parent_id to root]
+    D --> E[applyEntryToContext in append order]
+    E --> F[modelFacingMessages]
+    F --> G[defaultSystemPrompt]
+    G --> H[AutoActivateSkills]
+    H --> I[Append active skill content to system prompt]
+    I --> J[CompletionRequest]
+    J --> K[Provider adapter]
+```
+
+`BuildContext` reconstructs a `SessionContextEntity` from the active branch. It applies entries in order and mutates context state:
+
+- `message` appends the message.
+- `custom_message` appends custom context.
+- `branch_summary` appends branch summary context.
+- `compaction` replaces all previous context messages with one compaction summary.
+- `model_change` changes provider/model metadata.
+- `thinking_level_change` changes thinking metadata.
+- labels/session info/custom state do not affect prompt context.
+
+After that, `modelFacingMessages` filters the messages. Today, only user and assistant messages survive the filter.
+
+## Provider-specific message mapping
+
+```mermaid
+flowchart LR
+    A[CompletionRequest Messages] --> B{Provider API}
+    B --> C[OpenAI Chat]
+    B --> D[OpenAI Responses]
+    B --> E[OpenAI Codex Responses]
+    B --> F[Anthropic Messages]
+
+    C --> C1[user -> user]
+    C --> C2[assistant -> assistant]
+
+    D --> D1[user -> user]
+    D --> D2[assistant -> user-visible context]
+
+    E --> E1[compact consecutive assistant messages]
+    E --> E2[user/assistant -> Responses input]
+
+    F --> F1[user -> user]
+    F --> F2[assistant -> assistant]
+```
+
+Provider adapters apply their own additional mapping rules. For example, OpenAI Responses currently replays assistant text as user-visible context because `store=false` means provider-side response item IDs are not available for continuation.
+
+## Current compaction behavior
+
+```mermaid
+stateDiagram-v2
+    [*] --> SupportedInSchema
+    SupportedInSchema --> NotTriggered: /compact command stub
+    SupportedInSchema --> NotTriggered: no auto threshold
+    NotTriggered --> FullActiveBranch: normal requests
+
+    state SupportedInSchema {
+        [*] --> EntryTypeCompaction
+        EntryTypeCompaction --> RoleCompactionSummary
+    }
+```
+
+The schema and repository can store compaction summaries:
+
+- `EntryTypeCompaction`
+- `RoleCompactionSummary`
+- `AppendCompaction`
+- `BuildContext` handling that resets prior messages to the compaction summary
+
+But there is currently no real compaction execution path:
+
+- `/compact` is not implemented.
+- no auto-compaction threshold exists.
+- context-limit errors are not recovered through compaction.
+
+## Current DB observations
+
+Local inspection of `~/.librecode/librecode.db` showed:
+
+- 33 sessions.
+- 18,490 total persisted messages.
+- about 71.9M persisted message characters.
+- 0 compaction entries.
+- most persisted data is `toolResult` content.
+
+For the latest long-running session:
+
+- total persisted session content is dominated by `toolResult` and `thinking` roles.
+- active branch includes 14,179 entries.
+- active model-facing messages are 596 user messages and 544 assistant messages.
+- active model-facing content is about 506k characters, roughly 126k tokens by the current chars/4 estimate.
+
+That explains why a raw DB estimate produced values like ~13M tokens, while a model-facing estimate produced ~132k tokens.
+
+## Problems with the current behavior
+
+1. **No intentional long-term memory compression**
+   - Old context can disappear implicitly due to provider/window limits instead of being summarized.
+
+2. **No user-facing compaction command**
+   - `/compact` exists as a command placeholder but does not summarize or alter context.
+
+3. **Tool outcomes are not model-facing**
+   - Tool result blocks are stored and rendered, but future model calls do not receive their raw content.
+   - This reduces context size, but it can also make the assistant forget exact tool evidence unless the assistant response summarized it.
+
+4. **Large assistant messages remain model-facing**
+   - Repeated long assistant outputs, such as `/skill` listings or architecture reports, can grow context quickly.
+
+5. **Context status is approximate**
+   - It uses a chars/4 estimate over the model-facing request context plus system/skill content.
+   - It is not tokenizer-accurate.
+
+## Recommended next architecture
+
+```mermaid
+flowchart TD
+    A[Before model request] --> B[Estimate active context]
+    B --> C{Over threshold?}
+    C -- no --> D[Send request]
+    C -- yes --> E[Select compaction range]
+    E --> F[Summarize older entries]
+    F --> G[Append compaction entry]
+    G --> H[Keep recent tail verbatim]
+    H --> I[BuildContext sees compaction summary]
+    I --> D
+
+    D --> J{Context overflow error?}
+    J -- no --> K[Done]
+    J -- yes --> L[Compact and retry once]
+    L --> D
+```
+
+Recommended compaction behavior:
+
+1. Keep the recent tail verbatim.
+2. Summarize older model-facing messages and important tool outcomes.
+3. Append a `compaction` entry as a child of the current leaf.
+4. Future `BuildContext` starts from the compaction summary plus newer entries.
+5. On provider context overflow, run compaction and retry once.
+
+## Implementation notes for future compaction
+
+A practical first version should:
+
+- add real `/compact` behavior.
+- summarize active branch entries older than a configurable tail window.
+- include important tool outcomes, file edits, commands, decisions, and unresolved tasks.
+- store `tokensBefore` and `firstKeptEntryID` in compaction metadata.
+- add a context breakdown debug view before and after compaction.
+- avoid deleting old DB history; compaction changes future context reconstruction, not durable history.
+
+Potential config:
+
+```yaml
+assistant:
+  compaction:
+    enabled: true
+    threshold_percent: 80
+    keep_recent_messages: 40
+    retry_on_context_overflow: true
+```
+
+## Key takeaway
+
+The database is a full durable transcript/audit log. The model context is a filtered active-branch projection. Today we rely on filtering and provider limits, not actual compaction. Implementing real compaction should be a high-priority reliability feature for week-long sessions.

--- a/internal/database/entity.go
+++ b/internal/database/entity.go
@@ -82,35 +82,52 @@ type SessionEntity struct {
 
 // EntryEntity is a persisted node in a session tree.
 type EntryEntity struct {
-	Message    MessageEntity `json:"message"`
-	CreatedAt  time.Time     `json:"created_at"`
-	ParentID   *string       `json:"parent_id,omitempty"`
-	ID         string        `json:"id"`
-	SessionID  string        `json:"session_id"`
-	Type       EntryType     `json:"type"`
-	CustomType string        `json:"custom_type,omitempty"`
-	DataJSON   string        `json:"data_json,omitempty"`
-	Summary    string        `json:"summary,omitempty"`
+	CreatedAt                  time.Time     `json:"created_at"`
+	ParentID                   *string       `json:"parent_id,omitempty"`
+	Message                    MessageEntity `json:"message"`
+	Summary                    string        `json:"summary,omitempty"`
+	ToolStatus                 string        `json:"tool_status,omitempty"`
+	Type                       EntryType     `json:"type"`
+	CustomType                 string        `json:"custom_type,omitempty"`
+	DataJSON                   string        `json:"data_json,omitempty"`
+	ID                         string        `json:"id"`
+	ToolName                   string        `json:"tool_name,omitempty"`
+	SessionID                  string        `json:"session_id"`
+	ToolArgsJSON               string        `json:"tool_args_json,omitempty"`
+	BranchFromEntryID          string        `json:"branch_from_entry_id,omitempty"`
+	CompactionFirstKeptEntryID string        `json:"compaction_first_kept_entry_id,omitempty"`
+	CompactionTokensBefore     int           `json:"compaction_tokens_before,omitempty"`
+	TokenEstimate              int           `json:"token_estimate,omitempty"`
+	Display                    bool          `json:"display"`
+	ModelFacing                bool          `json:"model_facing"`
 }
 
 // EntryDataEntity stores flexible per-entry metadata encoded in session_entries.data_json.
 type EntryDataEntity struct {
-	Details          map[string]any `json:"details,omitempty"`
-	Display          *bool          `json:"display,omitempty"`
-	Label            *string        `json:"label,omitempty"`
-	FirstKeptEntryID string         `json:"firstKeptEntryId,omitempty"`
-	FromID           string         `json:"fromId,omitempty"`
-	Name             string         `json:"name,omitempty"`
-	TargetID         string         `json:"targetId,omitempty"`
-	ThinkingLevel    string         `json:"thinkingLevel,omitempty"`
-	TokensBefore     int            `json:"tokensBefore,omitempty"`
-	FromHook         bool           `json:"fromHook,omitempty"`
+	Details                    map[string]any `json:"details,omitempty"`
+	Display                    *bool          `json:"display,omitempty"`
+	Label                      *string        `json:"label,omitempty"`
+	ModelFacing                *bool          `json:"modelFacing,omitempty"`
+	FromID                     string         `json:"fromId,omitempty"`
+	BranchFromEntryID          string         `json:"branchFromEntryId,omitempty"`
+	TargetID                   string         `json:"targetId,omitempty"`
+	ThinkingLevel              string         `json:"thinkingLevel,omitempty"`
+	ToolName                   string         `json:"toolName,omitempty"`
+	ToolStatus                 string         `json:"toolStatus,omitempty"`
+	ToolArgsJSON               string         `json:"toolArgsJson,omitempty"`
+	Name                       string         `json:"name,omitempty"`
+	FirstKeptEntryID           string         `json:"firstKeptEntryId,omitempty"`
+	CompactionFirstKeptEntryID string         `json:"compactionFirstKeptEntryId,omitempty"`
+	TokenEstimate              int            `json:"tokenEstimate,omitempty"`
+	CompactionTokensBefore     int            `json:"compactionTokensBefore,omitempty"`
+	TokensBefore               int            `json:"tokensBefore,omitempty"`
+	FromHook                   bool           `json:"fromHook,omitempty"`
 }
 
 // TreeNodeEntity is an entry and its direct descendants.
 type TreeNodeEntity struct {
-	Entry    EntryEntity      `json:"entry"`
 	Children []TreeNodeEntity `json:"children"`
+	Entry    EntryEntity      `json:"entry"`
 }
 
 // SessionContextEntity is the reconstructed context from a session branch.

--- a/internal/database/entry_metadata.go
+++ b/internal/database/entry_metadata.go
@@ -1,0 +1,190 @@
+package database
+
+import (
+	"encoding/json"
+	"strings"
+	"unicode/utf8"
+)
+
+const charsPerEstimatedToken = 4
+
+func applyEntryMetadata(entry *EntryEntity) error {
+	data, err := dataFromEntry(entry)
+	if err != nil {
+		return err
+	}
+
+	entry.TokenEstimate = estimateEntryTokens(entry)
+	entry.ModelFacing = entryParticipatesInModelContext(entry)
+	entry.Display = entryDisplaysInTranscript(entry, &data)
+	entry.CompactionFirstKeptEntryID = firstNonEmpty(data.CompactionFirstKeptEntryID, data.FirstKeptEntryID)
+	entry.CompactionTokensBefore = firstPositive(data.CompactionTokensBefore, data.TokensBefore)
+	entry.BranchFromEntryID = firstNonEmpty(data.BranchFromEntryID, data.FromID)
+
+	if entry.Message.Role == RoleToolResult {
+		metadata := parseToolMetadata(entry.Message.Content)
+		entry.ToolName = firstNonEmpty(data.ToolName, metadata.Name)
+		entry.ToolStatus = firstNonEmpty(data.ToolStatus, metadata.Status)
+		entry.ToolArgsJSON = firstNonEmpty(data.ToolArgsJSON, metadata.ArgsJSON)
+	}
+
+	data.ToolName = entry.ToolName
+	data.ToolStatus = entry.ToolStatus
+	data.ToolArgsJSON = entry.ToolArgsJSON
+	data.TokenEstimate = entry.TokenEstimate
+	data.ModelFacing = &entry.ModelFacing
+	data.CompactionFirstKeptEntryID = entry.CompactionFirstKeptEntryID
+	data.CompactionTokensBefore = entry.CompactionTokensBefore
+	data.BranchFromEntryID = entry.BranchFromEntryID
+	if data.Display == nil {
+		data.Display = &entry.Display
+	}
+
+	dataJSON, err := dataJSONFromEntity(&data)
+	if err != nil {
+		return err
+	}
+	entry.DataJSON = normalizeDataJSON(dataJSON)
+
+	return nil
+}
+
+func estimateEntryTokens(entry *EntryEntity) int {
+	text := entry.Message.Content
+	if strings.TrimSpace(text) == "" {
+		text = entry.Summary
+	}
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return 0
+	}
+
+	return max(1, (utf8.RuneCountInString(trimmed)+charsPerEstimatedToken-1)/charsPerEstimatedToken)
+}
+
+func entryParticipatesInModelContext(entry *EntryEntity) bool {
+	switch entry.Type {
+	case EntryTypeMessage:
+		return entry.Message.Role == RoleUser || entry.Message.Role == RoleAssistant
+	case EntryTypeCustomMessage, EntryTypeBranchSummary, EntryTypeCompaction:
+		return true
+	case EntryTypeCustom, EntryTypeLabel, EntryTypeModelChange, EntryTypeSessionInfo, EntryTypeThinkingLevelChange:
+		return false
+	}
+
+	return false
+}
+
+func entryDisplaysInTranscript(entry *EntryEntity, data *EntryDataEntity) bool {
+	if data != nil && data.Display != nil {
+		return *data.Display
+	}
+
+	switch entry.Type {
+	case EntryTypeMessage,
+		EntryTypeCustom,
+		EntryTypeCustomMessage,
+		EntryTypeCompaction,
+		EntryTypeBranchSummary:
+		return true
+	case EntryTypeModelChange,
+		EntryTypeThinkingLevelChange,
+		EntryTypeLabel,
+		EntryTypeSessionInfo:
+		return false
+	}
+
+	return true
+}
+
+type toolMetadata struct {
+	Name     string
+	Status   string
+	ArgsJSON string
+}
+
+func parseToolMetadata(content string) toolMetadata {
+	metadata := toolMetadata{Name: "", Status: "success", ArgsJSON: ""}
+	sections := splitToolSections(content)
+	metadata.Name = strings.TrimSpace(sections["tool"])
+	metadata.ArgsJSON = strings.TrimSpace(sections["arguments"])
+	if strings.TrimSpace(sections["error"]) != "" {
+		metadata.Status = "error"
+	}
+	if metadata.ArgsJSON != "" {
+		metadata.ArgsJSON = firstNonEmpty(compactJSON(metadata.ArgsJSON), metadata.ArgsJSON)
+	}
+
+	return metadata
+}
+
+func splitToolSections(content string) map[string]string {
+	sections := map[string]string{}
+	current := ""
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		name, value, ok := splitToolHeader(line)
+		if ok {
+			current = name
+			sections[current] = value
+			continue
+		}
+		if current == "" {
+			continue
+		}
+		if sections[current] == "" {
+			sections[current] = line
+		} else {
+			sections[current] += "\n" + line
+		}
+	}
+
+	return sections
+}
+
+func splitToolHeader(line string) (name, value string, ok bool) {
+	for _, section := range []string{"tool", "arguments", "error", "details", "output"} {
+		prefix := section + ":"
+		if strings.HasPrefix(line, prefix) {
+			return section, strings.TrimSpace(strings.TrimPrefix(line, prefix)), true
+		}
+	}
+
+	return "", "", false
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+
+	return ""
+}
+
+func firstPositive(values ...int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+
+	return 0
+}
+
+func compactJSON(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(value), &decoded); err != nil {
+		return value
+	}
+	encoded, err := json.Marshal(decoded)
+	if err != nil {
+		return value
+	}
+
+	return string(encoded)
+}

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -13,13 +13,18 @@ import (
 //go:embed migrations/*.sql
 var migrationsFS embed.FS
 
-// Migrate applies embedded SQLite schema migrations.
-func Migrate(ctx context.Context, database *sql.DB) error {
+// MigrationFS returns the embedded migration filesystem rooted at migrations/.
+func MigrationFS() (fs.FS, error) {
 	migrationRoot, err := fs.Sub(migrationsFS, "migrations")
 	if err != nil {
-		return fmt.Errorf("database: prepare migrations: %w", err)
+		return nil, fmt.Errorf("database: prepare migrations: %w", err)
 	}
 
+	return migrationRoot, nil
+}
+
+// NewMigrationProvider returns a goose migration provider for the given database.
+func NewMigrationProvider(database *sql.DB, migrationRoot fs.FS) (*goose.Provider, error) {
 	provider, err := goose.NewProvider(
 		goose.DialectSQLite3,
 		database,
@@ -27,7 +32,21 @@ func Migrate(ctx context.Context, database *sql.DB) error {
 		goose.WithDisableGlobalRegistry(true),
 	)
 	if err != nil {
-		return fmt.Errorf("database: create migration provider: %w", err)
+		return nil, fmt.Errorf("database: create migration provider: %w", err)
+	}
+
+	return provider, nil
+}
+
+// Migrate applies embedded SQLite schema migrations.
+func Migrate(ctx context.Context, database *sql.DB) error {
+	migrationRoot, err := MigrationFS()
+	if err != nil {
+		return err
+	}
+	provider, err := NewMigrationProvider(database, migrationRoot)
+	if err != nil {
+		return err
 	}
 
 	if _, err := provider.Up(ctx); err != nil {

--- a/internal/database/migrations/00004_enrich_session_entry_metadata.sql
+++ b/internal/database/migrations/00004_enrich_session_entry_metadata.sql
@@ -1,0 +1,78 @@
+-- +goose Up
+ALTER TABLE session_entries ADD COLUMN tool_name TEXT NOT NULL DEFAULT '';
+ALTER TABLE session_entries ADD COLUMN tool_status TEXT NOT NULL DEFAULT '';
+ALTER TABLE session_entries ADD COLUMN tool_args_json TEXT NOT NULL DEFAULT '';
+ALTER TABLE session_entries ADD COLUMN token_estimate INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE session_entries ADD COLUMN model_facing INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE session_entries ADD COLUMN display INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE session_entries ADD COLUMN compaction_first_kept_entry_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE session_entries ADD COLUMN compaction_tokens_before INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE session_entries ADD COLUMN branch_from_entry_id TEXT NOT NULL DEFAULT '';
+
+UPDATE session_entries
+SET
+    token_estimate = CASE
+        WHEN length(coalesce(content, '')) = 0 AND length(coalesce(summary, '')) = 0 THEN 0
+        ELSE max(1, (length(coalesce(content, '')) + length(coalesce(summary, '')) + 3) / 4)
+    END,
+    model_facing = CASE
+        WHEN entry_type = 'message' AND role IN ('user', 'assistant') THEN 1
+        WHEN entry_type = 'custom_message' THEN 1
+        WHEN entry_type IN ('compaction', 'branch_summary') THEN 1
+        ELSE 0
+    END,
+    display = CASE
+        WHEN entry_type IN ('model_change', 'thinking_level_change', 'label', 'session_info') THEN 0
+        ELSE 1
+    END,
+    tool_name = CASE
+        WHEN role = 'toolResult' AND instr(coalesce(content, ''), 'tool: ') = 1 THEN trim(substr(coalesce(content, ''), 7, CASE WHEN instr(coalesce(content, ''), char(10)) > 0 THEN instr(coalesce(content, ''), char(10)) - 7 ELSE length(coalesce(content, '')) END))
+        ELSE ''
+    END,
+    tool_status = CASE
+        WHEN role = 'toolResult' AND instr(coalesce(content, ''), char(10) || 'error:') > 0 THEN 'error'
+        WHEN role = 'toolResult' THEN 'success'
+        ELSE ''
+    END,
+    compaction_first_kept_entry_id = CASE
+        WHEN entry_type = 'compaction' AND json_valid(data_json) THEN coalesce(json_extract(data_json, '$.firstKeptEntryId'), '')
+        ELSE ''
+    END,
+    compaction_tokens_before = CASE
+        WHEN entry_type = 'compaction' AND json_valid(data_json) THEN coalesce(json_extract(data_json, '$.tokensBefore'), 0)
+        ELSE 0
+    END,
+    tool_args_json = CASE
+        WHEN role = 'toolResult' AND instr(coalesce(content, ''), char(10) || 'arguments:') > 0 THEN trim(
+            CASE
+                WHEN instr(substr(coalesce(content, ''), instr(coalesce(content, ''), char(10) || 'arguments:') + length(char(10) || 'arguments:')), char(10)) > 0
+                    THEN substr(
+                        substr(coalesce(content, ''), instr(coalesce(content, ''), char(10) || 'arguments:') + length(char(10) || 'arguments:')),
+                        1,
+                        instr(substr(coalesce(content, ''), instr(coalesce(content, ''), char(10) || 'arguments:') + length(char(10) || 'arguments:')), char(10)) - 1
+                    )
+                ELSE substr(coalesce(content, ''), instr(coalesce(content, ''), char(10) || 'arguments:') + length(char(10) || 'arguments:'))
+            END
+        )
+        ELSE ''
+    END,
+    branch_from_entry_id = CASE
+        WHEN entry_type = 'branch_summary' AND json_valid(data_json) THEN coalesce(json_extract(data_json, '$.fromId'), '')
+        ELSE ''
+    END;
+
+CREATE INDEX IF NOT EXISTS idx_session_entries_model_facing ON session_entries(session_id, model_facing, created_at);
+CREATE INDEX IF NOT EXISTS idx_session_entries_tool_name ON session_entries(session_id, tool_name, created_at);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_session_entries_tool_name;
+DROP INDEX IF EXISTS idx_session_entries_model_facing;
+ALTER TABLE session_entries DROP COLUMN branch_from_entry_id;
+ALTER TABLE session_entries DROP COLUMN compaction_tokens_before;
+ALTER TABLE session_entries DROP COLUMN compaction_first_kept_entry_id;
+ALTER TABLE session_entries DROP COLUMN display;
+ALTER TABLE session_entries DROP COLUMN model_facing;
+ALTER TABLE session_entries DROP COLUMN token_estimate;
+ALTER TABLE session_entries DROP COLUMN tool_args_json;
+ALTER TABLE session_entries DROP COLUMN tool_status;
+ALTER TABLE session_entries DROP COLUMN tool_name;

--- a/internal/database/session_entry_repository.go
+++ b/internal/database/session_entry_repository.go
@@ -15,7 +15,9 @@ import (
 
 const entrySelectColumns = `
 id, session_id, parent_id, entry_type, role, content,
-provider, model, custom_type, data_json, summary, created_at`
+provider, model, custom_type, data_json, summary, created_at,
+tool_name, tool_status, tool_args_json, token_estimate, model_facing, display,
+compaction_first_kept_entry_id, compaction_tokens_before, branch_from_entry_id`
 
 // LeafEntry returns the newest appended entry for a session.
 func (repository *SessionRepository) LeafEntry(ctx context.Context, sessionID string) (*EntryEntity, bool, error) {
@@ -197,42 +199,21 @@ ORDER BY created_at ASC`, entrySelectColumns)
 }
 
 func (repository *SessionRepository) appendEntry(ctx context.Context, entry *EntryEntity) error {
-	if err := validateEntryEntity(entry); err != nil {
-		return oops.In("database").Code("validate_entry").Wrapf(err, "validate entry")
+	if err := repository.prepareAppendEntry(entry); err != nil {
+		return err
 	}
-
-	const insertEntry = `
-INSERT INTO session_entries (
-    id, session_id, parent_id, entry_type, role, content,
-    provider, model, custom_type, data_json, summary, created_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	transaction, err := repository.connection.BeginTx(ctx, nil)
 	if err != nil {
 		return oops.In("database").Code("begin_append").Wrapf(err, "begin append entry")
 	}
 
-	if _, err := transaction.ExecContext(
-		ctx,
-		insertEntry,
-		entry.ID,
-		entry.SessionID,
-		entry.ParentID,
-		string(entry.Type),
-		string(entry.Message.Role),
-		entry.Message.Content,
-		entry.Message.Provider,
-		entry.Message.Model,
-		entry.CustomType,
-		entry.DataJSON,
-		entry.Summary,
-		formatTime(entry.CreatedAt),
-	); err != nil {
+	if err := repository.insertEntryTx(ctx, transaction, entry); err != nil {
 		rollbackErr := transaction.Rollback()
 		if rollbackErr != nil {
 			return oops.In("database").Code("append_entry_rollback").Wrapf(rollbackErr, "rollback append entry")
 		}
-		return oops.In("database").Code("append_entry").Wrapf(err, "append session entry")
+		return err
 	}
 
 	if err := repository.appendEntryMessage(ctx, transaction, entry); err != nil {
@@ -259,12 +240,66 @@ INSERT INTO session_entries (
 	return nil
 }
 
+func (repository *SessionRepository) prepareAppendEntry(entry *EntryEntity) error {
+	if err := applyEntryMetadata(entry); err != nil {
+		return oops.In("database").Code("entry_metadata").Wrapf(err, "prepare entry metadata")
+	}
+	if err := validateEntryEntity(entry); err != nil {
+		return oops.In("database").Code("validate_entry").Wrapf(err, "validate entry")
+	}
+
+	return nil
+}
+
+func (repository *SessionRepository) insertEntryTx(ctx context.Context, transaction *sql.Tx, entry *EntryEntity) error {
+	const insertEntry = `
+INSERT INTO session_entries (
+    id, session_id, parent_id, entry_type, role, content,
+    provider, model, custom_type, data_json, summary, created_at,
+    tool_name, tool_status, tool_args_json, token_estimate, model_facing, display,
+    compaction_first_kept_entry_id, compaction_tokens_before, branch_from_entry_id
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+
+	_, err := transaction.ExecContext(
+		ctx,
+		insertEntry,
+		entry.ID,
+		entry.SessionID,
+		entry.ParentID,
+		string(entry.Type),
+		string(entry.Message.Role),
+		entry.Message.Content,
+		entry.Message.Provider,
+		entry.Message.Model,
+		entry.CustomType,
+		entry.DataJSON,
+		entry.Summary,
+		formatTime(entry.CreatedAt),
+		entry.ToolName,
+		entry.ToolStatus,
+		entry.ToolArgsJSON,
+		entry.TokenEstimate,
+		boolToInt(entry.ModelFacing),
+		boolToInt(entry.Display),
+		entry.CompactionFirstKeptEntryID,
+		entry.CompactionTokensBefore,
+		entry.BranchFromEntryID,
+	)
+	if err != nil {
+		return oops.In("database").Code("append_entry").Wrapf(err, "append session entry")
+	}
+
+	return nil
+}
+
 func scanEntry(scanner rowScanner) (*EntryEntity, error) {
 	var parentID sql.NullString
 	var createdAt string
 	var entryType string
 	var role string
 	entry := EntryEntity{
+		CreatedAt: time.Time{},
+		ParentID:  nil,
 		Message: MessageEntity{
 			Timestamp: time.Time{},
 			Role:      "",
@@ -272,16 +307,25 @@ func scanEntry(scanner rowScanner) (*EntryEntity, error) {
 			Provider:  "",
 			Model:     "",
 		},
-		CreatedAt:  time.Time{},
-		ParentID:   nil,
-		ID:         "",
-		SessionID:  "",
-		Type:       "",
-		CustomType: "",
-		DataJSON:   "",
-		Summary:    "",
+		Summary:                    "",
+		ToolStatus:                 "",
+		Type:                       "",
+		CustomType:                 "",
+		DataJSON:                   "",
+		ID:                         "",
+		ToolName:                   "",
+		SessionID:                  "",
+		ToolArgsJSON:               "",
+		BranchFromEntryID:          "",
+		CompactionFirstKeptEntryID: "",
+		CompactionTokensBefore:     0,
+		TokenEstimate:              0,
+		Display:                    true,
+		ModelFacing:                false,
 	}
 
+	var modelFacing int
+	var display int
 	if err := scanner.Scan(
 		&entry.ID,
 		&entry.SessionID,
@@ -295,6 +339,15 @@ func scanEntry(scanner rowScanner) (*EntryEntity, error) {
 		&entry.DataJSON,
 		&entry.Summary,
 		&createdAt,
+		&entry.ToolName,
+		&entry.ToolStatus,
+		&entry.ToolArgsJSON,
+		&entry.TokenEstimate,
+		&modelFacing,
+		&display,
+		&entry.CompactionFirstKeptEntryID,
+		&entry.CompactionTokensBefore,
+		&entry.BranchFromEntryID,
 	); err != nil {
 		return nil, err
 	}
@@ -311,8 +364,18 @@ func scanEntry(scanner rowScanner) (*EntryEntity, error) {
 	entry.Message.Role = Role(role)
 	entry.Message.Timestamp = parsedCreatedAt
 	entry.CreatedAt = parsedCreatedAt
+	entry.ModelFacing = modelFacing != 0
+	entry.Display = display != 0
 
 	return &entry, nil
+}
+
+func boolToInt(value bool) int {
+	if value {
+		return 1
+	}
+
+	return 0
 }
 
 func newEntryID() string {

--- a/internal/database/session_metadata_test.go
+++ b/internal/database/session_metadata_test.go
@@ -1,0 +1,118 @@
+package database_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/database"
+)
+
+func TestSessionRepository_EnrichesEntryMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repository := newTestSessionRepository(t)
+	session, err := repository.CreateSession(ctx, "/work", "metadata", "")
+	require.NoError(t, err)
+
+	userEntry := appendTestMessage(ctx, t, repository, session.ID, nil, database.RoleUser, "hello world")
+	assert.True(t, userEntry.ModelFacing)
+	assert.True(t, userEntry.Display)
+	assert.Positive(t, userEntry.TokenEstimate)
+	assert.Empty(t, userEntry.ToolName)
+
+	toolEntry := appendTestMessage(
+		ctx,
+		t,
+		repository,
+		session.ID,
+		&userEntry.ID,
+		database.RoleToolResult,
+		"tool: read\narguments: {\"path\":\"main.go\"}\noutput:\npackage main\n",
+	)
+	assert.False(t, toolEntry.ModelFacing)
+	assert.True(t, toolEntry.Display)
+	assert.Equal(t, "read", toolEntry.ToolName)
+	assert.Equal(t, "success", toolEntry.ToolStatus)
+	assert.JSONEq(t, `{"path":"main.go"}`, toolEntry.ToolArgsJSON)
+	assert.Positive(t, toolEntry.TokenEstimate)
+
+	fetched, found, err := repository.Entry(ctx, session.ID, toolEntry.ID)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, toolEntry.ToolName, fetched.ToolName)
+	assert.Equal(t, toolEntry.ToolStatus, fetched.ToolStatus)
+	assert.Equal(t, toolEntry.ToolArgsJSON, fetched.ToolArgsJSON)
+	assert.Equal(t, toolEntry.TokenEstimate, fetched.TokenEstimate)
+	assert.Equal(t, toolEntry.ModelFacing, fetched.ModelFacing)
+	assert.Equal(t, toolEntry.Display, fetched.Display)
+}
+
+func TestSessionRepository_EnrichesCompactionMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repository := newTestSessionRepository(t)
+	session, err := repository.CreateSession(ctx, "/work", "compaction", "")
+	require.NoError(t, err)
+	rootEntry := appendTestMessage(ctx, t, repository, session.ID, nil, database.RoleUser, "hello")
+
+	compactionEntry, err := repository.AppendCompaction(
+		ctx,
+		session.ID,
+		&rootEntry.ID,
+		"summary",
+		rootEntry.ID,
+		1234,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+	assert.True(t, compactionEntry.ModelFacing)
+	assert.True(t, compactionEntry.Display)
+	assert.Equal(t, rootEntry.ID, compactionEntry.CompactionFirstKeptEntryID)
+	assert.Equal(t, 1234, compactionEntry.CompactionTokensBefore)
+	assert.Positive(t, compactionEntry.TokenEstimate)
+}
+
+func TestSessionRepository_BackfillsEntryMetadataMigration(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	connection := newMigratedThroughVersion(t, 3)
+	repository := database.NewSessionRepository(connection)
+	session, err := repository.CreateSession(ctx, "/work", "legacy", "")
+	require.NoError(t, err)
+
+	createdAt := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err = connection.ExecContext(
+		ctx,
+		`INSERT INTO session_entries (
+			id, session_id, parent_id, entry_type, role, content,
+			provider, model, custom_type, data_json, summary, created_at
+		) VALUES (?, ?, NULL, ?, ?, ?, '', '', '', '{}', '', ?)`,
+		"legacy-tool",
+		session.ID,
+		string(database.EntryTypeMessage),
+		string(database.RoleToolResult),
+		"tool: bash\narguments: {\"command\":\"echo hi\"}\nerror:\nboom\n",
+		createdAt,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, database.Migrate(ctx, connection))
+
+	entry, found, err := repository.Entry(ctx, session.ID, "legacy-tool")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "bash", entry.ToolName)
+	assert.Equal(t, "error", entry.ToolStatus)
+	assert.JSONEq(t, `{"command":"echo hi"}`, entry.ToolArgsJSON)
+	assert.False(t, entry.ModelFacing)
+	assert.True(t, entry.Display)
+	assert.Positive(t, entry.TokenEstimate)
+}

--- a/internal/database/session_repository_test.go
+++ b/internal/database/session_repository_test.go
@@ -312,6 +312,26 @@ func newTestSessionRepository(t *testing.T) *database.SessionRepository {
 	return database.NewSessionRepository(connection)
 }
 
+func newMigratedThroughVersion(t *testing.T, version int64) *sql.DB {
+	t.Helper()
+
+	connection, err := sql.Open(sqliteDriver(), ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, connection.Close())
+	})
+	connection.SetMaxOpenConns(1)
+
+	migrationRoot, err := database.MigrationFS()
+	require.NoError(t, err)
+	provider, err := database.NewMigrationProvider(connection, migrationRoot)
+	require.NoError(t, err)
+	_, err = provider.UpTo(context.Background(), version)
+	require.NoError(t, err)
+
+	return connection
+}
+
 func sqliteDriver() string {
 	return "sqlite"
 }

--- a/internal/database/session_store.go
+++ b/internal/database/session_store.go
@@ -155,6 +155,30 @@ func (repository *SessionRepository) BuildContext(
 	return &contextEntity, nil
 }
 
+func newEntryEntity(sessionID string, parentID *string, entryType EntryType, message *MessageEntity) EntryEntity {
+	createdAt := message.Timestamp
+	return EntryEntity{
+		CreatedAt:                  createdAt,
+		ParentID:                   parentID,
+		Message:                    *message,
+		Summary:                    "",
+		ToolStatus:                 "",
+		Type:                       entryType,
+		CustomType:                 "",
+		DataJSON:                   "{}",
+		ID:                         newEntryID(),
+		ToolName:                   "",
+		SessionID:                  sessionID,
+		ToolArgsJSON:               "",
+		BranchFromEntryID:          "",
+		CompactionFirstKeptEntryID: "",
+		CompactionTokensBefore:     0,
+		TokenEstimate:              0,
+		Display:                    true,
+		ModelFacing:                false,
+	}
+}
+
 // AppendMessage appends a message as a child of the current leaf or provided parent.
 func (repository *SessionRepository) AppendMessage(
 	ctx context.Context,
@@ -162,17 +186,9 @@ func (repository *SessionRepository) AppendMessage(
 	parentID *string,
 	message *MessageEntity,
 ) (*EntryEntity, error) {
-	entry := EntryEntity{
-		Message:    *message,
-		CreatedAt:  repository.now().UTC(),
-		ParentID:   parentID,
-		ID:         newEntryID(),
-		SessionID:  sessionID,
-		Type:       EntryTypeMessage,
-		CustomType: "",
-		DataJSON:   "{}",
-		Summary:    "",
-	}
+	entry := newEntryEntity(sessionID, parentID, EntryTypeMessage, message)
+	entry.CreatedAt = repository.now().UTC()
+	entry.Message.Timestamp = entry.CreatedAt
 
 	if err := repository.appendEntry(ctx, &entry); err != nil {
 		return nil, err
@@ -200,23 +216,15 @@ func (repository *SessionRepository) AppendCustomEntry(
 	dataJSON string,
 ) (*EntryEntity, error) {
 	timestamp := repository.now().UTC()
-	entry := EntryEntity{
-		Message: MessageEntity{
-			Timestamp: timestamp,
-			Role:      "",
-			Content:   "",
-			Provider:  "",
-			Model:     "",
-		},
-		CreatedAt:  timestamp,
-		ParentID:   parentID,
-		ID:         newEntryID(),
-		SessionID:  sessionID,
-		Type:       EntryTypeCustom,
-		CustomType: customType,
-		DataJSON:   normalizeDataJSON(dataJSON),
-		Summary:    "",
-	}
+	entry := newEntryEntity(sessionID, parentID, EntryTypeCustom, &MessageEntity{
+		Timestamp: timestamp,
+		Role:      "",
+		Content:   "",
+		Provider:  "",
+		Model:     "",
+	})
+	entry.CustomType = customType
+	entry.DataJSON = normalizeDataJSON(dataJSON)
 
 	if err := repository.appendEntry(ctx, &entry); err != nil {
 		return nil, err
@@ -236,39 +244,39 @@ func (repository *SessionRepository) AppendCustomMessage(
 	details map[string]any,
 ) (*EntryEntity, error) {
 	dataJSON, err := dataJSONFromEntity(&EntryDataEntity{
-		Details:          details,
-		Display:          &display,
-		FromHook:         false,
-		FirstKeptEntryID: "",
-		FromID:           "",
-		Label:            nil,
-		Name:             "",
-		TargetID:         "",
-		ThinkingLevel:    "",
-		TokensBefore:     0,
+		Details:                    details,
+		Display:                    &display,
+		FromHook:                   false,
+		FirstKeptEntryID:           "",
+		FromID:                     "",
+		Label:                      nil,
+		Name:                       "",
+		TargetID:                   "",
+		ThinkingLevel:              "",
+		ToolName:                   "",
+		ToolStatus:                 "",
+		ToolArgsJSON:               "",
+		TokenEstimate:              0,
+		ModelFacing:                nil,
+		CompactionFirstKeptEntryID: "",
+		CompactionTokensBefore:     0,
+		BranchFromEntryID:          "",
+		TokensBefore:               0,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	timestamp := repository.now().UTC()
-	entry := EntryEntity{
-		Message: MessageEntity{
-			Timestamp: timestamp,
-			Role:      RoleCustom,
-			Content:   content,
-			Provider:  "",
-			Model:     "",
-		},
-		CreatedAt:  timestamp,
-		ParentID:   parentID,
-		ID:         newEntryID(),
-		SessionID:  sessionID,
-		Type:       EntryTypeCustomMessage,
-		CustomType: customType,
-		DataJSON:   dataJSON,
-		Summary:    "",
-	}
+	entry := newEntryEntity(sessionID, parentID, EntryTypeCustomMessage, &MessageEntity{
+		Timestamp: timestamp,
+		Role:      RoleCustom,
+		Content:   content,
+		Provider:  "",
+		Model:     "",
+	})
+	entry.CustomType = customType
+	entry.DataJSON = dataJSON
 
 	if err := repository.appendEntry(ctx, &entry); err != nil {
 		return nil, err
@@ -286,23 +294,13 @@ func (repository *SessionRepository) AppendModelChange(
 	model string,
 ) (*EntryEntity, error) {
 	timestamp := repository.now().UTC()
-	entry := EntryEntity{
-		Message: MessageEntity{
-			Timestamp: timestamp,
-			Role:      "",
-			Content:   "",
-			Provider:  provider,
-			Model:     model,
-		},
-		CreatedAt:  timestamp,
-		ParentID:   parentID,
-		ID:         newEntryID(),
-		SessionID:  sessionID,
-		Type:       EntryTypeModelChange,
-		CustomType: "",
-		DataJSON:   "{}",
-		Summary:    "",
-	}
+	entry := newEntryEntity(sessionID, parentID, EntryTypeModelChange, &MessageEntity{
+		Timestamp: timestamp,
+		Role:      "",
+		Content:   "",
+		Provider:  provider,
+		Model:     model,
+	})
 
 	if err := repository.appendEntry(ctx, &entry); err != nil {
 		return nil, err
@@ -319,39 +317,38 @@ func (repository *SessionRepository) AppendThinkingLevelChange(
 	thinkingLevel string,
 ) (*EntryEntity, error) {
 	dataJSON, err := dataJSONFromEntity(&EntryDataEntity{
-		Details:          nil,
-		Display:          nil,
-		FromHook:         false,
-		FirstKeptEntryID: "",
-		FromID:           "",
-		Label:            nil,
-		Name:             "",
-		TargetID:         "",
-		ThinkingLevel:    thinkingLevel,
-		TokensBefore:     0,
+		Details:                    nil,
+		Display:                    nil,
+		FromHook:                   false,
+		FirstKeptEntryID:           "",
+		FromID:                     "",
+		Label:                      nil,
+		Name:                       "",
+		TargetID:                   "",
+		ThinkingLevel:              thinkingLevel,
+		ToolName:                   "",
+		ToolStatus:                 "",
+		ToolArgsJSON:               "",
+		TokenEstimate:              0,
+		ModelFacing:                nil,
+		CompactionFirstKeptEntryID: "",
+		CompactionTokensBefore:     0,
+		BranchFromEntryID:          "",
+		TokensBefore:               0,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	timestamp := repository.now().UTC()
-	entry := EntryEntity{
-		Message: MessageEntity{
-			Timestamp: timestamp,
-			Role:      "",
-			Content:   "",
-			Provider:  "",
-			Model:     "",
-		},
-		CreatedAt:  timestamp,
-		ParentID:   parentID,
-		ID:         newEntryID(),
-		SessionID:  sessionID,
-		Type:       EntryTypeThinkingLevelChange,
-		CustomType: "",
-		DataJSON:   dataJSON,
-		Summary:    "",
-	}
+	entry := newEntryEntity(sessionID, parentID, EntryTypeThinkingLevelChange, &MessageEntity{
+		Timestamp: timestamp,
+		Role:      "",
+		Content:   "",
+		Provider:  "",
+		Model:     "",
+	})
+	entry.DataJSON = dataJSON
 
 	if err := repository.appendEntry(ctx, &entry); err != nil {
 		return nil, err
@@ -372,16 +369,24 @@ func (repository *SessionRepository) AppendCompaction(
 	fromHook bool,
 ) (*EntryEntity, error) {
 	dataJSON, err := dataJSONFromEntity(&EntryDataEntity{
-		Details:          details,
-		Display:          nil,
-		FromHook:         fromHook,
-		FirstKeptEntryID: firstKeptEntryID,
-		FromID:           "",
-		Label:            nil,
-		Name:             "",
-		TargetID:         "",
-		ThinkingLevel:    "",
-		TokensBefore:     tokensBefore,
+		Details:                    details,
+		Display:                    nil,
+		FromHook:                   fromHook,
+		FirstKeptEntryID:           firstKeptEntryID,
+		FromID:                     "",
+		Label:                      nil,
+		Name:                       "",
+		TargetID:                   "",
+		ThinkingLevel:              "",
+		ToolName:                   "",
+		ToolStatus:                 "",
+		ToolArgsJSON:               "",
+		TokenEstimate:              0,
+		ModelFacing:                nil,
+		CompactionFirstKeptEntryID: firstKeptEntryID,
+		CompactionTokensBefore:     tokensBefore,
+		BranchFromEntryID:          "",
+		TokensBefore:               tokensBefore,
 	})
 	if err != nil {
 		return nil, err
@@ -401,16 +406,24 @@ func (repository *SessionRepository) AppendBranchSummary(
 	fromHook bool,
 ) (*EntryEntity, error) {
 	dataJSON, err := dataJSONFromEntity(&EntryDataEntity{
-		Details:          details,
-		Display:          nil,
-		FromHook:         fromHook,
-		FirstKeptEntryID: "",
-		FromID:           fromID,
-		Label:            nil,
-		Name:             "",
-		TargetID:         "",
-		ThinkingLevel:    "",
-		TokensBefore:     0,
+		Details:                    details,
+		Display:                    nil,
+		FromHook:                   fromHook,
+		FirstKeptEntryID:           "",
+		FromID:                     fromID,
+		Label:                      nil,
+		Name:                       "",
+		TargetID:                   "",
+		ThinkingLevel:              "",
+		ToolName:                   "",
+		ToolStatus:                 "",
+		ToolArgsJSON:               "",
+		TokenEstimate:              0,
+		ModelFacing:                nil,
+		CompactionFirstKeptEntryID: "",
+		CompactionTokensBefore:     0,
+		BranchFromEntryID:          fromID,
+		TokensBefore:               0,
 	})
 	if err != nil {
 		return nil, err
@@ -428,16 +441,24 @@ func (repository *SessionRepository) AppendLabelChange(
 	label *string,
 ) (*EntryEntity, error) {
 	dataJSON, err := dataJSONFromEntity(&EntryDataEntity{
-		Details:          nil,
-		Display:          nil,
-		FromHook:         false,
-		FirstKeptEntryID: "",
-		FromID:           "",
-		Label:            label,
-		Name:             "",
-		TargetID:         targetID,
-		ThinkingLevel:    "",
-		TokensBefore:     0,
+		Details:                    nil,
+		Display:                    nil,
+		FromHook:                   false,
+		FirstKeptEntryID:           "",
+		FromID:                     "",
+		Label:                      label,
+		Name:                       "",
+		TargetID:                   targetID,
+		ThinkingLevel:              "",
+		ToolName:                   "",
+		ToolStatus:                 "",
+		ToolArgsJSON:               "",
+		TokenEstimate:              0,
+		ModelFacing:                nil,
+		CompactionFirstKeptEntryID: "",
+		CompactionTokensBefore:     0,
+		BranchFromEntryID:          "",
+		TokensBefore:               0,
 	})
 	if err != nil {
 		return nil, err
@@ -454,16 +475,24 @@ func (repository *SessionRepository) AppendSessionInfo(
 	name string,
 ) (*EntryEntity, error) {
 	dataJSON, err := dataJSONFromEntity(&EntryDataEntity{
-		Details:          nil,
-		Display:          nil,
-		FromHook:         false,
-		FirstKeptEntryID: "",
-		FromID:           "",
-		Label:            nil,
-		Name:             name,
-		TargetID:         "",
-		ThinkingLevel:    "",
-		TokensBefore:     0,
+		Details:                    nil,
+		Display:                    nil,
+		FromHook:                   false,
+		FirstKeptEntryID:           "",
+		FromID:                     "",
+		Label:                      nil,
+		Name:                       name,
+		TargetID:                   "",
+		ThinkingLevel:              "",
+		ToolName:                   "",
+		ToolStatus:                 "",
+		ToolArgsJSON:               "",
+		TokenEstimate:              0,
+		ModelFacing:                nil,
+		CompactionFirstKeptEntryID: "",
+		CompactionTokensBefore:     0,
+		BranchFromEntryID:          "",
+		TokensBefore:               0,
 	})
 	if err != nil {
 		return nil, err
@@ -491,23 +520,15 @@ func (repository *SessionRepository) appendSummaryEntry(
 	dataJSON string,
 ) (*EntryEntity, error) {
 	timestamp := repository.now().UTC()
-	entry := EntryEntity{
-		Message: MessageEntity{
-			Timestamp: timestamp,
-			Role:      "",
-			Content:   "",
-			Provider:  "",
-			Model:     "",
-		},
-		CreatedAt:  timestamp,
-		ParentID:   parentID,
-		ID:         newEntryID(),
-		SessionID:  sessionID,
-		Type:       entryType,
-		CustomType: "",
-		DataJSON:   normalizeDataJSON(dataJSON),
-		Summary:    summary,
-	}
+	entry := newEntryEntity(sessionID, parentID, entryType, &MessageEntity{
+		Timestamp: timestamp,
+		Role:      "",
+		Content:   "",
+		Provider:  "",
+		Model:     "",
+	})
+	entry.DataJSON = normalizeDataJSON(dataJSON)
+	entry.Summary = summary
 
 	if err := repository.appendEntry(ctx, &entry); err != nil {
 		return nil, err
@@ -527,16 +548,24 @@ func dataJSONFromEntity(data *EntryDataEntity) (string, error) {
 
 func dataFromEntry(entry *EntryEntity) (EntryDataEntity, error) {
 	data := EntryDataEntity{
-		Details:          nil,
-		Display:          nil,
-		FromHook:         false,
-		FirstKeptEntryID: "",
-		FromID:           "",
-		Label:            nil,
-		Name:             "",
-		TargetID:         "",
-		ThinkingLevel:    "",
-		TokensBefore:     0,
+		Details:                    nil,
+		Display:                    nil,
+		FromHook:                   false,
+		FirstKeptEntryID:           "",
+		FromID:                     "",
+		Label:                      nil,
+		Name:                       "",
+		TargetID:                   "",
+		ThinkingLevel:              "",
+		ToolName:                   "",
+		ToolStatus:                 "",
+		ToolArgsJSON:               "",
+		TokenEstimate:              0,
+		ModelFacing:                nil,
+		CompactionFirstKeptEntryID: "",
+		CompactionTokensBefore:     0,
+		BranchFromEntryID:          "",
+		TokensBefore:               0,
 	}
 	if normalizeDataJSON(entry.DataJSON) == "{}" {
 		return data, nil


### PR DESCRIPTION
## Summary
- add typed metadata columns to session entries for tools, display, model-facing context, token estimates, and future compaction coverage
- backfill existing rows with conservative heuristics while guarding malformed JSON/odd content
- document current session/context architecture with Mermaid diagrams

## Validation
- mise exec -- go test ./...
- mise exec -- task build
- mise exec -- task ci