### PR TITLE
docs(readme): rewrite as manifesto, add pre-release notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@
 </p>
 
 <p align="center">
-  <strong>librecode is a terminal AI agent for people who trust themselves.</strong>
+  <strong>librecode is a small, local-first terminal AI agent.</strong>
   <br><br>
-  No sandbox. No MCP. No permission prompts. No marketplace. No telemetry. No chaperone.
+  No sandbox. No MCP. No permission prompts. No marketplace. No telemetry.
   <br><br>
-  Just a model, your shell, and seven tools that do what they say. If you wouldn't <code>rm -rf</code> your homedir by accident, you don't need an LLM to ask you twice before it touches a file.
+  Just a model, your shell, and seven tools that do what they say, designed for developers who'd rather review their own diffs than click through approval dialogs.
 </p>
 
 <p align="center">
@@ -30,38 +30,42 @@
 </p>
 
 > [!IMPORTANT]
-> librecode is pre-release software. Expect bugs, rough edges, breaking changes, half-finished surfaces, and the occasional crash. APIs, config keys, and on-disk formats may shift without notice until 1.0. If you need stability, wait. If you want to help shape it, jump in — issues and PRs welcome.
+> librecode is pre-release software. Expect bugs, rough edges, breaking changes, half-finished surfaces, and the occasional crash. APIs, config keys, and on-disk formats may shift without notice until 1.0. If you need stability, wait. If you want to help shape it, jump in: issues and PRs welcome.
 
 ## Philosophy
 
-Most agent CLIs are racing toward enterprise-shaped problems: permission models, sandboxed tool servers, RBAC, audit logs, marketplaces, protocol committees. librecode runs the other way.
+The agent CLI space is moving toward more layers: permission models, sandboxed tool servers, plugin marketplaces, extension protocols. Those are reasonable choices for some teams. librecode is the smaller, simpler alternative for people who want fewer of them.
 
-- **No MCP.** Not an oversight — a stance. Built-in tools plus optional Lua are the entire surface area. No servers to spin up, no protocols to negotiate, no ecosystem tax.
-- **No sandbox.** `bash` runs what you tell it to run. `write` and `edit` mutate files. You are the adult in the room.
-- **No permission theater.** No "can the assistant read this file?" modal on every step. If you didn't want it touching your repo, you wouldn't have launched it in your repo.
-- **No vendor lock-in.** OAuth into ChatGPT/Codex or Claude Pro/Max, drop in an API key for anything OpenAI-compatible, or define your own provider. Pick the model that gets it done.
-- **One binary.** Static Go. No Node. No Python venv. No Electron. It starts in milliseconds and does not phone home.
-- **Local everything.** Sessions live in a SQLite file. Auth lives in a JSON file. Project-local `.librecode/` keeps secrets and history scoped to the repo.
+- **No MCP.** Built-in tools plus optional Lua extensions are the entire surface area. Fewer moving parts, no separate servers to manage.
+- **No sandbox.** Tools run with your permissions, in your shell, against your files. You decide what to run librecode against.
+- **No permission prompts.** The agent acts within the project you launched it in, without interrupting to confirm each step.
+- **Bring your own model.** OAuth into ChatGPT/Codex or Claude Pro/Max, use an API key for anything OpenAI-compatible, or define your own provider.
+- **One binary.** Static Go. No Node, no Python venv, no Electron. Fast cold start, no background services.
+- **Local everything.** Sessions in a SQLite file, auth in a JSON file. Project-local `.librecode/` keeps state scoped to the repo.
 
-This is a sharp knife. That's the feature.
+It's a direct, capable tool. Treat it like one.
 
 ## What's in the box
 
-- **Interactive terminal chat** — streaming output, visible reasoning blocks, chronological tool activity, scrollback, prompt history, mouse selection, configurable loader text.
-- **Seven built-in tools** — `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`. That's the entire toolkit. You don't need more.
-- **Persistent SQLite sessions** — branchable, resumable, listable. Per-project or global.
-- **Agent Skills support** — drop a `SKILL.md` in `.librecode/skills/` or `.agents/skills/` and it's discoverable. Autocomplete and explicit `/skill:<name>` loading included.
-- **Provider/model registry** — true OAuth for ChatGPT/Codex and Claude Pro/Max, API-key providers, automatic retries on transient failures, custom provider definitions.
-- **Lua extensions** — optional escape hatch. Register commands, intercept keys, mutate buffers, hook events. Trusted local code, not a plugin marketplace.
-- **YAML config + env vars** — sane defaults, strict validation, no surprises.
+- **Interactive terminal chat**: streaming output, visible reasoning blocks, chronological tool activity, scrollback, prompt history, mouse selection, configurable loader text.
+- **Seven built-in tools**: `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`. A small toolkit that covers most coding workflows.
+- **Persistent SQLite sessions**: branchable, resumable, listable. Per-project or global.
+- **Agent Skills support**: drop a `SKILL.md` in `.librecode/skills/` or `.agents/skills/` and it's discoverable. Autocomplete and explicit `/skill:<name>` loading included.
+- **Provider/model registry**: OAuth for ChatGPT/Codex and Claude Pro/Max, API-key providers, automatic retries on transient failures, custom provider definitions.
+- **Lua extensions**: an optional layer for commands, key interception, buffer mutation, and event hooks. Trusted local code rather than a plugin marketplace.
+- **YAML config + env vars**: sane defaults and strict validation.
 
-## Threat model
+## What to expect
 
-librecode will execute any shell command the model asks for. It will overwrite any file you have write permission to. It does not ask first.
+librecode executes shell commands and edits files as the model requests them, without per-action confirmation prompts. That's the design: it keeps the loop fast and the surface area small, but it's worth being explicit about.
 
-This is intentional. Use it in workspaces you own, on commands you'd be willing to run yourself, with models you trust to behave. If that sounds reckless, you want a different tool — and that's fine, there are plenty.
+A few suggestions for using it comfortably:
 
-Run it like you'd run `make` from an unfamiliar repo: with your eyes open.
+- Run it in workspaces you own, ideally under version control, so changes are easy to review and revert.
+- Use models you've found reliable for the kind of work you're asking for.
+- Treat a librecode session like running a script from an unfamiliar repo: fine when you've decided to trust it, worth pausing on when you haven't.
+
+If you'd prefer per-action approval, sandboxing, or policy enforcement, other agent CLIs offer that and may suit you better.
 
 ## Install
 
@@ -234,7 +238,7 @@ Inside chat, `/skill` lists discovered skills. Use `/skill my-skill` or `/skill:
 
 ## Extensions
 
-Extensions are trusted local code — not a sandboxed plugin protocol, not a marketplace, not MCP. Lua is the first supported runtime; the host is designed so additional runtimes can be added later. Extensions are powerful, low-level, and allowed to footgun if you ask them to. That is the whole point.
+Extensions are trusted local code that runs in the same process as librecode. Lua is the first supported runtime; the host is designed so additional runtimes can be added later. Because extensions have direct access to runtime state, only install ones you've reviewed or trust the source of.
 
 Extensions are declared with `extensions.use` in config. The default source is:
 
@@ -297,7 +301,7 @@ librecode extension run <command> [args...]
 
 ## Built-in tools
 
-Seven tools. That's it. No registry, no marketplace, no MCP server lifecycle to babysit.
+Seven tools, kept deliberately small. No registry, marketplace, or external server lifecycle to manage.
 
 | Tool    | Mutates? | Purpose                                            |
 | ------- | -------- | -------------------------------------------------- |
@@ -309,7 +313,7 @@ Seven tools. That's it. No registry, no marketplace, no MCP server lifecycle to 
 | `edit`  | **Yes**  | Exact text replacement with uniqueness checks.     |
 | `bash`  | **Yes**  | Execute shell commands with timeout/output limits. |
 
-`bash` is `bash`. It runs commands. It does not negotiate.
+The `bash` tool executes commands directly in your shell with the permissions of the librecode process. There is no allowlist or interactive confirmation.
 
 On Windows, the `bash` tool requires a real Bash shell rather than `cmd.exe`. librecode checks `LIBRECODE_BASH_PATH`, common Git Bash install paths, then `bash.exe` on `PATH`. Native Windows users should install Git Bash/MSYS2/Cygwin or run librecode from WSL.
 
@@ -396,6 +400,6 @@ The release workflow cross-compiles Linux, macOS, and Windows binaries, archives
 
 ## License
 
-MIT — see [`LICENSE.txt`](LICENSE.txt).
+MIT. See [`LICENSE.txt`](LICENSE.txt).
 
 <a href="https://sonarcloud.io/summary/new_code?id=omarluq_librecode"><img src="https://sonarcloud.io/images/project_badges/sonarcloud-dark.svg" alt="SonarCloud Quality Gate"></a>

--- a/README.md
+++ b/README.md
@@ -17,22 +17,51 @@
   <a href="https://deepwiki.com/omarluq/librecode"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 </p>
 
-**librecode** is a free and open source terminal agent harness with a small core and room for extension. One binary. Terminal interface. Local sessions. Built-in tools. Provider auth by OAuth or API key. Lua at the edges.
+<p align="center">
+  <strong>librecode is a terminal AI agent for people who trust themselves.</strong>
+  <br><br>
+  No sandbox. No MCP. No permission prompts. No marketplace. No telemetry. No chaperone.
+  <br><br>
+  Just a model, your shell, and seven tools that do what they say. If you wouldn't <code>rm -rf</code> your homedir by accident, you don't need an LLM to ask you twice before it touches a file.
+</p>
 
 <p align="center">
   <img src="docs/assets/librecode-introduce-yourself.gif" alt="librecode terminal demo" width="820">
 </p>
 
-## Features
+> [!IMPORTANT]
+> librecode is pre-release software. Expect bugs, rough edges, breaking changes, half-finished surfaces, and the occasional crash. APIs, config keys, and on-disk formats may shift without notice until 1.0. If you need stability, wait. If you want to help shape it, jump in — issues and PRs welcome.
 
-- **Written in Go, not JavaScript** for a fast native CLI with straightforward binaries.
-- **Interactive terminal chat** with streaming answers, visible reasoning blocks, chronological tool activity, scrollback, prompt history, app-owned mouse selection/copy, and a shimmering configurable working loader.
-- **Persistent SQLite session trees** stored per user, with session listing, showing, branching metadata, and context rebuilding.
-- **Built-in coding tools**: `read`, `write`, `edit`, `bash`, `grep`, `find`, and `ls` are available to the assistant and through the CLI.
-- **Agent Skills support** loaded from project and user skill directories, with spec frontmatter support, autocomplete, explicit `/skill:<name>` loading, and conservative auto-activation.
-- **Provider/model registry** with true OAuth for ChatGPT/Codex and Claude Pro/Max, API-key providers, transient provider retries, and custom model/provider definitions.
-- **Trusted extensions** with Lua as the first runtime adapter for optional commands, tools, hooks, keymaps, runtime buffers, and low-level terminal events.
-- **Configuration via YAML + env vars** with sane defaults and strict validation.
+## Philosophy
+
+Most agent CLIs are racing toward enterprise-shaped problems: permission models, sandboxed tool servers, RBAC, audit logs, marketplaces, protocol committees. librecode runs the other way.
+
+- **No MCP.** Not an oversight — a stance. Built-in tools plus optional Lua are the entire surface area. No servers to spin up, no protocols to negotiate, no ecosystem tax.
+- **No sandbox.** `bash` runs what you tell it to run. `write` and `edit` mutate files. You are the adult in the room.
+- **No permission theater.** No "can the assistant read this file?" modal on every step. If you didn't want it touching your repo, you wouldn't have launched it in your repo.
+- **No vendor lock-in.** OAuth into ChatGPT/Codex or Claude Pro/Max, drop in an API key for anything OpenAI-compatible, or define your own provider. Pick the model that gets it done.
+- **One binary.** Static Go. No Node. No Python venv. No Electron. It starts in milliseconds and does not phone home.
+- **Local everything.** Sessions live in a SQLite file. Auth lives in a JSON file. Project-local `.librecode/` keeps secrets and history scoped to the repo.
+
+This is a sharp knife. That's the feature.
+
+## What's in the box
+
+- **Interactive terminal chat** — streaming output, visible reasoning blocks, chronological tool activity, scrollback, prompt history, mouse selection, configurable loader text.
+- **Seven built-in tools** — `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`. That's the entire toolkit. You don't need more.
+- **Persistent SQLite sessions** — branchable, resumable, listable. Per-project or global.
+- **Agent Skills support** — drop a `SKILL.md` in `.librecode/skills/` or `.agents/skills/` and it's discoverable. Autocomplete and explicit `/skill:<name>` loading included.
+- **Provider/model registry** — true OAuth for ChatGPT/Codex and Claude Pro/Max, API-key providers, automatic retries on transient failures, custom provider definitions.
+- **Lua extensions** — optional escape hatch. Register commands, intercept keys, mutate buffers, hook events. Trusted local code, not a plugin marketplace.
+- **YAML config + env vars** — sane defaults, strict validation, no surprises.
+
+## Threat model
+
+librecode will execute any shell command the model asks for. It will overwrite any file you have write permission to. It does not ask first.
+
+This is intentional. Use it in workspaces you own, on commands you'd be willing to run yourself, with models you trust to behave. If that sounds reckless, you want a different tool — and that's fine, there are plenty.
+
+Run it like you'd run `make` from an unfamiliar repo: with your eyes open.
 
 ## Install
 
@@ -205,7 +234,7 @@ Inside chat, `/skill` lists discovered skills. Use `/skill my-skill` or `/skill:
 
 ## Extensions
 
-Extensions are trusted local code. librecode follows the Unix philosophy here: extensions are powerful, low-level, and allowed to footgun if you ask them to. Lua is the first supported extension runtime; the host is designed so additional runtimes can be added later.
+Extensions are trusted local code — not a sandboxed plugin protocol, not a marketplace, not MCP. Lua is the first supported runtime; the host is designed so additional runtimes can be added later. Extensions are powerful, low-level, and allowed to footgun if you ask them to. That is the whole point.
 
 Extensions are declared with `extensions.use` in config. The default source is:
 
@@ -241,8 +270,6 @@ Current extension capabilities include:
 - reading and mutating runtime buffers such as `composer`, `status`, `transcript`, `thinking`, and `tools`;
 - creating namespaces, autocmds, and keymaps through a Neovim-inspired Lua API.
 
-Architecture note: Go owns the polished default chat experience and hot rendering paths. Lua remains a trusted optional extension layer for keymaps, commands, hooks, small overlays, and custom workflows.
-
 For architecture, roadmap, and API details, see:
 
 - [`docs/adr/0001-programmable-runtime.md`](docs/adr/0001-programmable-runtime.md)
@@ -268,25 +295,23 @@ librecode extension doctor
 librecode extension run <command> [args...]
 ```
 
-## Built-in tools and trust boundaries
+## Built-in tools
 
-The built-in tools are intentionally powerful. `bash` can execute commands, and file tools can read or mutate paths you provide. This is a local coding assistant, not a sandbox.
+Seven tools. That's it. No registry, no marketplace, no MCP server lifecycle to babysit.
+
+| Tool    | Mutates? | Purpose                                            |
+| ------- | -------- | -------------------------------------------------- |
+| `read`  | No       | Read text/image files with truncation controls.    |
+| `ls`    | No       | List directory entries.                            |
+| `find`  | No       | Search file paths by glob.                         |
+| `grep`  | No       | Search file contents.                              |
+| `write` | **Yes**  | Overwrite/create files.                            |
+| `edit`  | **Yes**  | Exact text replacement with uniqueness checks.     |
+| `bash`  | **Yes**  | Execute shell commands with timeout/output limits. |
+
+`bash` is `bash`. It runs commands. It does not negotiate.
 
 On Windows, the `bash` tool requires a real Bash shell rather than `cmd.exe`. librecode checks `LIBRECODE_BASH_PATH`, common Git Bash install paths, then `bash.exe` on `PATH`. Native Windows users should install Git Bash/MSYS2/Cygwin or run librecode from WSL.
-
-Available tools:
-
-| Tool    | Mutates files? | Purpose                                            |
-| ------- | -------------- | -------------------------------------------------- |
-| `read`  | No             | Read text/image files with truncation controls.    |
-| `ls`    | No             | List directory entries.                            |
-| `find`  | No             | Search file paths by glob.                         |
-| `grep`  | No             | Search file contents.                              |
-| `write` | Yes            | Overwrite/create files.                            |
-| `edit`  | Yes            | Exact text replacement with uniqueness checks.     |
-| `bash`  | Yes            | Execute shell commands with timeout/output limits. |
-
-Only run librecode in workspaces where you trust the model, tools, and extensions you enable.
 
 ## CLI reference
 


### PR DESCRIPTION
## Summary

Rewrites the README to clearly reflect librecode's actual stance: a deliberately minimal, deliberately un-sandboxed terminal AI agent for people who trust themselves. The previous README read like a generic feature list and undersold the project's opinionated philosophy.

## Changes

- **Centered manifesto lead** — tagline, list of negations (no sandbox, no MCP, no permission prompts, no marketplace, no telemetry, no chaperone), and a punchline that sets reader expectations on the first screen.
- **Pre-release `[!IMPORTANT]` callout** directly under the demo GIF, naming bugs / rough edges / breaking changes honestly and inviting contributions.
- **New `## Philosophy` section** that turns every absence into a deliberate, named choice (no MCP, no sandbox, no permission theater, no vendor lock-in, one binary, local everything). Closes with *"This is a sharp knife. That's the feature."*
- **Renamed `## Features` → `## What's in the box`** and rewrote bullets in a tighter, more confident voice.
- **New `## Threat model` section** — names the danger out loud so users can opt in with eyes open.
- **Reworked `## Extensions` opener** — explicitly contrasts against sandboxed plugin protocols, marketplaces, and MCP.
- **Renamed `## Built-in tools and trust boundaries` → `## Built-in tools`** with a sharper opener (*"Seven tools. That's it."*).
- **Removed** the "Architecture note" paragraph in the Extensions section — redundant given the surrounding context.

## Out of scope

No functional changes. README only.