### PR TITLE
fix(extension): route keymaps by focus

### DIFF
--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -627,7 +627,7 @@ Handlers for terminal events receive a table like:
   data = {
     text = "incremental event text",
   },
-  focus = { kind = "composer", window = "composer", buffer = "composer", role = "composer", exclusive = false },
+  focus = { kind = "composer", window = "composer", buffer = "composer", role = "composer", panel_kind = "", exclusive = false },
   composer = { text = "hello", cursor = 5, chars = { "h", "e", "l", "l", "o" }, metadata = {} },
   buffers = {
     composer = { text = "hello", cursor = 5, chars = { "h", "e", "l", "l", "o" }, blocks = {}, metadata = {} },

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -242,13 +242,13 @@ Registers a keymap against a generic target.
 Examples:
 
 ```lua
-lc.keymap.set({ role = "composer" }, "ctrl+j", function(ev)
+lc.keymap.set({ focus = "composer" }, "ctrl+j", function(ev)
   lc.buf.set_text("status", "ctrl+j pressed")
   return true
-end, { priority = 100, desc = "example role keymap" })
+end, { priority = 100, desc = "example composer keymap" })
 
 lc.keymap.set({ buffer = "composer" }, "*", function(ev)
-  lc.log("composer key: " .. ev.key)
+  lc.log("focused composer buffer key: " .. ev.key)
 end)
 
 lc.keymap.set("global", "ctrl+p", function()
@@ -260,13 +260,14 @@ end)
 Supported target forms:
 
 - `"global"` for global keymaps
-- `{ buffer = "name" }` for buffer-scoped keymaps
-- `{ window = "name" }` for window-scoped keymaps
-- `{ role = "name" }` for role-scoped keymaps
-- `{ scope = "buffer" | "window" | "role", name = "name" }`
+- `{ focus = "name" }` for focused target kind keymaps, such as `composer`, `autocomplete`, or `panel`
+- `{ buffer = "name" }` for focused-buffer keymaps
+- `{ window = "name" }` for focused-window keymaps
+- `{ role = "name" }` for focused-role keymaps
+- `{ scope = "focus" | "buffer" | "window" | "role", name = "name" }`
 - a list of any of the above
 
-String targets other than `"global"` are shorthand for role-scoped keymaps. Prefer explicit target tables for clarity.
+String targets other than `"global"` are shorthand for role-scoped keymaps. Prefer explicit target tables for clarity. Non-global keymaps match the currently focused target only, not every visible window. This keeps composer extensions from stealing keys while autocomplete or panels are focused.
 
 Notes:
 
@@ -626,6 +627,7 @@ Handlers for terminal events receive a table like:
   data = {
     text = "incremental event text",
   },
+  focus = { kind = "composer", window = "composer", buffer = "composer", role = "composer", exclusive = false },
   composer = { text = "hello", cursor = 5, chars = { "h", "e", "l", "l", "o" }, metadata = {} },
   buffers = {
     composer = { text = "hello", cursor = 5, chars = { "h", "e", "l", "l", "o" }, blocks = {}, metadata = {} },
@@ -653,7 +655,7 @@ A project extension can build substantial behavior using the current API:
 ```lua
 local lc = require("librecode")
 
-lc.keymap.set({ role = "composer" }, "<c-j>", function()
+lc.keymap.set({ focus = "composer" }, "<c-j>", function()
   lc.action.run("submit")
   lc.event.consume()
 end)

--- a/extensions/vim-mode/vim.lua
+++ b/extensions/vim-mode/vim.lua
@@ -628,7 +628,7 @@ local function setup(api)
     sync_label()
   end)
 
-  lc.keymap.set({ role = "composer" }, "*", function(ev)
+  lc.keymap.set({ focus = "composer" }, "*", function(ev)
     if state.mode == "insert" then
       return handle_insert(ev)
     elseif state.mode == "visual" then

--- a/internal/extension/focus_test.go
+++ b/internal/extension/focus_test.go
@@ -1,0 +1,73 @@
+package extension_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/extension"
+)
+
+const (
+	testFocusAutocomplete = "autocomplete"
+	testFocusTranscript   = "transcript"
+)
+
+func TestManager_KeymapsUseFocusedTargetsOnly(t *testing.T) {
+	t.Parallel()
+
+	manager := loadTestExtension(t, `
+local lc = require("librecode")
+lc.keymap.set({ role = "composer" }, "x", function()
+  lc.buf.set_text("composer", "role")
+  lc.event.consume()
+end)
+lc.keymap.set({ focus = "autocomplete" }, "x", function()
+  lc.buf.set_text("composer", "focus")
+  lc.event.consume()
+end)
+`)
+
+	event := testTerminalEventWithComposerWindow("", "x")
+	event.Focus = extension.FocusState{
+		Kind:      testFocusAutocomplete,
+		Window:    testFocusAutocomplete,
+		Buffer:    "status",
+		Role:      testFocusAutocomplete,
+		PanelKind: "",
+		Exclusive: true,
+	}
+
+	result, err := manager.HandleTerminalEvent(context.Background(), &event)
+	require.NoError(t, err)
+
+	assert.True(t, result.Consumed)
+	assert.Equal(t, "focus", result.Buffers[testBufferComposer].Text)
+}
+
+func TestManager_TerminalEventsExposeFocusToLua(t *testing.T) {
+	t.Parallel()
+
+	manager := loadTestExtension(t, `
+local lc = require("librecode")
+lc.on("key", function(event)
+  lc.buf.set_text("seen", event.focus.kind .. ":" .. event.focus.role .. ":" .. tostring(event.focus.exclusive))
+end)
+`)
+	event := testTerminalEventWithComposerWindow("", "x")
+	event.Focus = extension.FocusState{
+		Kind:      "panel",
+		Window:    testFocusTranscript,
+		Buffer:    testFocusTranscript,
+		Role:      "model",
+		PanelKind: "model",
+		Exclusive: true,
+	}
+
+	result, err := manager.HandleTerminalEvent(context.Background(), &event)
+	require.NoError(t, err)
+
+	assert.Equal(t, "panel:model:true", result.Buffers["seen"].Text)
+}

--- a/internal/extension/focus_test.go
+++ b/internal/extension/focus_test.go
@@ -12,13 +12,47 @@ import (
 
 const (
 	testFocusAutocomplete = "autocomplete"
+	testFocusModel        = "model"
 	testFocusTranscript   = "transcript"
 )
+
+type focusedKeymapCase struct {
+	name         string
+	wantText     string
+	focus        extension.FocusState
+	wantConsumed bool
+}
 
 func TestManager_KeymapsUseFocusedTargetsOnly(t *testing.T) {
 	t.Parallel()
 
-	manager := loadTestExtension(t, `
+	manager := loadFocusedKeymapTestExtension(t)
+
+	for _, testCase := range focusedKeymapCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			event := testTerminalEventWithComposerWindow("", "x")
+			event.Focus = testCase.focus
+
+			result, err := manager.HandleTerminalEvent(context.Background(), &event)
+			require.NoError(t, err)
+
+			assert.Equal(t, testCase.wantConsumed, result.Consumed)
+			if testCase.wantConsumed {
+				require.Contains(t, result.Buffers, testBufferComposer)
+				assert.Equal(t, testCase.wantText, result.Buffers[testBufferComposer].Text)
+			} else {
+				assert.NotContains(t, result.Buffers, testBufferComposer)
+			}
+		})
+	}
+}
+
+func loadFocusedKeymapTestExtension(t *testing.T) *extension.Manager {
+	t.Helper()
+
+	return loadTestExtension(t, `
 local lc = require("librecode")
 lc.keymap.set({ role = "composer" }, "x", function()
   lc.buf.set_text("composer", "role")
@@ -29,22 +63,56 @@ lc.keymap.set({ focus = "autocomplete" }, "x", function()
   lc.event.consume()
 end)
 `)
+}
 
-	event := testTerminalEventWithComposerWindow("", "x")
-	event.Focus = extension.FocusState{
-		Kind:      testFocusAutocomplete,
-		Window:    testFocusAutocomplete,
-		Buffer:    "status",
-		Role:      testFocusAutocomplete,
-		PanelKind: "",
-		Exclusive: true,
+func focusedKeymapCases() []focusedKeymapCase {
+	return []focusedKeymapCase{
+		{
+			focus:        testComposerFocus(),
+			name:         "composer role target matches composer focus",
+			wantText:     "role",
+			wantConsumed: true,
+		},
+		{
+			focus: extension.FocusState{
+				Kind:      testFocusAutocomplete,
+				Window:    testFocusAutocomplete,
+				Buffer:    "status",
+				Role:      testFocusAutocomplete,
+				PanelKind: "",
+				Exclusive: true,
+			},
+			name:         "autocomplete focus target matches autocomplete focus",
+			wantText:     "focus",
+			wantConsumed: true,
+		},
+		{
+			focus: extension.FocusState{
+				Kind:      "panel",
+				Window:    testFocusTranscript,
+				Buffer:    testFocusTranscript,
+				Role:      testFocusModel,
+				PanelKind: testFocusModel,
+				Exclusive: true,
+			},
+			name:         "panel focus does not match visible composer role",
+			wantText:     "",
+			wantConsumed: false,
+		},
+		{
+			focus: extension.FocusState{
+				Kind:      testFocusTranscript,
+				Window:    testFocusTranscript,
+				Buffer:    testFocusTranscript,
+				Role:      testFocusTranscript,
+				PanelKind: "",
+				Exclusive: false,
+			},
+			name:         "different focused role does not match composer role",
+			wantText:     "",
+			wantConsumed: false,
+		},
 	}
-
-	result, err := manager.HandleTerminalEvent(context.Background(), &event)
-	require.NoError(t, err)
-
-	assert.True(t, result.Consumed)
-	assert.Equal(t, "focus", result.Buffers[testBufferComposer].Text)
 }
 
 func TestManager_TerminalEventsExposeFocusToLua(t *testing.T) {
@@ -53,7 +121,15 @@ func TestManager_TerminalEventsExposeFocusToLua(t *testing.T) {
 	manager := loadTestExtension(t, `
 local lc = require("librecode")
 lc.on("key", function(event)
-  lc.buf.set_text("seen", event.focus.kind .. ":" .. event.focus.role .. ":" .. tostring(event.focus.exclusive))
+  local fields = {
+    event.focus.kind,
+    event.focus.window,
+    event.focus.buffer,
+    event.focus.role,
+    event.focus.panel_kind,
+    tostring(event.focus.exclusive),
+  }
+  lc.buf.set_text("seen", table.concat(fields, ":"))
 end)
 `)
 	event := testTerminalEventWithComposerWindow("", "x")
@@ -61,13 +137,13 @@ end)
 		Kind:      "panel",
 		Window:    testFocusTranscript,
 		Buffer:    testFocusTranscript,
-		Role:      "model",
-		PanelKind: "model",
+		Role:      testFocusModel,
+		PanelKind: testFocusModel,
 		Exclusive: true,
 	}
 
 	result, err := manager.HandleTerminalEvent(context.Background(), &event)
 	require.NoError(t, err)
 
-	assert.Equal(t, "panel:model:true", result.Buffers["seen"].Text)
+	assert.Equal(t, "panel:transcript:transcript:model:model:true", result.Buffers["seen"].Text)
 }

--- a/internal/extension/host_event.go
+++ b/internal/extension/host_event.go
@@ -15,6 +15,7 @@ type luaHostEvent struct {
 	uiCursor       *UICursor
 	context        map[string]any
 	data           map[string]any
+	focus          FocusState
 	changedBuffers map[string]struct{}
 	name           string
 	key            ComposerKeyEvent
@@ -38,6 +39,7 @@ func newLuaHostEvent(event *TerminalEvent) *luaHostEvent {
 		layout:         cloneLayout(event.Layout),
 		context:        cloneMap(event.Context),
 		data:           cloneMap(event.Data),
+		focus:          event.Focus,
 		changedBuffers: map[string]struct{}{},
 		changedWindows: map[string]struct{}{},
 		actions:        []ActionCall{},
@@ -76,6 +78,7 @@ func (event *luaHostEvent) eventSnapshot() *TerminalEvent {
 		Data:    cloneMap(event.data),
 		Name:    event.name,
 		Key:     event.key,
+		Focus:   event.focus,
 	}
 }
 

--- a/internal/extension/lua_values.go
+++ b/internal/extension/lua_values.go
@@ -194,10 +194,26 @@ func terminalEventTable(state *lua.LState, event *TerminalEvent) *lua.LTable {
 		"buffers":      bufferMapForLua(event.Buffers),
 		"windows":      windowMapForLua(event.Windows),
 		"layout":       layoutForLua(&event.Layout),
+		"focus":        focusForLua(&event.Focus),
 		"composer":     bufferForLua(&composer),
 		"working":      luaContextBool(event.Context, "working"),
 		"auth_working": luaContextBool(event.Context, "auth_working"),
 	})
+}
+
+func focusForLua(focus *FocusState) map[string]any {
+	if focus == nil {
+		return map[string]any{}
+	}
+
+	return map[string]any{
+		"kind":          focus.Kind,
+		"window":        focus.Window,
+		"buffer":        focus.Buffer,
+		keymapScopeRole: focus.Role,
+		"panel_kind":    focus.PanelKind,
+		"exclusive":     focus.Exclusive,
+	}
 }
 
 func luaContextBool(eventContext map[string]any, key string) bool {

--- a/internal/extension/lua_values.go
+++ b/internal/extension/lua_values.go
@@ -202,10 +202,6 @@ func terminalEventTable(state *lua.LState, event *TerminalEvent) *lua.LTable {
 }
 
 func focusForLua(focus *FocusState) map[string]any {
-	if focus == nil {
-		return map[string]any{}
-	}
-
 	return map[string]any{
 		"kind":          focus.Kind,
 		"window":        focus.Window,

--- a/internal/extension/manager_runtime_api.go
+++ b/internal/extension/manager_runtime_api.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	keymapScopeBuffer = "buffer"
+	keymapScopeFocus  = "focus"
 	keymapScopeGlobal = "global"
 	keymapScopeRole   = "role"
 	keymapScopeWindow = "window"
@@ -277,24 +278,13 @@ func (manager *Manager) keymapsFor(event *luaHostEvent) []luaKeymap {
 
 func keymapEventTargets(event *luaHostEvent) map[string]struct{} {
 	targets := map[string]struct{}{globalKeymapTarget().key(): {}}
-	for name, buffer := range event.buffers {
-		bufferName := buffer.Name
-		if bufferName == "" {
-			bufferName = name
-		}
-		addKeymapTarget(targets, keymapScopeBuffer, bufferName)
-		addKeymapTarget(targets, "", bufferName)
-	}
-	for name := range event.windows {
-		window := event.windows[name]
-		windowName := window.Name
-		if windowName == "" {
-			windowName = name
-		}
-		addKeymapTarget(targets, keymapScopeWindow, windowName)
-		addKeymapTarget(targets, keymapScopeRole, window.Role)
-		addKeymapTarget(targets, "", window.Role)
-	}
+	focus := event.focus
+	addKeymapTarget(targets, keymapScopeFocus, focus.Kind)
+	addKeymapTarget(targets, keymapScopeBuffer, focus.Buffer)
+	addKeymapTarget(targets, keymapScopeWindow, focus.Window)
+	addKeymapTarget(targets, keymapScopeRole, focus.Role)
+	addKeymapTarget(targets, "", focus.Role)
+	addKeymapTarget(targets, "", focus.Kind)
 
 	return targets
 }
@@ -373,7 +363,7 @@ func luaKeymapTarget(table *lua.LTable) (keymapTarget, bool) {
 		return keymapTarget{Scope: scope, Name: luaTableString(table, "name", "")}, true
 	}
 
-	for _, field := range []string{keymapScopeBuffer, keymapScopeWindow, keymapScopeRole} {
+	for _, field := range []string{keymapScopeBuffer, keymapScopeFocus, keymapScopeWindow, keymapScopeRole} {
 		name := luaTableString(table, field, "")
 		if name != "" {
 			return keymapTarget{Scope: field, Name: name}, true
@@ -413,7 +403,7 @@ func normalizeKeymapTarget(target keymapTarget) keymapTarget {
 func normalizeKeymapScope(scope string) string {
 	scope = normalizeKeymapName(scope)
 	switch scope {
-	case "", keymapScopeBuffer, keymapScopeGlobal, keymapScopeRole, keymapScopeWindow:
+	case "", keymapScopeBuffer, keymapScopeFocus, keymapScopeGlobal, keymapScopeRole, keymapScopeWindow:
 		return scope
 	default:
 		return scope

--- a/internal/extension/manager_test.go
+++ b/internal/extension/manager_test.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	testBufferComposer       = "composer"
+	testBufferTranscript     = "transcript"
 	testContextModeKey       = "mode"
 	testEventKey             = "key"
 	testEventStartup         = "startup"
@@ -65,8 +66,8 @@ func testTerminalEventWithComposerWindow(text, key string) extension.TerminalEve
 	window := testComposerWindow()
 	return extension.TerminalEvent{
 		Buffers: map[string]extension.BufferState{
-			testBufferComposer: testTextBuffer(testBufferComposer, text),
-			"transcript":       testTranscriptBuffer(text),
+			testBufferComposer:   testTextBuffer(testBufferComposer, text),
+			testBufferTranscript: testTranscriptBuffer(text),
 		},
 		Windows: map[string]extension.WindowState{testBufferComposer: window},
 		Layout:  testLayout(map[string]extension.WindowState{testBufferComposer: window}),
@@ -80,6 +81,18 @@ func testTerminalEventWithComposerWindow(text, key string) extension.TerminalEve
 			Alt:   false,
 			Shift: false,
 		},
+		Focus: testComposerFocus(),
+	}
+}
+
+func testComposerFocus() extension.FocusState {
+	return extension.FocusState{
+		Kind:      testBufferComposer,
+		Window:    testBufferComposer,
+		Buffer:    testBufferComposer,
+		Role:      testBufferComposer,
+		PanelKind: "",
+		Exclusive: false,
 	}
 }
 
@@ -105,7 +118,7 @@ func testTextBuffer(name, text string) extension.BufferState {
 }
 
 func testTranscriptBuffer(text string) extension.BufferState {
-	buffer := testTextBuffer("transcript", "")
+	buffer := testTextBuffer(testBufferTranscript, "")
 	buffer.Metadata = map[string]any{"count": 1}
 	buffer.Blocks = []extension.BufferBlock{
 		{
@@ -147,7 +160,7 @@ lc.on("startup", function()
   lc.buf.set("composer", composer)
 end)
 
-lc.keymap.set({ role = "composer" }, "x", function(event)
+lc.keymap.set({ focus = "composer" }, "x", function(event)
   local composer = lc.buf.get("composer")
   lc.buf.set("composer", {
     text = composer.text .. event.key,
@@ -214,6 +227,7 @@ end)
 			Alt:   false,
 			Shift: false,
 		},
+		Focus: testComposerFocus(),
 	}
 	result, err := manager.HandleTerminalEvent(context.Background(), &event)
 	require.NoError(t, err)
@@ -334,6 +348,7 @@ end)
 			Alt:   false,
 			Shift: false,
 		},
+		Focus: testComposerFocus(),
 	}
 	result, err := manager.HandleTerminalEvent(context.Background(), &event)
 	require.NoError(t, err)
@@ -560,7 +575,7 @@ func assertLoadedExtension(t *testing.T, loaded []extension.LoadedExtension) {
 
 	require.Len(t, loaded, 1)
 	assert.Equal(t, []string{testEventStartup}, loaded[0].Handlers)
-	assert.Equal(t, []string{"role:composer:x"}, loaded[0].Keymaps)
+	assert.Equal(t, []string{"focus:composer:x"}, loaded[0].Keymaps)
 	assert.Positive(t, loaded[0].TotalDuration)
 }
 
@@ -571,7 +586,7 @@ func TestManager_HasTerminalEventHandlers(t *testing.T) {
 	t.Cleanup(manager.Shutdown)
 	script := `
 librecode.on("startup", function() end)
-librecode.keymap.set({ role = "composer" }, "x", function() end)
+librecode.keymap.set({ focus = "composer" }, "x", function() end)
 `
 	extensionPath := filepath.Join(t.TempDir(), "handlers.lua")
 	require.NoError(t, writeTestFile(extensionPath, script))
@@ -619,6 +634,7 @@ func assertTerminalKeyExecution(t *testing.T, manager *extension.Manager) {
 			Alt:   false,
 			Shift: false,
 		},
+		Focus: testComposerFocus(),
 	}
 	startup, err := manager.HandleTerminalEvent(context.Background(), &startupEvent)
 	require.NoError(t, err)
@@ -641,6 +657,7 @@ func assertTerminalKeyExecution(t *testing.T, manager *extension.Manager) {
 			Alt:   false,
 			Shift: false,
 		},
+		Focus: testComposerFocus(),
 	}
 	result, err := manager.HandleTerminalEvent(context.Background(), &resultEvent)
 	require.NoError(t, err)

--- a/internal/extension/types.go
+++ b/internal/extension/types.go
@@ -144,6 +144,16 @@ type WindowState struct {
 	Visible   bool           `json:"visible"`
 }
 
+// FocusState describes the currently focused input target for extension key routing.
+type FocusState struct {
+	Kind      string `json:"kind"`
+	Window    string `json:"window"`
+	Buffer    string `json:"buffer"`
+	Role      string `json:"role"`
+	PanelKind string `json:"panel_kind"`
+	Exclusive bool   `json:"exclusive"`
+}
+
 // TerminalEvent describes a low-level terminal runtime event exposed to extensions.
 type TerminalEvent struct {
 	Buffers map[string]BufferState `json:"buffers"`
@@ -153,6 +163,7 @@ type TerminalEvent struct {
 	Name    string                 `json:"name"`
 	Key     ComposerKeyEvent       `json:"key"`
 	Layout  LayoutState            `json:"layout"`
+	Focus   FocusState             `json:"focus"`
 }
 
 // TerminalEventResult describes mutations produced by low-level extension handlers.

--- a/internal/terminal/extension_events.go
+++ b/internal/terminal/extension_events.go
@@ -444,6 +444,9 @@ func (app *App) applyComposerBuffer(buffer *extension.BufferState) {
 	if app.composerText() != oldText || app.composerCursor() != oldCursor {
 		app.resetPromptHistoryNavigation()
 	}
+	if app.composerText() != oldText {
+		app.resetAutocompleteSelection()
+	}
 }
 
 func (app *App) applyUIWindowResult(result *extension.TerminalEventResult) {

--- a/internal/terminal/extension_events.go
+++ b/internal/terminal/extension_events.go
@@ -242,6 +242,7 @@ func (app *App) newExtensionEventWithLayoutAndData(
 		Data:    cloneExtensionMetadata(data),
 		Name:    name,
 		Key:     key,
+		Focus:   app.focusState(),
 	}
 }
 
@@ -297,6 +298,7 @@ func (app *App) extensionContext() map[string]any {
 		"working":              app.working,
 		"auth_working":         app.authWorking,
 		"cwd":                  app.cwd,
+		"focus":                app.focusState(),
 		extensionDataSessionID: app.sessionID,
 	}
 }

--- a/internal/terminal/focus.go
+++ b/internal/terminal/focus.go
@@ -1,0 +1,41 @@
+package terminal
+
+import "github.com/omarluq/librecode/internal/extension"
+
+const (
+	focusKindAutocomplete = "autocomplete"
+	focusKindComposer     = "composer"
+	focusKindPanel        = "panel"
+)
+
+func (app *App) focusState() extension.FocusState {
+	if app.mode == modePanel && app.panel != nil {
+		return extension.FocusState{
+			Kind:      focusKindPanel,
+			Window:    extensionBufferTranscript,
+			Buffer:    extensionBufferTranscript,
+			Role:      string(app.selectedPanelKind),
+			PanelKind: string(app.selectedPanelKind),
+			Exclusive: true,
+		}
+	}
+	if app.autocompleteActive() {
+		return extension.FocusState{
+			Kind:      focusKindAutocomplete,
+			Window:    focusKindAutocomplete,
+			Buffer:    extensionBufferStatus,
+			Role:      focusKindAutocomplete,
+			PanelKind: "",
+			Exclusive: true,
+		}
+	}
+
+	return extension.FocusState{
+		Kind:      focusKindComposer,
+		Window:    extensionBufferComposer,
+		Buffer:    extensionBufferComposer,
+		Role:      extensionBufferComposer,
+		PanelKind: "",
+		Exclusive: false,
+	}
+}

--- a/internal/terminal/focus_test.go
+++ b/internal/terminal/focus_test.go
@@ -1,0 +1,83 @@
+//nolint:testpackage // These tests exercise unexported terminal focus routing helpers.
+package terminal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gdamore/tcell/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFocusStatePrioritizesPanelAndAutocomplete(t *testing.T) {
+	t.Parallel()
+
+	app := newRenderTestApp(t)
+	assert.Equal(t, focusKindComposer, app.focusState().Kind)
+
+	app.setComposerText("/s")
+	autocompleteFocus := app.focusState()
+	assert.Equal(t, focusKindAutocomplete, autocompleteFocus.Kind)
+	assert.True(t, autocompleteFocus.Exclusive)
+
+	app.openModelPanel()
+	panelFocus := app.focusState()
+	assert.Equal(t, focusKindPanel, panelFocus.Kind)
+	assert.Equal(t, string(panelModel), panelFocus.PanelKind)
+	assert.True(t, panelFocus.Exclusive)
+}
+
+func TestFocusedPanelPreventsComposerExtensionKeymap(t *testing.T) {
+	t.Parallel()
+
+	app := newExtensionRuntimeTestApp(t, `
+librecode.keymap.set({ focus = "composer" }, "down", function()
+  librecode.buf.set_text("composer", "stolen")
+  librecode.event.consume()
+end)
+`)
+	app.openPanel(newSelectionPanel(panelModel, "Models", "", []panelItem{
+		{Value: "one", Title: "one", Description: "", Meta: ""},
+		{Value: "two", Title: "two", Description: "", Meta: ""},
+	}, true))
+	selected := app.panel.selected
+
+	pressTerminalKey(t, app, tcell.KeyDown, "")
+
+	assert.Equal(t, selected+1, app.panel.selected)
+	assertEditorText(t, app, "")
+}
+
+func TestFocusedAutocompletePreventsComposerExtensionKeymap(t *testing.T) {
+	t.Parallel()
+
+	app := newExtensionRuntimeTestApp(t, `
+librecode.keymap.set({ focus = "composer" }, "down", function()
+  librecode.buf.set_text("composer", "stolen")
+  librecode.event.consume()
+end)
+`)
+	app.setComposerText("/s")
+
+	pressTerminalKey(t, app, tcell.KeyDown, "")
+
+	assert.NotZero(t, app.autocompleteSelection)
+	assertEditorText(t, app, "/s")
+}
+
+func TestFocusedComposerExtensionStillHandlesComposerKeys(t *testing.T) {
+	t.Parallel()
+
+	app := newExtensionRuntimeTestApp(t, `
+librecode.keymap.set({ focus = "composer" }, "x", function()
+  librecode.buf.set_text("composer", "handled")
+  librecode.event.consume()
+end)
+`)
+
+	shouldQuit, err := app.handleKey(context.Background(), tcell.NewEventKey(tcell.KeyRune, "x", tcell.ModNone))
+	require.NoError(t, err)
+	assert.False(t, shouldQuit)
+	assertEditorText(t, app, "handled")
+}

--- a/internal/terminal/focus_test.go
+++ b/internal/terminal/focus_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/gdamore/tcell/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/extension"
 )
 
 func TestFocusStatePrioritizesPanelAndAutocomplete(t *testing.T) {
@@ -64,6 +66,36 @@ end)
 
 	assert.NotZero(t, app.autocompleteSelection)
 	assertEditorText(t, app, "/s")
+}
+
+func TestExtensionComposerEditsReopenAutocomplete(t *testing.T) {
+	t.Parallel()
+
+	app := newExtensionRuntimeTestApp(t, `
+librecode.keymap.set({ focus = "composer" }, "*", function()
+  local composer = librecode.buf.get("composer")
+  composer.text = composer.text .. "x"
+  composer.cursor = composer.cursor + 1
+  librecode.buf.set("composer", composer)
+  librecode.event.consume()
+  return true
+end)
+`)
+	app.setComposerText("/s")
+	app.closeAutocomplete()
+	assert.False(t, app.autocompleteActive())
+	app.applyComposerBuffer(&extension.BufferState{
+		Metadata: map[string]any{},
+		Blocks:   []extension.BufferBlock{},
+		Name:     extensionBufferComposer,
+		Text:     "/se",
+		Chars:    nil,
+		Label:    "",
+		Cursor:   3,
+	})
+
+	assert.True(t, app.autocompleteActive())
+	assertEditorText(t, app, "/se")
 }
 
 func TestFocusedComposerExtensionStillHandlesComposerKeys(t *testing.T) {

--- a/internal/terminal/input.go
+++ b/internal/terminal/input.go
@@ -53,23 +53,35 @@ func (app *App) handlePriorityKey(ctx context.Context, event *tcell.EventKey) ke
 	if app.handleWorkingInterruptKey(ctx, event) {
 		return keyHandlingResult{err: nil, shouldQuit: false, handled: true}
 	}
-	if handled, err := app.handleExtensionKey(ctx, event); handled || err != nil {
-		return keyHandlingResult{err: err, shouldQuit: false, handled: true}
-	}
-	if app.handleAutocompleteEscape(event) {
-		return keyHandlingResult{err: nil, shouldQuit: false, handled: true}
-	}
 	if app.keys.matches(event, actionForceExit) && app.composerEmpty() {
 		return keyHandlingResult{err: nil, shouldQuit: app.handleForceExit(), handled: true}
 	}
-	if app.mode == modePanel && app.panel != nil {
-		return keyHandlingResult{err: app.handlePanelKey(ctx, event), shouldQuit: false, handled: true}
+	if result := app.handlePanelPriorityKey(ctx, event); result.handled || result.err != nil {
+		return result
+	}
+	if app.handleAutocompletePriorityKey(event) {
+		return keyHandlingResult{err: nil, shouldQuit: false, handled: true}
+	}
+	if handled, err := app.handleExtensionKey(ctx, event); handled || err != nil {
+		return keyHandlingResult{err: err, shouldQuit: false, handled: true}
 	}
 	if app.handlePreEditorKey(ctx, event) {
 		return keyHandlingResult{err: nil, shouldQuit: false, handled: true}
 	}
 
 	return keyHandlingResult{err: nil, shouldQuit: false, handled: false}
+}
+
+func (app *App) handlePanelPriorityKey(ctx context.Context, event *tcell.EventKey) keyHandlingResult {
+	if app.mode != modePanel || app.panel == nil {
+		return keyHandlingResult{err: nil, shouldQuit: false, handled: false}
+	}
+
+	return keyHandlingResult{err: app.handlePanelKey(ctx, event), shouldQuit: false, handled: true}
+}
+
+func (app *App) handleAutocompletePriorityKey(event *tcell.EventKey) bool {
+	return app.handleAutocompleteEscape(event) || app.handleFocusedAutocompleteKey(event)
 }
 
 func (app *App) handleAutocompleteEscape(event *tcell.EventKey) bool {
@@ -81,12 +93,15 @@ func (app *App) handleAutocompleteEscape(event *tcell.EventKey) bool {
 	return true
 }
 
-func (app *App) handleInputKey(ctx context.Context, event *tcell.EventKey) (bool, error) {
-	if app.autocompleteActive() {
-		if app.handleAutocompleteKey(event) {
-			return false, nil
-		}
+func (app *App) handleFocusedAutocompleteKey(event *tcell.EventKey) bool {
+	if app.working || !app.autocompleteActive() {
+		return false
 	}
+
+	return app.handleAutocompleteKey(event)
+}
+
+func (app *App) handleInputKey(ctx context.Context, event *tcell.EventKey) (bool, error) {
 	if app.keys.matches(event, actionInputClear) && !app.composerEmpty() {
 		app.clearComposer()
 		app.resetPromptHistoryNavigation()


### PR DESCRIPTION
## Summary
- add explicit focus state to terminal extension events
- route non-global keymaps through the focused target only
- let native panels/autocomplete handle keys before composer extensions
- update Vim extension to target focused composer input

## Validation
- mise exec -- go test ./...
- mise exec -- task build
- mise exec -- task ci