### PR TITLE
fix(assistant): support anthropic native tool names

### DIFF
--- a/internal/assistant/anthropic_internal_test.go
+++ b/internal/assistant/anthropic_internal_test.go
@@ -1,6 +1,7 @@
 package assistant
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,6 +43,10 @@ func TestAnthropicOAuthPayloadAddsClaudeCodeIdentity(t *testing.T) {
 	assert.Len(t, systemBlocks, 2)
 	assert.Contains(t, systemBlocks[0]["text"], "Claude Code")
 	assert.Equal(t, anthropicTestSystemPrompt, systemBlocks[1][jsonTextKey])
+	encodedTools := encodeTestJSON(t, payload["tools"])
+	assert.Contains(t, encodedTools, `"name":"Read"`)
+	assert.Contains(t, encodedTools, `"name":"Write"`)
+	assert.Contains(t, encodedTools, `"eager_input_streaming":true`)
 }
 
 func TestAnthropicPayloadAddsBudgetThinking(t *testing.T) {
@@ -71,6 +76,30 @@ func TestAnthropicPayloadDisablesThinkingWhenOff(t *testing.T) {
 
 	assert.Equal(t, map[string]any{jsonTypeKey: "disabled"}, payload[jsonThinkingKey])
 	assert.NotContains(t, payload, "output_config")
+}
+
+func TestAnthropicPayloadUsesLocalToolNamesForAPIKey(t *testing.T) {
+	t.Parallel()
+
+	payload := anthropicPayload(testCompletionRequestAuth("sk-ant-api03-secret"), nil)
+
+	encodedTools := encodeTestJSON(t, payload["tools"])
+	assert.Contains(t, encodedTools, `"name":"`+jsonReadToolName+`"`)
+	assert.Contains(t, encodedTools, `"name":"`+jsonWriteToolName+`"`)
+	assert.NotContains(t, encodedTools, `"name":"`+anthropicReadToolName+`"`)
+}
+
+func TestAnthropicToolCallMapsClaudeCodeNamesToLocalNames(t *testing.T) {
+	t.Parallel()
+
+	call := anthropicToolCall(testAnthropicToolUseID, "Write", map[string]any{
+		jsonPathKey:    "hello.txt",
+		jsonContentKey: "hello",
+	})
+
+	assert.Equal(t, jsonWriteToolName, call.Name)
+	assert.Equal(t, "hello.txt", call.Arguments[jsonPathKey])
+	assert.Equal(t, "hello", call.Arguments[jsonContentKey])
 }
 
 func TestAnthropicPayloadAddsAdaptiveThinking(t *testing.T) {
@@ -113,6 +142,15 @@ func TestAnthropicHeadersUseBearerForOAuth(t *testing.T) {
 	assert.Contains(t, headers["anthropic-beta"], "claude-code-20250219")
 	assert.Contains(t, headers["anthropic-beta"], "oauth-2025-04-20")
 	assert.NotContains(t, headers["anthropic-beta"], "interleaved-thinking-2025-05-14")
+}
+
+func encodeTestJSON(t *testing.T, value any) string {
+	t.Helper()
+
+	encoded, err := json.Marshal(value)
+	assert.NoError(t, err)
+
+	return string(encoded)
 }
 
 func testCompletionRequestAuth(args ...string) *CompletionRequest {

--- a/internal/assistant/tool_schema.go
+++ b/internal/assistant/tool_schema.go
@@ -106,9 +106,9 @@ func writeToolSchema() map[string]any {
 			jsonPathKey: stringSchema(
 				"Path to create or overwrite, relative to the current workspace or absolute.",
 			),
-			"content": stringSchema("Complete file content to write."),
+			jsonContentKey: stringSchema("Complete file content to write."),
 		},
-		jsonRequiredKey: []string{jsonPathKey, "content"},
+		jsonRequiredKey: []string{jsonPathKey, jsonContentKey},
 	}
 }
 

--- a/internal/tool/registry_test.go
+++ b/internal/tool/registry_test.go
@@ -66,6 +66,19 @@ func TestRegistry_ExecuteJSONRunsBashInWorkingDirectory(t *testing.T) {
 	assert.Contains(t, result.Text(), "ok")
 }
 
+func TestRegistry_ExecuteJSONRejectsEmptyWriteContent(t *testing.T) {
+	t.Parallel()
+
+	registry := tool.NewRegistry(t.TempDir())
+	payload, err := json.Marshal(map[string]any{"path": "empty.txt", "content": ""})
+	require.NoError(t, err)
+
+	_, err = registry.ExecuteJSON(context.Background(), "write", payload)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write content is required")
+}
+
 func executeTool(
 	ctx context.Context,
 	t *testing.T,

--- a/internal/tool/write.go
+++ b/internal/tool/write.go
@@ -55,6 +55,9 @@ func (writeTool *WriteTool) Write(ctx context.Context, input WriteInput) (Result
 	if strings.TrimSpace(input.Path) == "" {
 		return emptyToolResult(), oops.In("tool").Code("write_path_required").Errorf("write path is required")
 	}
+	if strings.TrimSpace(input.Content) == "" {
+		return emptyToolResult(), oops.In("tool").Code("write_content_required").Errorf("write content is required")
+	}
 	absolutePath, err := ResolveToCWD(input.Path, writeTool.cwd)
 	if err != nil {
 		return emptyToolResult(), oops.In("tool").Code("write_resolve_path").Wrapf(err, "resolve write path")


### PR DESCRIPTION
## Summary
- map Anthropic OAuth tool definitions to Claude Code-style tool names
- map incoming Anthropic native tool calls back to local tool names
- add eager input streaming metadata on Anthropic tool definitions
- reject empty write content at the tool layer

## Validation
- mise exec -- go test ./...
- mise exec -- task build
- mise exec -- task ci