### PR TITLE
feat(assistant): add context build seam

### DIFF
--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -709,6 +709,13 @@ Current assistant lifecycle events include:
 - `before_agent_start`
 - `agent_start`
 - `turn_start`
+- `context_build`
+- `before_provider_request`
+- `after_provider_response`
+- `provider_error`
+- `tool_call`
+- `tool_result`
+- `tool_error`
 - `message_append`
 - `turn_end`
 - `agent_end`
@@ -725,9 +732,23 @@ end)
 lc.on("message_append", function(event)
   lc.log("appended " .. event.payload.role .. " entry " .. event.payload.entry_id)
 end)
+
+lc.on("context_build", function(event)
+  event.payload.contributions = {
+    {
+      name = "project-constraints",
+      source = "my-extension",
+      role = "system",
+      content = "Prefer small focused commits and run the project CI before committing.",
+    },
+  }
+  return { payload = event.payload }
+end)
 ```
 
-Lifecycle payloads are intentionally bounded. `message_append` includes the appended entry text and metadata for the current message, but lifecycle events do not include full transcript history. Future PRs will add explicit mutation contracts for context, provider, and tool middleware.
+Lifecycle payloads are intentionally bounded. `message_append` includes the appended entry text and metadata for the current message, but lifecycle events do not include full transcript history.
+
+`context_build` is the first lifecycle seam with a mutation contract. Handlers may return bounded `contributions` entries. Each contribution must include non-empty `content` and is capped by the host. The context payload exposes `breakdown.system`, `breakdown.skills`, `breakdown.history`, and `breakdown.extensions` token estimates so extensions can reason about context budget without seeing the full transcript.
 
 ## Current limitations
 

--- a/internal/assistant/context_build.go
+++ b/internal/assistant/context_build.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 
 	"github.com/samber/oops"
@@ -215,15 +216,15 @@ func appendContextContributions(result *contextBuildResult, contributions []cont
 		result.Contributions = append(result.Contributions, contribution)
 		builder.WriteString("\n<block")
 		if contribution.Name != "" {
-			_, _ = fmt.Fprintf(&builder, " name=%q", contribution.Name)
+			builder.WriteString(" name=")
+			builder.WriteString(strconv.Quote(contribution.Name))
 		}
-		_, _ = fmt.Fprintf(
-			&builder,
-			" source=%q role=%q tokens=%d",
-			contribution.Source,
-			contribution.Role,
-			contribution.Tokens,
-		)
+		builder.WriteString(" source=")
+		builder.WriteString(strconv.Quote(contribution.Source))
+		builder.WriteString(" role=")
+		builder.WriteString(strconv.Quote(contribution.Role))
+		builder.WriteString(" tokens=")
+		builder.WriteString(strconv.Itoa(contribution.Tokens))
 		builder.WriteString(">\n")
 		builder.WriteString(contribution.Content)
 		builder.WriteString("\n</block>")

--- a/internal/assistant/context_build.go
+++ b/internal/assistant/context_build.go
@@ -1,0 +1,348 @@
+package assistant
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/samber/oops"
+
+	"github.com/omarluq/librecode/internal/core"
+	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/extension"
+	"github.com/omarluq/librecode/internal/model"
+)
+
+const (
+	contextContributionSourceExtension = "extension"
+	contextContributionRoleSystem      = "system"
+	contextContributionMaxTokens       = 2048
+)
+
+type contextContribution struct {
+	Metadata map[string]any
+	Source   string
+	Name     string
+	Role     string
+	Content  string
+	Tokens   int
+}
+
+type contextBuildResult struct {
+	Breakdown     map[string]int
+	SystemPrompt  string
+	Contributions []contextContribution
+	Messages      []database.MessageEntity
+	Usage         model.TokenUsage
+}
+
+type modelContextBase struct {
+	BaseSystemPrompt string
+	SkillPrompt      string
+	SystemPrompt     string
+	ActiveSkills     []core.ActivatedSkill
+	SkillDiagnostics []core.SkillActivationDiagnostic
+	Messages         []database.MessageEntity
+	SystemTokens     int
+	SkillTokens      int
+	HistoryTokens    int
+}
+
+func (runtime *Runtime) buildModelContext(
+	ctx context.Context,
+	sessionID string,
+	cwd string,
+	prompt string,
+	selectedModel *model.Model,
+	onEvent func(StreamEvent),
+) (*contextBuildResult, error) {
+	messages, err := runtime.modelContextMessages(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	base, err := runtime.modelContextBase(ctx, cwd, prompt, messages, onEvent)
+	if err != nil {
+		return nil, err
+	}
+	result := initialContextBuildResult(&base, selectedModel)
+
+	dispatchResult, err := runtime.dispatchContextBuild(ctx, sessionID, cwd, &base, result)
+	if err != nil {
+		return nil, err
+	}
+
+	contributions, err := contextContributionsFromPayload(dispatchResult.Payload)
+	if err != nil {
+		return nil, err
+	}
+	appendContextContributions(result, contributions)
+	recalculateContextBuildResult(result, &base, selectedModel)
+	runtime.emit(
+		ctx,
+		string(extension.LifecycleContextBuild),
+		contextBuildLifecyclePayload(sessionID, cwd, &base, result),
+	)
+
+	return result, nil
+}
+
+func (runtime *Runtime) modelContextBase(
+	ctx context.Context,
+	cwd string,
+	prompt string,
+	messages []database.MessageEntity,
+	onEvent func(StreamEvent),
+) (modelContextBase, error) {
+	basePrompt := baseSystemPrompt(cwd)
+	skills := core.LoadSkills(cwd, nil, true).Skills
+	availableSkillsPrompt := ""
+	if len(skills) > 0 {
+		availableSkillsPrompt = core.FormatSkillsForPrompt(skills)
+	}
+
+	skillActivation := core.AutoActivateSkillsDetailed(prompt, skills)
+	activeSkills := skillActivation.Activated
+	if len(skillActivation.Diagnostics) > 0 && runtime.logger != nil {
+		runtime.logger.Debug("skill auto-activation diagnostics", slog.Int("count", len(skillActivation.Diagnostics)))
+	}
+	for index := range skillActivation.Matches {
+		match := &skillActivation.Matches[index]
+		if runtime.logger != nil {
+			runtime.logger.Debug(
+				"skill auto-activated",
+				slog.String("skill", match.Skill.Name),
+				slog.String("reason", match.Reason),
+				slog.Int("score", match.Score),
+			)
+		}
+	}
+	activeSkillsPrompt := ""
+	runtime.emitActivatedSkillReads(ctx, cwd, activeSkills, onEvent)
+	if len(activeSkills) > 0 {
+		activeSkillsPrompt = core.FormatActiveSkillsForPrompt(activeSkills)
+		payload := map[string]any{
+			"skills":  activeSkillEventPayload(activeSkills),
+			"matches": activeSkillMatchPayload(skillActivation.Matches),
+		}
+		runtime.emit(ctx, "skill_auto_activate", payload)
+		if runtime.extensions != nil {
+			if emitErr := runtime.extensions.Emit(ctx, "skill_auto_activate", payload); emitErr != nil {
+				return modelContextBase{}, oops.In("assistant").
+					Code("skill_auto_activate").
+					Wrapf(emitErr, "emit skill auto activation")
+			}
+		}
+	}
+
+	return modelContextBase{
+		ActiveSkills:     activeSkills,
+		SkillDiagnostics: skillActivation.Matches,
+		Messages:         messages,
+		SystemPrompt:     basePrompt + availableSkillsPrompt + activeSkillsPrompt,
+		BaseSystemPrompt: basePrompt,
+		SkillPrompt:      availableSkillsPrompt + activeSkillsPrompt,
+		SystemTokens:     estimateTokens(basePrompt),
+		SkillTokens:      estimateTokens(availableSkillsPrompt) + estimateTokens(activeSkillsPrompt),
+		HistoryTokens:    estimateMessageTokens(messages),
+	}, nil
+}
+
+func initialContextBuildResult(base *modelContextBase, selectedModel *model.Model) *contextBuildResult {
+	return &contextBuildResult{
+		Contributions: []contextContribution{},
+		Messages:      base.Messages,
+		Breakdown:     contextBreakdown(base.SystemTokens, base.SkillTokens, base.HistoryTokens, nil),
+		SystemPrompt:  base.SystemPrompt,
+		Usage: estimateContextBuildUsage(
+			base.SystemPrompt,
+			base.Messages,
+			nil,
+			selectedModel,
+		),
+	}
+}
+
+func recalculateContextBuildResult(
+	result *contextBuildResult,
+	base *modelContextBase,
+	selectedModel *model.Model,
+) {
+	result.Usage = estimateContextBuildUsage(
+		base.SystemPrompt,
+		base.Messages,
+		result.Contributions,
+		selectedModel,
+	)
+	result.Breakdown = contextBreakdown(
+		base.SystemTokens,
+		base.SkillTokens,
+		base.HistoryTokens,
+		result.Contributions,
+	)
+}
+
+func estimateContextBuildUsage(
+	systemPrompt string,
+	messages []database.MessageEntity,
+	contributions []contextContribution,
+	selectedModel *model.Model,
+) model.TokenUsage {
+	inputTokens := estimateInputTokens(systemPrompt, messages)
+	for index := range contributions {
+		inputTokens += contributions[index].Tokens
+	}
+
+	return model.TokenUsage{
+		ContextWindow: selectedModel.ContextWindow,
+		ContextTokens: inputTokens,
+		InputTokens:   inputTokens,
+		OutputTokens:  0,
+	}
+}
+
+func appendContextContributions(result *contextBuildResult, contributions []contextContribution) {
+	if len(contributions) == 0 {
+		return
+	}
+
+	builder := strings.Builder{}
+	builder.WriteString(result.SystemPrompt)
+	builder.WriteString("\n\n<extension_context>")
+	for index := range contributions {
+		contribution := contributions[index]
+		result.Contributions = append(result.Contributions, contribution)
+		builder.WriteString("\n<block")
+		if contribution.Name != "" {
+			_, _ = fmt.Fprintf(&builder, " name=%q", contribution.Name)
+		}
+		_, _ = fmt.Fprintf(
+			&builder,
+			" source=%q role=%q tokens=%d",
+			contribution.Source,
+			contribution.Role,
+			contribution.Tokens,
+		)
+		builder.WriteString(">\n")
+		builder.WriteString(contribution.Content)
+		builder.WriteString("\n</block>")
+	}
+	builder.WriteString("\n</extension_context>")
+	result.SystemPrompt = builder.String()
+}
+
+func contextBreakdown(
+	systemTokens int,
+	skillTokens int,
+	historyTokens int,
+	contributions []contextContribution,
+) map[string]int {
+	breakdown := map[string]int{
+		"system":     systemTokens,
+		"skills":     skillTokens,
+		"history":    historyTokens,
+		"extensions": 0,
+	}
+	for index := range contributions {
+		breakdown["extensions"] += contributions[index].Tokens
+	}
+
+	return breakdown
+}
+
+func contextContributionsFromPayload(payload map[string]any) ([]contextContribution, error) {
+	raw, found := payload["contributions"]
+	if !found || raw == nil {
+		return []contextContribution{}, nil
+	}
+
+	rawContributions, ok := raw.([]any)
+	if !ok {
+		if rawMap, mapOK := raw.(map[string]any); mapOK {
+			rawContributions = numericMapValues(rawMap)
+		} else {
+			return nil, oops.In("assistant").
+				Code("invalid_context_contributions").
+				Errorf("context contributions must be a list")
+		}
+	}
+
+	contributions := make([]contextContribution, 0, len(rawContributions))
+	for index, rawContribution := range rawContributions {
+		contribution, err := contextContributionFromValue(rawContribution)
+		if err != nil {
+			return nil, oops.In("assistant").
+				Code("invalid_context_contribution").
+				Wrapf(err, "context contribution %d", index)
+		}
+		contributions = append(contributions, contribution)
+	}
+
+	return contributions, nil
+}
+
+func numericMapValues(values map[string]any) []any {
+	items := make([]any, 0, len(values))
+	for index := 1; index <= len(values); index++ {
+		value, ok := values[fmt.Sprint(index)]
+		if !ok {
+			return []any{}
+		}
+		items = append(items, value)
+	}
+
+	return items
+}
+
+func contextContributionFromValue(value any) (contextContribution, error) {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return contextContribution{}, fmt.Errorf("must be an object")
+	}
+	content := strings.TrimSpace(stringFromAny(object[jsonContentKey]))
+	if content == "" {
+		return contextContribution{}, fmt.Errorf("content is required")
+	}
+	tokens := estimateTokens(content)
+	if tokens > contextContributionMaxTokens {
+		return contextContribution{}, fmt.Errorf(
+			"content exceeds %d-token contribution limit",
+			contextContributionMaxTokens,
+		)
+	}
+
+	source := stringFromAny(object["source"])
+	if source == "" {
+		source = contextContributionSourceExtension
+	}
+	role := stringFromAny(object[jsonRoleKey])
+	if role == "" {
+		role = contextContributionRoleSystem
+	}
+
+	return contextContribution{
+		Metadata: mapFromAny(object["metadata"]),
+		Source:   source,
+		Name:     stringFromAny(object[jsonToolNameKey]),
+		Role:     role,
+		Content:  content,
+		Tokens:   tokens,
+	}, nil
+}
+
+func stringFromAny(value any) string {
+	if typed, ok := value.(string); ok {
+		return typed
+	}
+
+	return ""
+}
+
+func mapFromAny(value any) map[string]any {
+	if typed, ok := value.(map[string]any); ok {
+		return typed
+	}
+
+	return map[string]any{}
+}

--- a/internal/assistant/context_build_test.go
+++ b/internal/assistant/context_build_test.go
@@ -1,0 +1,139 @@
+package assistant_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/samber/ro"
+
+	"github.com/omarluq/librecode/internal/event"
+	"github.com/omarluq/librecode/internal/extension"
+)
+
+func TestRuntime_ContextBuildAcceptsBoundedExtensionContributions(t *testing.T) {
+	t.Parallel()
+
+	client := &capturingCompletionClient{request: nil}
+	runtime, _, manager := newTestRuntimeWithManager(t, client)
+	loadRuntimeExtension(t, manager, `
+local lc = require("librecode")
+lc.on("context_build", function(event)
+  event.payload.contributions = {
+    {
+      name = "project-note",
+      source = "test-extension",
+      role = "system",
+      content = "Always mention extension context when relevant.",
+      metadata = { reason = "test" },
+    },
+  }
+  return { payload = event.payload }
+end)
+`)
+
+	_, err := runtime.Prompt(context.Background(), newRuntimePromptRequest(testRuntimeCWD, "context", ""))
+
+	require.NoError(t, err)
+	require.NotNil(t, client.request)
+	assert.Contains(t, client.request.SystemPrompt, "<extension_context>")
+	assert.Contains(t, client.request.SystemPrompt, "project-note")
+	assert.Contains(t, client.request.SystemPrompt, "Always mention extension context")
+}
+
+func TestRuntime_ContextBuildRejectsOversizedExtensionContributions(t *testing.T) {
+	t.Parallel()
+
+	runtime, _, manager := newTestRuntimeWithManager(t, testCompletionClient{})
+	loadRuntimeExtension(t, manager, `
+local lc = require("librecode")
+lc.on("context_build", function(event)
+  event.payload.contributions = {
+    { name = "huge", content = string.rep("token ", 9000) },
+  }
+  return { payload = event.payload }
+end)
+`)
+
+	_, err := runtime.Prompt(context.Background(), newRuntimePromptRequest(testRuntimeCWD, "context", ""))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "contribution limit")
+}
+
+func TestRuntime_ContextBuildPayloadContainsBreakdown(t *testing.T) {
+	t.Parallel()
+
+	runtime, _, manager := newTestRuntimeWithManager(t, testCompletionClient{})
+	loadRuntimeExtension(t, manager, `
+local lc = require("librecode")
+local seen = ""
+lc.on("context_build", function(event)
+  local breakdown = event.payload.breakdown or {}
+  seen = table.concat({
+    tostring(breakdown.system ~= nil),
+    tostring(breakdown.skills ~= nil),
+    tostring(breakdown.history ~= nil),
+    tostring(breakdown.extensions ~= nil),
+    tostring(event.payload.max_contribution_tokens ~= nil),
+  }, ":")
+end)
+lc.register_command("context_seen", "context_seen", function()
+  return seen
+end)
+`)
+
+	request := newRuntimePromptRequest(testRuntimeCWD, strings.Repeat("hello ", 3), "")
+	_, err := runtime.Prompt(context.Background(), request)
+	require.NoError(t, err)
+
+	seen, err := manager.ExecuteCommand(context.Background(), "context_seen", "")
+	require.NoError(t, err)
+	assert.Equal(t, "true:true:true:true:true", seen)
+}
+
+func TestRuntime_ContextBuildPublishesContributionBreakdown(t *testing.T) {
+	t.Parallel()
+
+	client := &capturingCompletionClient{request: nil}
+	runtime, _, manager := newTestRuntimeWithManager(t, client)
+	loadRuntimeExtension(t, manager, `
+local lc = require("librecode")
+lc.on("context_build", function(event)
+  event.payload.contributions = {
+    { name = "note", content = "extra context" },
+  }
+  return { payload = event.payload }
+end)
+`)
+
+	var payload map[string]any
+	subscription := runtime.EventBus().Channel(string(extension.LifecycleContextBuild)).Subscribe(ro.NewObserver(
+		func(envelope event.Envelope) {
+			data, ok := envelope.Data.(map[string]any)
+			if ok {
+				payload = data
+			}
+		},
+		func(err error) {
+			t.Errorf("unexpected context_build stream error: %v", err)
+		},
+		func() {
+			// Test subscription should not complete before cleanup.
+		},
+	))
+	defer subscription.Unsubscribe()
+
+	_, err := runtime.Prompt(context.Background(), newRuntimePromptRequest(testRuntimeCWD, "context", ""))
+
+	require.NoError(t, err)
+	require.NotNil(t, payload)
+	breakdown, ok := payload["breakdown"].(map[string]any)
+	require.True(t, ok)
+	extensionTokens, ok := breakdown["extensions"].(int)
+	require.True(t, ok)
+	assert.Greater(t, extensionTokens, 0)
+}

--- a/internal/assistant/lifecycle.go
+++ b/internal/assistant/lifecycle.go
@@ -141,12 +141,8 @@ func (runtime *Runtime) dispatchObservationalLifecycle(
 	name extension.LifecycleEventName,
 	payload map[string]any,
 ) {
-	if _, err := runtime.dispatchLifecycle(ctx, name, payload); err != nil && runtime.logger != nil {
-		runtime.logger.Debug(
-			"observational lifecycle dispatch failed",
-			slog.String("event", string(name)),
-			slog.Any("error", err),
-		)
+	if _, err := runtime.dispatchLifecycle(ctx, name, payload); err != nil {
+		return
 	}
 }
 

--- a/internal/assistant/lifecycle.go
+++ b/internal/assistant/lifecycle.go
@@ -61,12 +61,20 @@ func (runtime *Runtime) dispatchLifecycle(
 	ctx context.Context,
 	name extension.LifecycleEventName,
 	payload map[string]any,
-) {
+) (extension.LifecycleDispatchResult, error) {
 	runtime.emit(ctx, string(name), payload)
 	if runtime.extensions == nil {
-		return
+		return extension.LifecycleDispatchResult{
+			Payload:      cloneAnyMap(payload),
+			Name:         string(name),
+			Errors:       []string{},
+			Duration:     0,
+			HandlerCount: 0,
+			Consumed:     false,
+			Stopped:      false,
+		}, nil
 	}
-	_, err := runtime.extensions.DispatchLifecycle(ctx, extension.LifecycleEvent{
+	result, err := runtime.extensions.DispatchLifecycle(ctx, extension.LifecycleEvent{
 		Payload: payload,
 		Name:    name,
 	})
@@ -77,13 +85,15 @@ func (runtime *Runtime) dispatchLifecycle(
 			slog.Any("error", err),
 		)
 	}
+
+	return result, err
 }
 
 func (runtime *Runtime) dispatchMessageAppend(ctx context.Context, entry *database.EntryEntity) {
 	if entry == nil {
 		return
 	}
-	runtime.dispatchLifecycle(ctx, extension.LifecycleMessageAppend, entryLifecyclePayload(entry))
+	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleMessageAppend, entryLifecyclePayload(entry))
 }
 
 func (runtime *Runtime) dispatchTurnStartLifecycle(
@@ -94,9 +104,9 @@ func (runtime *Runtime) dispatchTurnStartLifecycle(
 	parentEntryID *string,
 ) {
 	payload := turnLifecyclePayload(sessionID, request.CWD, request.Text, userEntryID, parentEntryID)
-	runtime.dispatchLifecycle(ctx, extension.LifecycleBeforeAgentStart, payload)
-	runtime.dispatchLifecycle(ctx, extension.LifecycleAgentStart, payload)
-	runtime.dispatchLifecycle(ctx, extension.LifecycleTurnStart, payload)
+	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleBeforeAgentStart, payload)
+	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleAgentStart, payload)
+	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleTurnStart, payload)
 }
 
 func (runtime *Runtime) dispatchTurnEndLifecycle(
@@ -108,8 +118,8 @@ func (runtime *Runtime) dispatchTurnEndLifecycle(
 	usage model.TokenUsage,
 ) {
 	payload := turnEndLifecyclePayload(sessionID, userEntryID, assistantEntryID, cached, nil, usage)
-	runtime.dispatchLifecycle(ctx, extension.LifecycleTurnEnd, payload)
-	runtime.dispatchLifecycle(ctx, extension.LifecycleAgentEnd, payload)
+	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleTurnEnd, payload)
+	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleAgentEnd, payload)
 }
 
 func (runtime *Runtime) dispatchTurnErrorLifecycle(
@@ -122,20 +132,33 @@ func (runtime *Runtime) dispatchTurnErrorLifecycle(
 		return
 	}
 	payload := turnEndLifecyclePayload(sessionID, userEntryID, "", false, turnErr, model.EmptyTokenUsage())
-	runtime.dispatchLifecycle(ctx, extension.LifecycleTurnEnd, payload)
-	runtime.dispatchLifecycle(ctx, extension.LifecycleAgentEnd, payload)
+	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleTurnEnd, payload)
+	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleAgentEnd, payload)
+}
+
+func (runtime *Runtime) dispatchObservationalLifecycle(
+	ctx context.Context,
+	name extension.LifecycleEventName,
+	payload map[string]any,
+) {
+	if _, err := runtime.dispatchLifecycle(ctx, name, payload); err != nil && runtime.logger != nil {
+		runtime.logger.Debug(
+			"observational lifecycle dispatch failed",
+			slog.String("event", string(name)),
+			slog.Any("error", err),
+		)
+	}
 }
 
 func (runtime *Runtime) dispatchContextBuild(
 	ctx context.Context,
 	sessionID string,
 	cwd string,
-	systemPrompt string,
-	messages []database.MessageEntity,
-	usage model.TokenUsage,
-) {
-	payload := contextBuildLifecyclePayload(sessionID, cwd, systemPrompt, messages, usage)
-	runtime.dispatchLifecycle(ctx, extension.LifecycleContextBuild, payload)
+	base *modelContextBase,
+	result *contextBuildResult,
+) (extension.LifecycleDispatchResult, error) {
+	payload := contextBuildLifecyclePayload(sessionID, cwd, base, result)
+	return runtime.dispatchLifecycle(ctx, extension.LifecycleContextBuild, payload)
 }
 
 func promptLifecyclePayload(request *PromptRequest) map[string]any {
@@ -210,19 +233,40 @@ func turnEndLifecyclePayload(
 func contextBuildLifecyclePayload(
 	sessionID string,
 	cwd string,
-	systemPrompt string,
-	messages []database.MessageEntity,
-	usage model.TokenUsage,
+	base *modelContextBase,
+	result *contextBuildResult,
 ) map[string]any {
 	return map[string]any{
-		lifecycleCWDKey:      cwd,
-		jsonSessionIDKey:     sessionID,
-		"message_count":      len(messages),
-		"system_tokens":      estimateTokens(systemPrompt),
-		"message_tokens":     estimateMessageTokens(messages),
-		jsonUsageKey:         tokenUsageLifecyclePayload(usage),
-		"model_facing_roles": modelFacingRoleCounts(messages),
+		lifecycleCWDKey:           cwd,
+		jsonSessionIDKey:          sessionID,
+		"message_count":           len(base.Messages),
+		"breakdown":               cloneIntMap(result.Breakdown),
+		"contributions":           []any{},
+		"max_contribution_tokens": contextContributionMaxTokens,
+		"system_tokens":           base.SystemTokens,
+		"skill_tokens":            base.SkillTokens,
+		"message_tokens":          base.HistoryTokens,
+		jsonUsageKey:              tokenUsageLifecyclePayload(result.Usage),
+		"model_facing_roles":      modelFacingRoleCounts(base.Messages),
 	}
+}
+
+func cloneAnyMap(values map[string]any) map[string]any {
+	cloned := make(map[string]any, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+
+	return cloned
+}
+
+func cloneIntMap(values map[string]int) map[string]any {
+	cloned := make(map[string]any, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+
+	return cloned
 }
 
 func estimateMessageTokens(messages []database.MessageEntity) int {

--- a/internal/assistant/runtime.go
+++ b/internal/assistant/runtime.go
@@ -132,14 +132,14 @@ func (runtime *Runtime) Prompt(ctx context.Context, request *PromptRequest) (res
 	if request == nil {
 		return nil, oops.In("assistant").Code("nil_prompt_request").Errorf("prompt request is nil")
 	}
-	runtime.dispatchLifecycle(ctx, extension.LifecycleInput, promptLifecyclePayload(request))
-	runtime.dispatchLifecycle(ctx, extension.LifecyclePromptPrepare, promptLifecyclePayload(request))
+	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleInput, promptLifecyclePayload(request))
+	runtime.dispatchObservationalLifecycle(ctx, extension.LifecyclePromptPrepare, promptLifecyclePayload(request))
 
 	activeSession, sessionEvent, err := runtime.resolveSession(ctx, request)
 	if err != nil {
 		return nil, err
 	}
-	runtime.dispatchLifecycle(ctx, sessionEvent, sessionLifecyclePayload(activeSession))
+	runtime.dispatchObservationalLifecycle(ctx, sessionEvent, sessionLifecyclePayload(activeSession))
 
 	parentID, err := runtime.promptParentID(ctx, activeSession.ID, request.ParentEntryID)
 	if err != nil {
@@ -616,48 +616,17 @@ func (runtime *Runtime) modelResponse(
 			With("provider", selectedModel.Provider).
 			Wrapf(fmt.Errorf("%s", auth.Error), "resolve model auth")
 	}
-	messages, err := runtime.modelContextMessages(ctx, sessionID)
+	contextResult, err := runtime.buildModelContext(ctx, sessionID, cwd, prompt, &selectedModel, onEvent)
 	if err != nil {
 		return nil, err
 	}
-
-	systemPrompt := defaultSystemPrompt(cwd)
-	skillActivation := core.AutoActivateSkillsDetailed(prompt, core.LoadSkills(cwd, nil, true).Skills)
-	activeSkills := skillActivation.Activated
-	if len(skillActivation.Diagnostics) > 0 {
-		runtime.logger.Debug("skill auto-activation diagnostics", slog.Int("count", len(skillActivation.Diagnostics)))
-	}
-	for index := range skillActivation.Matches {
-		match := &skillActivation.Matches[index]
-		runtime.logger.Debug(
-			"skill auto-activated",
-			slog.String("skill", match.Skill.Name),
-			slog.String("reason", match.Reason),
-			slog.Int("score", match.Score),
-		)
-	}
-	runtime.emitActivatedSkillReads(ctx, cwd, activeSkills, onEvent)
-	if len(activeSkills) > 0 {
-		systemPrompt += core.FormatActiveSkillsForPrompt(activeSkills)
-		payload := map[string]any{
-			"skills":  activeSkillEventPayload(activeSkills),
-			"matches": activeSkillMatchPayload(skillActivation.Matches),
-		}
-		runtime.emit(ctx, "skill_auto_activate", payload)
-		if emitErr := runtime.extensions.Emit(ctx, "skill_auto_activate", payload); emitErr != nil {
-			return nil, oops.In("assistant").Code("skill_auto_activate").Wrapf(emitErr, "emit skill auto activation")
-		}
-	}
-
-	estimatedUsage := estimateTokenUsage(systemPrompt, messages, &selectedModel)
-	runtime.dispatchContextBuild(ctx, sessionID, cwd, systemPrompt, messages, estimatedUsage)
-	runtime.emitUsage(ctx, onEvent, estimatedUsage)
+	runtime.emitUsage(ctx, onEvent, contextResult.Usage)
 	request := runtime.modelCompletionRequest(
 		&selectedModel,
 		auth,
-		messages,
+		contextResult.Messages,
 		sessionID,
-		systemPrompt,
+		contextResult.SystemPrompt,
 		cwd,
 		onEvent,
 	)
@@ -665,7 +634,7 @@ func (runtime *Runtime) modelResponse(
 	if err != nil {
 		return nil, err
 	}
-	usage := mergeUsage(estimatedUsage, result.Usage)
+	usage := mergeUsage(contextResult.Usage, result.Usage)
 	runtime.emitUsage(ctx, onEvent, usage)
 
 	return &responseBundle{
@@ -916,8 +885,8 @@ func isModelFacingRole(role database.Role) bool {
 	return false
 }
 
-func defaultSystemPrompt(cwd string) string {
-	prompt := strings.Join([]string{
+func baseSystemPrompt(cwd string) string {
+	return strings.Join([]string{
 		"You are librecode, an AI coding assistant. Be concise, helpful, and accurate.",
 		"You are running inside a local filesystem workspace.",
 		fmt.Sprintf("Current working directory: %s", cwd),
@@ -927,12 +896,6 @@ func defaultSystemPrompt(cwd string) string {
 		"Respect .gitignore and default ignored paths; avoid ignored files unless explicitly needed.",
 		"Use the fewest tool calls needed; once you have enough evidence, stop using tools and answer.",
 	}, "\n")
-	skills := core.LoadSkills(cwd, nil, true).Skills
-	if len(skills) > 0 {
-		prompt += core.FormatSkillsForPrompt(skills)
-	}
-
-	return prompt
 }
 
 func (runtime *Runtime) cacheKey(sessionID, prompt string) string {

--- a/internal/assistant/runtime_events.go
+++ b/internal/assistant/runtime_events.go
@@ -17,7 +17,7 @@ func (runtime *Runtime) emitProviderRequest(ctx context.Context, request *Comple
 	if request == nil {
 		return
 	}
-	runtime.dispatchLifecycle(ctx, extension.LifecycleBeforeProviderRequest, map[string]any{
+	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleBeforeProviderRequest, map[string]any{
 		lifecycleAPIKey:      request.Model.API,
 		lifecycleAttemptKey:  attempt,
 		jsonModelKey:         request.Model.ID,
@@ -36,7 +36,7 @@ func (runtime *Runtime) emitProviderResponse(
 	if request == nil || result == nil {
 		return
 	}
-	runtime.dispatchLifecycle(ctx, extension.LifecycleAfterProviderResponse, map[string]any{
+	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleAfterProviderResponse, map[string]any{
 		lifecycleAPIKey:      request.Model.API,
 		lifecycleAttemptKey:  attempt,
 		jsonModelKey:         request.Model.ID,
@@ -53,7 +53,7 @@ func (runtime *Runtime) emitProviderError(ctx context.Context, request *Completi
 	if request == nil || err == nil {
 		return
 	}
-	runtime.dispatchLifecycle(ctx, extension.LifecycleProviderError, map[string]any{
+	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleProviderError, map[string]any{
 		lifecycleAPIKey:      request.Model.API,
 		lifecycleAttemptKey:  attempt,
 		jsonModelKey:         request.Model.ID,
@@ -64,7 +64,7 @@ func (runtime *Runtime) emitProviderError(ctx context.Context, request *Completi
 }
 
 func (runtime *Runtime) emitToolCall(ctx context.Context, call ToolCallEvent) {
-	runtime.dispatchLifecycle(ctx, extension.LifecycleToolCall, toolCallPayload(call))
+	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleToolCall, toolCallPayload(call))
 }
 
 func (runtime *Runtime) emitToolResult(ctx context.Context, event *ToolEvent) {
@@ -72,9 +72,9 @@ func (runtime *Runtime) emitToolResult(ctx context.Context, event *ToolEvent) {
 		return
 	}
 	payload := toolEventPayload(event)
-	runtime.dispatchLifecycle(ctx, extension.LifecycleToolResult, payload)
+	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleToolResult, payload)
 	if event.Error != "" {
-		runtime.dispatchLifecycle(ctx, extension.LifecycleToolError, payload)
+		runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleToolError, payload)
 	}
 }
 

--- a/internal/assistant/usage.go
+++ b/internal/assistant/usage.go
@@ -9,21 +9,6 @@ import (
 	"github.com/omarluq/librecode/internal/model"
 )
 
-func estimateTokenUsage(
-	systemPrompt string,
-	messages []database.MessageEntity,
-	selectedModel *model.Model,
-) model.TokenUsage {
-	inputTokens := estimateInputTokens(systemPrompt, messages)
-
-	return model.TokenUsage{
-		ContextWindow: selectedModel.ContextWindow,
-		ContextTokens: inputTokens,
-		InputTokens:   inputTokens,
-		OutputTokens:  0,
-	}
-}
-
 func estimateInputTokens(systemPrompt string, messages []database.MessageEntity) int {
 	count := estimateTokens(systemPrompt)
 	for index := range messages {


### PR DESCRIPTION
## Summary
- add bounded extension context contributions through the context_build lifecycle seam
- expose context token breakdown for system, skills, history, and extensions
- wire model context construction through the new context builder before provider execution

## Validation
- mise exec -- go test ./...
- mise exec -- task build
- mise exec -- task ci