### PR TITLE
fix(assistant): remove tool iteration cap

### DIFF
--- a/internal/assistant/anthropic.go
+++ b/internal/assistant/anthropic.go
@@ -22,7 +22,7 @@ func (client *HTTPCompletionClient) completeAnthropic(
 		endpoint: joinEndpoint(request.Model.BaseURL, "/v1/messages"),
 		result:   &CompletionResult{Text: "", Thinking: nil, ToolEvents: nil, Usage: model.EmptyTokenUsage()},
 	}
-	for range maxToolIterations {
+	for {
 		finished, err := client.advanceAnthropicLoop(ctx, request, &state)
 		if err != nil {
 			return nil, err
@@ -31,8 +31,6 @@ func (client *HTTPCompletionClient) completeAnthropic(
 			return state.result, nil
 		}
 	}
-
-	return nil, toolIterationLimitError()
 }
 
 type anthropicLoopState struct {

--- a/internal/assistant/openai_chat.go
+++ b/internal/assistant/openai_chat.go
@@ -20,7 +20,7 @@ func (client *HTTPCompletionClient) completeOpenAIChat(
 		endpoint: joinEndpoint(request.Model.BaseURL, "/chat/completions"),
 		result:   &CompletionResult{Text: "", Thinking: nil, ToolEvents: nil, Usage: model.EmptyTokenUsage()},
 	}
-	for range maxToolIterations {
+	for {
 		finished, err := client.advanceOpenAIChatLoop(ctx, request, &state)
 		if err != nil {
 			return nil, err
@@ -29,8 +29,6 @@ func (client *HTTPCompletionClient) completeOpenAIChat(
 			return state.result, nil
 		}
 	}
-
-	return nil, toolIterationLimitError()
 }
 
 type openAIChatLoopState struct {

--- a/internal/assistant/tool_schema.go
+++ b/internal/assistant/tool_schema.go
@@ -3,12 +3,8 @@ package assistant
 import (
 	"encoding/json"
 
-	"github.com/samber/oops"
-
 	"github.com/omarluq/librecode/internal/tool"
 )
-
-const maxToolIterations = 8
 
 func responseTools() []map[string]any {
 	definitions := tool.AllDefinitions()
@@ -53,10 +49,6 @@ func toolArgumentsFromJSON(argumentsJSON string) map[string]any {
 	}
 
 	return arguments
-}
-
-func toolIterationLimitError() error {
-	return oops.In("assistant").Code("tool_iteration_limit").Errorf("tool iteration limit reached")
 }
 
 func toolParameterSchema(name tool.Name) map[string]any {


### PR DESCRIPTION
## Summary
- remove the fixed tool iteration cap for OpenAI Chat and Anthropic tool loops
- let tool loops continue until the provider returns final output or the context is canceled

## Validation
- mise exec -- go test ./...
- mise exec -- task build
- mise exec -- task ci