### PR TITLE
feat(tool): unify extension registry

### DIFF
--- a/internal/assistant/anthropic.go
+++ b/internal/assistant/anthropic.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/omarluq/librecode/internal/database"
 	"github.com/omarluq/librecode/internal/model"
-	"github.com/omarluq/librecode/internal/tool"
 )
 
 func (client *HTTPCompletionClient) completeAnthropic(
@@ -76,7 +75,7 @@ func executeAnthropicToolCalls(
 ) []ToolEvent {
 	_, events := executeToolCalls(
 		ctx,
-		request.CWD,
+		request.ToolRegistry,
 		calls,
 		request.OnEvent,
 		request.OnToolCall,
@@ -406,13 +405,13 @@ func anthropicMessages(messages []database.MessageEntity) []map[string]any {
 }
 
 func anthropicTools(request *CompletionRequest) []map[string]any {
-	definitions := tool.AllDefinitions()
+	definitions := requestToolDefinitions(request)
 	tools := make([]map[string]any, 0, len(definitions))
 	for _, definition := range definitions {
 		tools = append(tools, map[string]any{
 			jsonToolNameKey:         anthropicProviderToolName(string(definition.Name), usesAnthropicOAuth(request)),
 			jsonDescriptionKey:      definition.Description,
-			jsonInputSchemaKey:      toolParameterSchema(definition.Name),
+			jsonInputSchemaKey:      toolParameterSchema(&definition),
 			"eager_input_streaming": true,
 		})
 	}

--- a/internal/assistant/anthropic_internal_test.go
+++ b/internal/assistant/anthropic_internal_test.go
@@ -168,6 +168,7 @@ func testCompletionRequestAuth(args ...string) *CompletionRequest {
 		OnEvent:       nil,
 		OnToolCall:    nil,
 		OnToolResult:  nil,
+		ToolRegistry:  nil,
 		SessionID:     "",
 		SystemPrompt:  "",
 		ThinkingLevel: "",

--- a/internal/assistant/anthropic_internal_test.go
+++ b/internal/assistant/anthropic_internal_test.go
@@ -1,6 +1,7 @@
 package assistant
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,6 +43,10 @@ func TestAnthropicOAuthPayloadAddsClaudeCodeIdentity(t *testing.T) {
 	assert.Len(t, systemBlocks, 2)
 	assert.Contains(t, systemBlocks[0]["text"], "Claude Code")
 	assert.Equal(t, anthropicTestSystemPrompt, systemBlocks[1][jsonTextKey])
+	encodedTools := encodeTestJSON(t, payload["tools"])
+	assert.Contains(t, encodedTools, `"name":"Read"`)
+	assert.Contains(t, encodedTools, `"name":"Write"`)
+	assert.Contains(t, encodedTools, `"eager_input_streaming":true`)
 }
 
 func TestAnthropicPayloadAddsBudgetThinking(t *testing.T) {
@@ -71,6 +76,30 @@ func TestAnthropicPayloadDisablesThinkingWhenOff(t *testing.T) {
 
 	assert.Equal(t, map[string]any{jsonTypeKey: "disabled"}, payload[jsonThinkingKey])
 	assert.NotContains(t, payload, "output_config")
+}
+
+func TestAnthropicPayloadUsesLocalToolNamesForAPIKey(t *testing.T) {
+	t.Parallel()
+
+	payload := anthropicPayload(testCompletionRequestAuth("sk-ant-api03-secret"), nil)
+
+	encodedTools := encodeTestJSON(t, payload["tools"])
+	assert.Contains(t, encodedTools, `"name":"`+jsonReadToolName+`"`)
+	assert.Contains(t, encodedTools, `"name":"`+jsonWriteToolName+`"`)
+	assert.NotContains(t, encodedTools, `"name":"`+anthropicReadToolName+`"`)
+}
+
+func TestAnthropicToolCallMapsClaudeCodeNamesToLocalNames(t *testing.T) {
+	t.Parallel()
+
+	call := anthropicToolCall(testAnthropicToolUseID, "Write", map[string]any{
+		jsonPathKey:    "hello.txt",
+		jsonContentKey: "hello",
+	})
+
+	assert.Equal(t, jsonWriteToolName, call.Name)
+	assert.Equal(t, "hello.txt", call.Arguments[jsonPathKey])
+	assert.Equal(t, "hello", call.Arguments[jsonContentKey])
 }
 
 func TestAnthropicPayloadAddsAdaptiveThinking(t *testing.T) {
@@ -113,6 +142,15 @@ func TestAnthropicHeadersUseBearerForOAuth(t *testing.T) {
 	assert.Contains(t, headers["anthropic-beta"], "claude-code-20250219")
 	assert.Contains(t, headers["anthropic-beta"], "oauth-2025-04-20")
 	assert.NotContains(t, headers["anthropic-beta"], "interleaved-thinking-2025-05-14")
+}
+
+func encodeTestJSON(t *testing.T, value any) string {
+	t.Helper()
+
+	encoded, err := json.Marshal(value)
+	assert.NoError(t, err)
+
+	return string(encoded)
 }
 
 func testCompletionRequestAuth(args ...string) *CompletionRequest {

--- a/internal/assistant/client.go
+++ b/internal/assistant/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/omarluq/librecode/internal/database"
 	"github.com/omarluq/librecode/internal/model"
+	"github.com/omarluq/librecode/internal/tool"
 )
 
 const (
@@ -84,6 +85,7 @@ type CompletionRequest struct {
 	OnEvent       func(StreamEvent)                    `json:"-"`
 	OnToolCall    func(context.Context, ToolCallEvent) `json:"-"`
 	OnToolResult  func(context.Context, *ToolEvent)    `json:"-"`
+	ToolRegistry  *tool.Registry                       `json:"-"`
 	SessionID     string                               `json:"session_id"`
 	SystemPrompt  string                               `json:"system_prompt"`
 	ThinkingLevel string                               `json:"thinking_level"`

--- a/internal/assistant/openai_chat.go
+++ b/internal/assistant/openai_chat.go
@@ -78,7 +78,7 @@ func executeOpenAIChatToolCalls(
 ) []ToolEvent {
 	_, events := executeToolCalls(
 		ctx,
-		request.CWD,
+		request.ToolRegistry,
 		calls,
 		request.OnEvent,
 		request.OnToolCall,
@@ -116,7 +116,7 @@ func openAIChatPayload(request *CompletionRequest, messages []map[string]any) ma
 		"messages":        messages,
 		"stream":          false,
 		"temperature":     0.2,
-		"tools":           openAIChatTools(),
+		"tools":           openAIChatTools(request),
 		jsonToolChoiceKey: "auto",
 	}
 	if request.Model.Reasoning && request.ThinkingLevel != "" && request.ThinkingLevel != thinkingOff {

--- a/internal/assistant/openai_responses.go
+++ b/internal/assistant/openai_responses.go
@@ -60,7 +60,7 @@ func (client *HTTPCompletionClient) completeResponsesLoop(
 		input = append(input, statelessResponseOutputItems(providerResult.OutputItems)...)
 		outputs, events := executeToolCalls(
 			ctx,
-			request.CWD,
+			request.ToolRegistry,
 			providerResult.ToolCalls,
 			request.OnEvent,
 			request.OnToolCall,
@@ -73,7 +73,7 @@ func (client *HTTPCompletionClient) completeResponsesLoop(
 
 func responsesPayload(request *CompletionRequest, input []any, stream bool) map[string]any {
 	payload := responsesBasePayload(request, input, stream)
-	payload["tools"] = responseTools()
+	payload["tools"] = responseTools(request)
 	payload[jsonToolChoiceKey] = "auto"
 	payload["parallel_tool_calls"] = true
 

--- a/internal/assistant/runtime.go
+++ b/internal/assistant/runtime.go
@@ -543,7 +543,10 @@ func (runtime *Runtime) loadSkillWithReadTool(
 	skill *core.Skill,
 	limit *int,
 ) (string, ToolEvent, error) {
-	registry := tool.NewRegistry(cwd)
+	registry, err := newToolRegistry(cwd, runtime.extensions)
+	if err != nil {
+		return "", ToolEvent{}, err
+	}
 	input := map[string]any{jsonPathKey: skill.FilePath}
 	if limit != nil {
 		input["limit"] = *limit
@@ -581,7 +584,10 @@ func (runtime *Runtime) respondToToolCommand(ctx context.Context, cwd, args stri
 		payload = "{}"
 	}
 
-	registry := tool.NewRegistry(cwd)
+	registry, err := newToolRegistry(cwd, runtime.extensions)
+	if err != nil {
+		return "", err
+	}
 	result, err := registry.ExecuteJSON(ctx, toolName, []byte(payload))
 	if err != nil {
 		return "", oops.
@@ -621,6 +627,10 @@ func (runtime *Runtime) modelResponse(
 		return nil, err
 	}
 	runtime.emitUsage(ctx, onEvent, contextResult.Usage)
+	registry, err := newToolRegistry(cwd, runtime.extensions)
+	if err != nil {
+		return nil, err
+	}
 	request := runtime.modelCompletionRequest(
 		&selectedModel,
 		auth,
@@ -628,6 +638,7 @@ func (runtime *Runtime) modelResponse(
 		sessionID,
 		contextResult.SystemPrompt,
 		cwd,
+		registry,
 		onEvent,
 	)
 	result, err := runtime.completeWithRetry(ctx, request, onRetry)
@@ -652,12 +663,14 @@ func (runtime *Runtime) modelCompletionRequest(
 	sessionID string,
 	systemPrompt string,
 	cwd string,
+	registry *tool.Registry,
 	onEvent func(StreamEvent),
 ) *CompletionRequest {
 	return &CompletionRequest{
 		OnEvent:       onEvent,
 		OnToolCall:    runtime.emitToolCall,
 		OnToolResult:  runtime.emitToolResult,
+		ToolRegistry:  registry,
 		SessionID:     sessionID,
 		SystemPrompt:  systemPrompt,
 		ThinkingLevel: runtime.cfg.Assistant.ThinkingLevel,

--- a/internal/assistant/tool_loop.go
+++ b/internal/assistant/tool_loop.go
@@ -31,13 +31,15 @@ func validateToolCalls(calls []toolCall) error {
 
 func executeToolCalls(
 	ctx context.Context,
-	cwd string,
+	registry *tool.Registry,
 	calls []toolCall,
 	onEvent func(StreamEvent),
 	onToolCall func(context.Context, ToolCallEvent),
 	onToolResult func(context.Context, *ToolEvent),
 ) ([]any, []ToolEvent) {
-	registry := tool.NewRegistry(cwd)
+	if registry == nil {
+		registry = tool.NewRegistry("")
+	}
 	outputs := make([]any, 0, len(calls))
 	events := make([]ToolEvent, 0, len(calls))
 	for _, call := range calls {

--- a/internal/assistant/tool_loop_test.go
+++ b/internal/assistant/tool_loop_test.go
@@ -7,9 +7,20 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/tool"
 )
 
 const testCallID = "call-1"
+
+func newToolRegistryForTest(t *testing.T) *tool.Registry {
+	t.Helper()
+
+	registry, err := newToolRegistry(t.TempDir(), nil)
+	require.NoError(t, err)
+
+	return registry
+}
 
 func TestValidateToolCallsRejectsMissingFields(t *testing.T) {
 	t.Parallel()
@@ -45,7 +56,7 @@ func TestExecuteToolCallsInvokesCallbacksAndStreamsEvents(t *testing.T) {
 	toolResults := []ToolEvent{}
 	outputs, events := executeToolCalls(
 		context.Background(),
-		t.TempDir(),
+		newToolRegistryForTest(t),
 		[]toolCall{{
 			Arguments:     map[string]any{jsonPathKey: "missing.txt"},
 			ID:            testCallID,

--- a/internal/assistant/tool_registry.go
+++ b/internal/assistant/tool_registry.go
@@ -1,0 +1,25 @@
+package assistant
+
+import (
+	"github.com/samber/oops"
+
+	"github.com/omarluq/librecode/internal/extension"
+	"github.com/omarluq/librecode/internal/tool"
+)
+
+type toolProvider interface {
+	Tools() []extension.Tool
+	tool.ExtensionToolRunner
+}
+
+func newToolRegistry(cwd string, provider toolProvider) (*tool.Registry, error) {
+	registry := tool.NewRegistry(cwd)
+	if provider == nil {
+		return registry, nil
+	}
+	if err := registry.RegisterExtensions(provider, provider.Tools()); err != nil {
+		return nil, oops.In("assistant").Code("register_extension_tools").Wrapf(err, "register extension tools")
+	}
+
+	return registry, nil
+}

--- a/internal/assistant/tool_registry_test.go
+++ b/internal/assistant/tool_registry_test.go
@@ -1,0 +1,148 @@
+package assistant_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/assistant"
+	"github.com/omarluq/librecode/internal/model"
+	"github.com/omarluq/librecode/internal/tool"
+)
+
+func TestRuntimeRegistersExtensionToolsInModelRegistry(t *testing.T) {
+	t.Parallel()
+
+	client := newExtensionToolCompletionClient()
+	runtime, _, manager := newTestRuntimeWithManager(t, client)
+	loadRuntimeExtension(t, manager, echoToolExtensionSource())
+
+	_, err := runtime.Prompt(context.Background(), newRuntimePromptRequest(testRuntimeCWD, "use echo", ""))
+	require.NoError(t, err)
+
+	assert.Contains(t, toolDefinitionNames(*client.definitions), "echo")
+	assert.Equal(t, "hello", *client.toolResult)
+	assert.Equal(t, true, (*client.toolDetails)["seen"])
+}
+
+func TestRuntimeRejectsExtensionToolNameCollision(t *testing.T) {
+	t.Parallel()
+
+	runtime, _, manager := newTestRuntimeWithManager(t, testCompletionClient{})
+	loadRuntimeExtension(t, manager, `
+local lc = require("librecode")
+lc.register_tool("read", "collides", function()
+  return { content = "bad" }
+end)
+`)
+
+	_, err := runtime.Prompt(context.Background(), newRuntimePromptRequest(testRuntimeCWD, "hello", ""))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate tool")
+}
+
+func TestExtensionToolSchemaIsVisibleInRegistryDefinitions(t *testing.T) {
+	t.Parallel()
+
+	client := newExtensionToolCompletionClient()
+	runtime, _, manager := newTestRuntimeWithManager(t, client)
+	loadRuntimeExtension(t, manager, echoToolExtensionSource())
+
+	_, err := runtime.Prompt(context.Background(), newRuntimePromptRequest(testRuntimeCWD, "schema", ""))
+	require.NoError(t, err)
+
+	definition := findToolDefinition(t, *client.definitions, "echo")
+	properties, ok := definition.Schema["properties"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, properties, "text")
+}
+
+type extensionToolCompletionClient struct {
+	toolDetails *map[string]any
+	definitions *[]tool.Definition
+	toolResult  *string
+}
+
+func newExtensionToolCompletionClient() *extensionToolCompletionClient {
+	definitions := []tool.Definition{}
+	toolDetails := map[string]any{}
+	toolResult := ""
+
+	return &extensionToolCompletionClient{
+		toolDetails: &toolDetails,
+		definitions: &definitions,
+		toolResult:  &toolResult,
+	}
+}
+
+func (client *extensionToolCompletionClient) Complete(
+	ctx context.Context,
+	request *assistant.CompletionRequest,
+) (*assistant.CompletionResult, error) {
+	if request.ToolRegistry == nil {
+		return nil, errors.New("missing tool registry")
+	}
+	*client.definitions = request.ToolRegistry.Definitions()
+	result, err := request.ToolRegistry.Execute(ctx, "echo", map[string]any{"text": "hello"})
+	if err != nil {
+		return nil, err
+	}
+	*client.toolResult = result.Text()
+	*client.toolDetails = result.Details
+
+	return &assistant.CompletionResult{
+		Text:       "tool registry inspected",
+		Thinking:   nil,
+		ToolEvents: nil,
+		Usage:      model.EmptyTokenUsage(),
+	}, nil
+}
+
+func echoToolExtensionSource() string {
+	return `
+local lc = require("librecode")
+lc.register_tool("echo", "Echo text", function(args)
+  return { content = args.text, details = { seen = true } }
+end, {
+  type = "object",
+  properties = {
+    text = { type = "string", description = "Text to echo" },
+  },
+  required = { "text" },
+})
+`
+}
+
+func toolDefinitionNames(definitions []tool.Definition) []string {
+	names := make([]string, 0, len(definitions))
+	for _, definition := range definitions {
+		names = append(names, string(definition.Name))
+	}
+
+	return names
+}
+
+func findToolDefinition(t *testing.T, definitions []tool.Definition, name string) tool.Definition {
+	t.Helper()
+
+	for _, definition := range definitions {
+		if definition.Name == tool.Name(name) {
+			return definition
+		}
+	}
+	require.Failf(t, "tool definition not found", "name=%s", name)
+
+	return tool.Definition{
+		Schema:           nil,
+		Name:             "",
+		Label:            "",
+		Description:      "",
+		PromptSnippet:    "",
+		PromptGuidelines: nil,
+		ReadOnly:         false,
+	}
+}

--- a/internal/assistant/tool_schema.go
+++ b/internal/assistant/tool_schema.go
@@ -6,15 +6,15 @@ import (
 	"github.com/omarluq/librecode/internal/tool"
 )
 
-func responseTools() []map[string]any {
-	definitions := tool.AllDefinitions()
+func responseTools(request *CompletionRequest) []map[string]any {
+	definitions := requestToolDefinitions(request)
 	tools := make([]map[string]any, 0, len(definitions))
 	for _, definition := range definitions {
 		tools = append(tools, map[string]any{
 			jsonTypeKey:        functionToolType,
 			jsonToolNameKey:    string(definition.Name),
 			jsonDescriptionKey: definition.Description,
-			jsonToolParamsKey:  toolParameterSchema(definition.Name),
+			jsonToolParamsKey:  toolParameterSchema(&definition),
 			"strict":           false,
 		})
 	}
@@ -22,8 +22,8 @@ func responseTools() []map[string]any {
 	return tools
 }
 
-func openAIChatTools() []map[string]any {
-	definitions := tool.AllDefinitions()
+func openAIChatTools(request *CompletionRequest) []map[string]any {
+	definitions := requestToolDefinitions(request)
 	tools := make([]map[string]any, 0, len(definitions))
 	for _, definition := range definitions {
 		tools = append(tools, map[string]any{
@@ -31,12 +31,20 @@ func openAIChatTools() []map[string]any {
 			"function": map[string]any{
 				jsonToolNameKey:    string(definition.Name),
 				jsonDescriptionKey: definition.Description,
-				jsonToolParamsKey:  toolParameterSchema(definition.Name),
+				jsonToolParamsKey:  toolParameterSchema(&definition),
 			},
 		})
 	}
 
 	return tools
+}
+
+func requestToolDefinitions(request *CompletionRequest) []tool.Definition {
+	if request != nil && request.ToolRegistry != nil {
+		return request.ToolRegistry.Definitions()
+	}
+
+	return tool.AllDefinitions()
 }
 
 func toolArgumentsFromJSON(argumentsJSON string) map[string]any {
@@ -51,30 +59,36 @@ func toolArgumentsFromJSON(argumentsJSON string) map[string]any {
 	return arguments
 }
 
-func toolParameterSchema(name tool.Name) map[string]any {
-	var schema map[string]any
-	switch name {
-	case tool.NameRead:
-		schema = readToolSchema()
-	case tool.NameBash:
-		schema = bashToolSchema()
-	case tool.NameEdit:
-		schema = editToolSchema()
-	case tool.NameWrite:
-		schema = writeToolSchema()
-	case tool.NameGrep:
-		schema = grepToolSchema()
-	case tool.NameFind:
-		schema = findToolSchema()
-	case tool.NameLS:
-		schema = lsToolSchema()
+var builtinToolSchemas = map[tool.Name]func() map[string]any{
+	tool.NameRead:  readToolSchema,
+	tool.NameBash:  bashToolSchema,
+	tool.NameEdit:  editToolSchema,
+	tool.NameWrite: writeToolSchema,
+	tool.NameGrep:  grepToolSchema,
+	tool.NameFind:  findToolSchema,
+	tool.NameLS:    lsToolSchema,
+}
+
+func toolParameterSchema(definition *tool.Definition) map[string]any {
+	if definition != nil && len(definition.Schema) > 0 {
+		return cloneToolSchema(definition.Schema)
 	}
-	if schema == nil {
-		return map[string]any{jsonTypeKey: jsonObjectType, "additionalProperties": true}
+	if definition == nil {
+		return freeformToolSchema()
 	}
+
+	factory, ok := builtinToolSchemas[definition.Name]
+	if !ok {
+		return freeformToolSchema()
+	}
+	schema := factory()
 	schema["additionalProperties"] = false
 
 	return schema
+}
+
+func freeformToolSchema() map[string]any {
+	return map[string]any{jsonTypeKey: jsonObjectType, "additionalProperties": true}
 }
 
 func readToolSchema() map[string]any {
@@ -179,6 +193,15 @@ func lsToolSchema() map[string]any {
 			jsonLimitKey: integerSchema("Optional maximum number of entries."),
 		},
 	}
+}
+
+func cloneToolSchema(schema map[string]any) map[string]any {
+	clone := make(map[string]any, len(schema))
+	for key, value := range schema {
+		clone[key] = value
+	}
+
+	return clone
 }
 
 func stringSchema(description string) map[string]any {

--- a/internal/assistant/tool_schema.go
+++ b/internal/assistant/tool_schema.go
@@ -137,9 +137,9 @@ func writeToolSchema() map[string]any {
 			jsonPathKey: stringSchema(
 				"Path to create or overwrite, relative to the current workspace or absolute.",
 			),
-			"content": stringSchema("Complete file content to write."),
+			jsonContentKey: stringSchema("Complete file content to write."),
 		},
-		jsonRequiredKey: []string{jsonPathKey, "content"},
+		jsonRequiredKey: []string{jsonPathKey, jsonContentKey},
 	}
 }
 

--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -500,7 +500,12 @@ func (manager *Manager) luaRegisterCommand(extensionRuntime *luaExtension) lua.L
 func (manager *Manager) luaRegisterTool(extensionRuntime *luaExtension) lua.LGFunction {
 	return func(state *lua.LState) int {
 		name, description, function := luaRegistrationArgs(state)
-		definition := Tool{Name: name, Description: description, Extension: extensionRuntime.name}
+		definition := Tool{
+			InputSchema: luaOptionalSchema(state, 4),
+			Name:        name,
+			Description: description,
+			Extension:   extensionRuntime.name,
+		}
 
 		manager.lock.Lock()
 		manager.tools[name] = luaTool{extension: extensionRuntime, function: function, definition: definition}
@@ -536,6 +541,17 @@ func (manager *Manager) luaLog(extensionRuntime *luaExtension) lua.LGFunction {
 
 func luaRegistrationArgs(state *lua.LState) (name, description string, function *lua.LFunction) {
 	return state.CheckString(1), state.OptString(2, ""), state.CheckFunction(3)
+}
+
+func luaOptionalSchema(state *lua.LState, index int) map[string]any {
+	if state.GetTop() < index {
+		return map[string]any{}
+	}
+	if table, ok := state.Get(index).(*lua.LTable); ok {
+		return luaTableToMap(table)
+	}
+
+	return map[string]any{}
 }
 
 func luaEventHandlerArgs(state *lua.LState) (priority int, function *lua.LFunction) {

--- a/internal/extension/manager_test.go
+++ b/internal/extension/manager_test.go
@@ -564,6 +564,7 @@ func assertLoadedTool(t *testing.T, tools []extension.Tool, extensionName string
 
 	require.Len(t, tools, 1)
 	assert.Equal(t, extension.Tool{
+		InputSchema: map[string]any{},
 		Name:        "echo",
 		Description: "Echo text",
 		Extension:   extensionName,

--- a/internal/extension/types.go
+++ b/internal/extension/types.go
@@ -13,11 +13,12 @@ type Command struct {
 	Extension   string `json:"extension"`
 }
 
-// Tool describes a Lua-provided tool callable by the runtime.
+// Tool describes an extension-provided tool callable by the runtime.
 type Tool struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Extension   string `json:"extension"`
+	InputSchema map[string]any `json:"input_schema"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Extension   string         `json:"extension"`
 }
 
 // ToolResult is returned from Lua tool handlers.

--- a/internal/tool/bash.go
+++ b/internal/tool/bash.go
@@ -38,6 +38,7 @@ func NewBashTool(cwd string) *BashTool {
 // Definition returns bash tool metadata.
 func (bashTool *BashTool) Definition() Definition {
 	return Definition{
+		Schema:        nil,
 		Name:          NameBash,
 		Label:         "bash",
 		Description:   bashDescription(),

--- a/internal/tool/edit.go
+++ b/internal/tool/edit.go
@@ -28,6 +28,7 @@ func NewEditTool(cwd string) *EditTool {
 // Definition returns edit tool metadata.
 func (editTool *EditTool) Definition() Definition {
 	return Definition{
+		Schema:        nil,
 		Name:          NameEdit,
 		Label:         "edit",
 		Description:   editDescription(),

--- a/internal/tool/extension.go
+++ b/internal/tool/extension.go
@@ -1,0 +1,60 @@
+package tool
+
+import (
+	"context"
+
+	"github.com/omarluq/librecode/internal/extension"
+)
+
+// ExtensionToolRunner runs one named extension-provided tool.
+type ExtensionToolRunner interface {
+	ExecuteTool(ctx context.Context, name string, args map[string]any) (extension.ToolResult, error)
+}
+
+// ExtensionExecutor adapts an extension-provided tool to the core tool executor interface.
+type ExtensionExecutor struct {
+	runner     ExtensionToolRunner
+	definition Definition
+}
+
+// NewExtensionExecutor creates a core tool executor for an extension-provided tool.
+func NewExtensionExecutor(definition extension.Tool, runner ExtensionToolRunner) *ExtensionExecutor {
+	return &ExtensionExecutor{
+		runner: runner,
+		definition: Definition{
+			Schema:           definition.InputSchema,
+			Name:             Name(definition.Name),
+			Label:            definition.Name,
+			Description:      definition.Description,
+			PromptSnippet:    "",
+			PromptGuidelines: []string{},
+			ReadOnly:         false,
+		},
+	}
+}
+
+// Definition returns model-visible extension tool metadata.
+func (executor *ExtensionExecutor) Definition() Definition {
+	return executor.definition
+}
+
+// Execute runs the extension tool and converts its result into the core tool result shape.
+func (executor *ExtensionExecutor) Execute(ctx context.Context, input map[string]any) (Result, error) {
+	result, err := executor.runner.ExecuteTool(ctx, string(executor.definition.Name), input)
+	if err != nil {
+		return emptyToolResult(), err
+	}
+
+	return TextResult(result.Content, result.Details), nil
+}
+
+// RegisterExtensions registers extension-provided tools on a core registry.
+func (registry *Registry) RegisterExtensions(runner ExtensionToolRunner, definitions []extension.Tool) error {
+	for _, definition := range definitions {
+		if err := registry.Register(NewExtensionExecutor(definition, runner)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/tool/find.go
+++ b/internal/tool/find.go
@@ -38,6 +38,7 @@ func NewFindTool(cwd string) *FindTool {
 // Definition returns find tool metadata.
 func (findTool *FindTool) Definition() Definition {
 	return Definition{
+		Schema:        nil,
 		Name:          NameFind,
 		Label:         "find",
 		Description:   findDescription(),

--- a/internal/tool/grep.go
+++ b/internal/tool/grep.go
@@ -59,6 +59,7 @@ func NewGrepTool(cwd string) *GrepTool {
 // Definition returns grep tool metadata.
 func (grepTool *GrepTool) Definition() Definition {
 	return Definition{
+		Schema:        nil,
 		Name:          NameGrep,
 		Label:         "grep",
 		Description:   grepDescription(),

--- a/internal/tool/ls.go
+++ b/internal/tool/ls.go
@@ -32,6 +32,7 @@ func NewLSTool(cwd string) *LSTool {
 // Definition returns ls tool metadata.
 func (lsTool *LSTool) Definition() Definition {
 	return Definition{
+		Schema:        nil,
 		Name:          NameLS,
 		Label:         "ls",
 		Description:   lsDescription(),

--- a/internal/tool/read.go
+++ b/internal/tool/read.go
@@ -33,6 +33,7 @@ func NewReadTool(cwd string) *ReadTool {
 // Definition returns read tool metadata.
 func (readTool *ReadTool) Definition() Definition {
 	return Definition{
+		Schema:        nil,
 		Name:          NameRead,
 		Label:         "read",
 		Description:   readDescription(),

--- a/internal/tool/registry.go
+++ b/internal/tool/registry.go
@@ -13,6 +13,9 @@ import (
 // ErrUnknownTool is returned when a registry cannot resolve a tool name.
 var ErrUnknownTool = errors.New("tool: unknown tool")
 
+// ErrDuplicateTool is returned when a registry already has an executor for a tool name.
+var ErrDuplicateTool = errors.New("tool: duplicate tool")
+
 // Registry owns built-in tool executors for a working directory.
 type Registry struct {
 	executors map[Name]Executor
@@ -42,6 +45,21 @@ func NewRegistry(cwd string) *Registry {
 // CWD returns the registry working directory.
 func (registry *Registry) CWD() string {
 	return registry.cwd
+}
+
+// Register adds a tool executor to the registry.
+func (registry *Registry) Register(executor Executor) error {
+	definition := executor.Definition()
+	if _, exists := registry.executors[definition.Name]; exists {
+		return oops.
+			In("tool").
+			Code("duplicate_tool").
+			With("tool", definition.Name).
+			Wrapf(ErrDuplicateTool, "register tool")
+	}
+	registry.executors[definition.Name] = executor
+
+	return nil
 }
 
 // Definitions returns sorted tool definitions.

--- a/internal/tool/registry_test.go
+++ b/internal/tool/registry_test.go
@@ -66,6 +66,19 @@ func TestRegistry_ExecuteJSONRunsBashInWorkingDirectory(t *testing.T) {
 	assert.Contains(t, result.Text(), "ok")
 }
 
+func TestRegistry_ExecuteJSONRejectsEmptyWriteContent(t *testing.T) {
+	t.Parallel()
+
+	registry := tool.NewRegistry(t.TempDir())
+	payload, err := json.Marshal(map[string]any{"path": "empty.txt", "content": ""})
+	require.NoError(t, err)
+
+	_, err = registry.ExecuteJSON(context.Background(), "write", payload)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write content is required")
+}
+
 func executeTool(
 	ctx context.Context,
 	t *testing.T,

--- a/internal/tool/registry_test.go
+++ b/internal/tool/registry_test.go
@@ -3,6 +3,7 @@ package tool_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,6 +65,17 @@ func TestRegistry_ExecuteJSONRunsBashInWorkingDirectory(t *testing.T) {
 	})
 
 	assert.Contains(t, result.Text(), "ok")
+}
+
+func TestRegistry_RegisterRejectsDuplicateTool(t *testing.T) {
+	t.Parallel()
+
+	registry := tool.NewRegistry(t.TempDir())
+
+	err := registry.Register(tool.NewReadTool(t.TempDir()))
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, tool.ErrDuplicateTool))
 }
 
 func TestRegistry_ExecuteJSONRejectsEmptyWriteContent(t *testing.T) {

--- a/internal/tool/types.go
+++ b/internal/tool/types.go
@@ -37,12 +37,13 @@ const (
 
 // Definition describes a built-in coding tool.
 type Definition struct {
-	Name             Name     `json:"name"`
-	Label            string   `json:"label"`
-	Description      string   `json:"description"`
-	PromptSnippet    string   `json:"prompt_snippet"`
-	PromptGuidelines []string `json:"prompt_guidelines"`
-	ReadOnly         bool     `json:"read_only"`
+	Schema           map[string]any `json:"schema"`
+	Name             Name           `json:"name"`
+	Label            string         `json:"label"`
+	Description      string         `json:"description"`
+	PromptSnippet    string         `json:"prompt_snippet"`
+	PromptGuidelines []string       `json:"prompt_guidelines"`
+	ReadOnly         bool           `json:"read_only"`
 }
 
 // ContentBlock is one model-facing piece of tool output.

--- a/internal/tool/write.go
+++ b/internal/tool/write.go
@@ -55,6 +55,9 @@ func (writeTool *WriteTool) Write(ctx context.Context, input WriteInput) (Result
 	if strings.TrimSpace(input.Path) == "" {
 		return emptyToolResult(), oops.In("tool").Code("write_path_required").Errorf("write path is required")
 	}
+	if strings.TrimSpace(input.Content) == "" {
+		return emptyToolResult(), oops.In("tool").Code("write_content_required").Errorf("write content is required")
+	}
 	absolutePath, err := ResolveToCWD(input.Path, writeTool.cwd)
 	if err != nil {
 		return emptyToolResult(), oops.In("tool").Code("write_resolve_path").Wrapf(err, "resolve write path")

--- a/internal/tool/write.go
+++ b/internal/tool/write.go
@@ -29,6 +29,7 @@ func NewWriteTool(cwd string) *WriteTool {
 // Definition returns write tool metadata.
 func (writeTool *WriteTool) Definition() Definition {
 	return Definition{
+		Schema:        nil,
 		Name:          NameWrite,
 		Label:         "write",
 		Description:   "Write content to a file. Creates parent directories and overwrites existing files.",


### PR DESCRIPTION
## Summary
- register extension-provided tools in the same runtime tool registry as built-ins
- advertise extension tool schemas to OpenAI/Anthropic provider payloads
- execute extension tools through the normal assistant tool loop

## Validation
- mise exec -- task ci

Stacked after #35.