### PR TITLE
feat(extension): add provider lifecycle hooks

### DIFF
--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -748,7 +748,25 @@ end)
 
 Lifecycle payloads are intentionally bounded. `message_append` includes the appended entry text and metadata for the current message, but lifecycle events do not include full transcript history.
 
-`context_build` is the first lifecycle seam with a mutation contract. Handlers may return bounded `contributions` entries. Each contribution must include non-empty `content` and is capped by the host. The context payload exposes `breakdown.system`, `breakdown.skills`, `breakdown.history`, and `breakdown.extensions` token estimates so extensions can reason about context budget without seeing the full transcript.
+`context_build` has a bounded mutation contract. Handlers may return `contributions` entries. Each contribution must include non-empty `content` and is capped by the host. The context payload exposes `breakdown.system`, `breakdown.skills`, `breakdown.history`, and `breakdown.extensions` token estimates so extensions can reason about context budget without seeing the full transcript.
+
+`before_provider_request` has a conservative mutation contract. The payload exposes request metadata, a redacted header map, and a provider `payload` object. Handlers may return a modified `payload` and `provider_request.headers` for non-sensitive headers:
+
+```lua
+lc.on("before_provider_request", function(event)
+  event.payload.payload.metadata = "debug-marker"
+  return {
+    payload = event.payload,
+    provider_request = {
+      headers = {
+        ["X-Debug-Run"] = "local",
+      },
+    },
+  }
+end)
+```
+
+Sensitive headers such as `Authorization`, `x-api-key`, `cookie`, and `proxy-authorization` are redacted in payloads and cannot be modified by provider hooks.
 
 ## Current limitations
 

--- a/internal/assistant/anthropic.go
+++ b/internal/assistant/anthropic.go
@@ -118,10 +118,10 @@ func anthropicPayload(request *CompletionRequest, messages []map[string]any) map
 	// reasoning is available. Match production agent clients by omitting
 	// temperature unless/until librecode exposes an explicit user setting.
 	payload := map[string]any{
-		jsonModelKey: request.Model.ID,
-		"max_tokens": minPositive(request.Model.MaxTokens, 4096),
-		"messages":   messages,
-		"tools":      anthropicTools(request),
+		jsonModelKey:    request.Model.ID,
+		"max_tokens":    minPositive(request.Model.MaxTokens, 4096),
+		jsonMessagesKey: messages,
+		"tools":         anthropicTools(request),
 	}
 	if usesAnthropicOAuth(request) {
 		payload["system"] = anthropicOAuthSystemPrompt(request.SystemPrompt)
@@ -282,7 +282,12 @@ func (client *HTTPCompletionClient) requestAnthropic(
 	request *CompletionRequest,
 	payload map[string]any,
 ) (*providerResult, error) {
-	content, err := client.postJSON(ctx, endpoint, anthropicHeaders(request), payload)
+	headers := anthropicHeaders(request)
+	providerRequest, err := applyProviderRequestHook(ctx, request, payload, headers)
+	if err != nil {
+		return nil, err
+	}
+	content, err := client.postJSON(ctx, endpoint, providerRequest.Headers, providerRequest.Payload)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/assistant/anthropic_internal_test.go
+++ b/internal/assistant/anthropic_internal_test.go
@@ -191,17 +191,19 @@ func testCompletionRequestAuth(args ...string) *CompletionRequest {
 	}
 
 	return &CompletionRequest{
-		OnEvent:       nil,
-		OnToolCall:    nil,
-		OnToolResult:  nil,
-		ToolRegistry:  nil,
-		SessionID:     "",
-		SystemPrompt:  "",
-		ThinkingLevel: "",
-		CWD:           "",
-		Auth:          testRequestAuth(apiKey),
-		Messages:      nil,
-		Usage:         model.EmptyTokenUsage(),
+		OnEvent:           nil,
+		OnProviderObserve: nil,
+		OnProviderRequest: nil,
+		OnToolCall:        nil,
+		OnToolResult:      nil,
+		ToolRegistry:      nil,
+		SessionID:         "",
+		SystemPrompt:      "",
+		ThinkingLevel:     "",
+		CWD:               "",
+		Auth:              testRequestAuth(apiKey),
+		Messages:          nil,
+		Usage:             model.EmptyTokenUsage(),
 		Model: model.Model{
 			ThinkingLevelMap: nil,
 			Headers:          nil,
@@ -217,6 +219,7 @@ func testCompletionRequestAuth(args ...string) *CompletionRequest {
 			MaxTokens:        0,
 			Reasoning:        false,
 		},
+		ProviderAttempt: 0,
 	}
 }
 

--- a/internal/assistant/client.go
+++ b/internal/assistant/client.go
@@ -49,6 +49,8 @@ const (
 	jsonUserRole            = "user"
 	jsonAssistantRole       = "assistant"
 	jsonToolRole            = "tool"
+	jsonSystemRole          = "system"
+	jsonMessagesKey         = "messages"
 	jsonCommandKey          = "command"
 	jsonBreakdownKey        = "breakdown"
 	jsonReadToolName        = "read"
@@ -83,18 +85,21 @@ const (
 
 // CompletionRequest describes one model completion request.
 type CompletionRequest struct {
-	OnEvent       func(StreamEvent)                    `json:"-"`
-	OnToolCall    func(context.Context, ToolCallEvent) `json:"-"`
-	OnToolResult  func(context.Context, *ToolEvent)    `json:"-"`
-	ToolRegistry  *tool.Registry                       `json:"-"`
-	SessionID     string                               `json:"session_id"`
-	SystemPrompt  string                               `json:"system_prompt"`
-	ThinkingLevel string                               `json:"thinking_level"`
-	CWD           string                               `json:"cwd"`
-	Auth          model.RequestAuth                    `json:"auth"`
-	Messages      []database.MessageEntity             `json:"messages"`
-	Usage         model.TokenUsage                     `json:"usage"`
-	Model         model.Model                          `json:"model"`
+	OnEvent           func(StreamEvent)                              `json:"-"`
+	OnProviderObserve func(context.Context, *CompletionRequest, int) `json:"-"`
+	OnProviderRequest ProviderRequestHook                            `json:"-"`
+	OnToolCall        func(context.Context, ToolCallEvent)           `json:"-"`
+	OnToolResult      func(context.Context, *ToolEvent)              `json:"-"`
+	ToolRegistry      *tool.Registry                                 `json:"-"`
+	SessionID         string                                         `json:"session_id"`
+	SystemPrompt      string                                         `json:"system_prompt"`
+	ThinkingLevel     string                                         `json:"thinking_level"`
+	CWD               string                                         `json:"cwd"`
+	Auth              model.RequestAuth                              `json:"auth"`
+	Messages          []database.MessageEntity                       `json:"messages"`
+	Usage             model.TokenUsage                               `json:"usage"`
+	Model             model.Model                                    `json:"model"`
+	ProviderAttempt   int                                            `json:"-"`
 }
 
 // CompletionResult is a provider response plus model-visible side effects.

--- a/internal/assistant/context_build.go
+++ b/internal/assistant/context_build.go
@@ -246,10 +246,10 @@ func contextBreakdown(
 	contributions []contextContribution,
 ) map[string]int {
 	breakdown := map[string]int{
-		"system":     systemTokens,
-		"skills":     skillTokens,
-		"history":    historyTokens,
-		"extensions": 0,
+		jsonSystemRole: systemTokens,
+		"skills":       skillTokens,
+		"history":      historyTokens,
+		"extensions":   0,
 	}
 	for index := range contributions {
 		breakdown["extensions"] += contributions[index].Tokens

--- a/internal/assistant/lifecycle.go
+++ b/internal/assistant/lifecycle.go
@@ -65,13 +65,14 @@ func (runtime *Runtime) dispatchLifecycle(
 	runtime.emit(ctx, string(name), payload)
 	if runtime.extensions == nil {
 		return extension.LifecycleDispatchResult{
-			Payload:      cloneAnyMap(payload),
-			Name:         string(name),
-			Errors:       []string{},
-			Duration:     0,
-			HandlerCount: 0,
-			Consumed:     false,
-			Stopped:      false,
+			Payload:         cloneAnyMap(payload),
+			ProviderRequest: extension.ProviderRequestMutation{Headers: map[string]string{}},
+			Name:            string(name),
+			Errors:          []string{},
+			Duration:        0,
+			HandlerCount:    0,
+			Consumed:        false,
+			Stopped:         false,
 		}, nil
 	}
 	result, err := runtime.extensions.DispatchLifecycle(ctx, extension.LifecycleEvent{

--- a/internal/assistant/openai_chat.go
+++ b/internal/assistant/openai_chat.go
@@ -43,7 +43,12 @@ func (client *HTTPCompletionClient) advanceOpenAIChatLoop(
 	state *openAIChatLoopState,
 ) (bool, error) {
 	payload := openAIChatPayload(request, state.messages)
-	content, err := client.postJSON(ctx, state.endpoint, openAIHeaders(request), payload)
+	headers := openAIHeaders(request)
+	providerRequest, err := applyProviderRequestHook(ctx, request, payload, headers)
+	if err != nil {
+		return false, err
+	}
+	content, err := client.postJSON(ctx, state.endpoint, providerRequest.Headers, providerRequest.Payload)
 	if err != nil {
 		return false, err
 	}
@@ -114,7 +119,7 @@ func appendOpenAIChatToolConversation(state *openAIChatLoopState, result *provid
 func openAIChatPayload(request *CompletionRequest, messages []map[string]any) map[string]any {
 	payload := map[string]any{
 		jsonModelKey:      request.Model.ID,
-		"messages":        messages,
+		jsonMessagesKey:   messages,
 		"stream":          false,
 		"temperature":     0.2,
 		"tools":           openAIChatTools(request),
@@ -181,7 +186,7 @@ func parseOpenAIChatResult(content []byte) (*providerResult, error) {
 func openAIChatMessages(request *CompletionRequest) []map[string]any {
 	messages := []map[string]any{}
 	if request.SystemPrompt != "" {
-		messages = append(messages, map[string]any{jsonRoleKey: "system", jsonContentKey: request.SystemPrompt})
+		messages = append(messages, map[string]any{jsonRoleKey: jsonSystemRole, jsonContentKey: request.SystemPrompt})
 	}
 	for _, message := range request.Messages {
 		role, ok := openAIRole(message.Role)

--- a/internal/assistant/openai_responses.go
+++ b/internal/assistant/openai_responses.go
@@ -41,7 +41,18 @@ func (client *HTTPCompletionClient) completeResponsesLoop(
 	result := &CompletionResult{Text: "", Thinking: nil, ToolEvents: nil, Usage: model.EmptyTokenUsage()}
 	for {
 		payload := responsesPayload(request, input, stream)
-		providerResult, err := client.requestResponses(ctx, endpoint, headers, payload, stream, request.OnEvent)
+		providerRequest, err := applyProviderRequestHook(ctx, request, payload, headers)
+		if err != nil {
+			return nil, err
+		}
+		providerResult, err := client.requestResponses(
+			ctx,
+			endpoint,
+			providerRequest.Headers,
+			providerRequest.Payload,
+			stream,
+			request.OnEvent,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/assistant/openai_responses.go
+++ b/internal/assistant/openai_responses.go
@@ -41,7 +41,7 @@ func (client *HTTPCompletionClient) completeResponsesLoop(
 	result := &CompletionResult{Text: "", Thinking: nil, ToolEvents: nil, Usage: model.EmptyTokenUsage()}
 	for {
 		payload := responsesPayload(request, input, stream)
-		providerRequest, err := applyProviderRequestHook(ctx, request, payload, headers)
+		providerRequest, err := applyProviderRequestHook(ctx, request, payload, cloneStringMap(headers))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/assistant/provider_hooks.go
+++ b/internal/assistant/provider_hooks.go
@@ -52,11 +52,17 @@ func applyProviderRequestHook(
 	if request == nil {
 		return providerHookOutput{Payload: input.Payload, Headers: input.Headers}, nil
 	}
+	if request.OnProviderRequest != nil {
+		output, err := request.OnProviderRequest(ctx, input)
+		if err != nil {
+			return providerHookOutput{}, oops.In("assistant").
+				Code("provider_request_hook_failed").
+				Wrapf(err, "apply provider request hook")
+		}
+		return output, nil
+	}
 	if request.OnProviderObserve != nil {
 		request.OnProviderObserve(ctx, request, providerAttempt(request))
-	}
-	if request.OnProviderRequest != nil {
-		return request.OnProviderRequest(ctx, input)
 	}
 
 	return providerHookOutput{Payload: input.Payload, Headers: input.Headers}, nil
@@ -77,10 +83,14 @@ func (runtime *Runtime) dispatchProviderRequestHook(
 	payload := providerRequestLifecyclePayload(input)
 	result, err := runtime.dispatchLifecycle(ctx, extension.LifecycleBeforeProviderRequest, payload)
 	if err != nil {
-		return providerHookOutput{}, err
+		return providerHookOutput{}, oops.In("assistant").
+			Code("before_provider_request_dispatch_failed").
+			Wrapf(err, "dispatch before_provider_request lifecycle")
 	}
 	if err := validateProviderRequestMutation(result.ProviderRequest); err != nil {
-		return providerHookOutput{}, err
+		return providerHookOutput{}, oops.In("assistant").
+			Code("provider_request_mutation_invalid").
+			Wrapf(err, "validate provider_request mutation")
 	}
 
 	return providerHookOutput{

--- a/internal/assistant/provider_hooks.go
+++ b/internal/assistant/provider_hooks.go
@@ -1,0 +1,166 @@
+package assistant
+
+import (
+	"context"
+	"strings"
+
+	"github.com/samber/oops"
+
+	"github.com/omarluq/librecode/internal/extension"
+)
+
+const (
+	providerRequestHeadersKey = "headers"
+)
+
+var blockedProviderHeaderNames = map[string]struct{}{
+	"authorization":       {},
+	"cookie":              {},
+	"proxy-authorization": {},
+	"x-api-key":           {},
+	"api-key":             {},
+}
+
+// ProviderRequestHook can inspect and conservatively mutate a provider request.
+type ProviderRequestHook func(context.Context, providerHookInput) (providerHookOutput, error)
+
+type providerHookInput struct {
+	Request *CompletionRequest
+	Payload map[string]any
+	Headers map[string]string
+	Attempt int
+}
+
+type providerHookOutput struct {
+	Payload map[string]any
+	Headers map[string]string
+}
+
+func applyProviderRequestHook(
+	ctx context.Context,
+	request *CompletionRequest,
+	payload map[string]any,
+	headers map[string]string,
+) (providerHookOutput, error) {
+	input := providerHookInput{
+		Request: request,
+		Payload: cloneAnyMap(payload),
+		Headers: cloneStringMap(headers),
+		Attempt: providerAttempt(request),
+	}
+	if request == nil {
+		return providerHookOutput{Payload: input.Payload, Headers: input.Headers}, nil
+	}
+	if request.OnProviderRequest != nil {
+		return request.OnProviderRequest(ctx, input)
+	}
+	if request.OnProviderObserve != nil {
+		request.OnProviderObserve(ctx, request, providerAttempt(request))
+	}
+
+	return providerHookOutput{Payload: input.Payload, Headers: input.Headers}, nil
+}
+
+func providerAttempt(request *CompletionRequest) int {
+	if request == nil || request.ProviderAttempt <= 0 {
+		return 1
+	}
+
+	return request.ProviderAttempt
+}
+
+func (runtime *Runtime) dispatchProviderRequestHook(
+	ctx context.Context,
+	input providerHookInput,
+) (providerHookOutput, error) {
+	payload := providerRequestLifecyclePayload(input)
+	result, err := runtime.dispatchLifecycle(ctx, extension.LifecycleBeforeProviderRequest, payload)
+	if err != nil {
+		return providerHookOutput{}, err
+	}
+	if err := validateProviderRequestMutation(result.ProviderRequest); err != nil {
+		return providerHookOutput{}, err
+	}
+
+	return providerHookOutput{
+		Payload: providerPayloadFromLifecycle(result.Payload, input.Payload),
+		Headers: mergeProviderHeaders(input.Headers, result.ProviderRequest.Headers),
+	}, nil
+}
+
+func providerRequestLifecyclePayload(input providerHookInput) map[string]any {
+	request := input.Request
+	if request == nil {
+		return map[string]any{}
+	}
+
+	return map[string]any{
+		lifecycleAPIKey:           request.Model.API,
+		lifecycleAttemptKey:       input.Attempt,
+		providerRequestHeadersKey: redactedHeaders(input.Headers),
+		jsonModelKey:              request.Model.ID,
+		lifecycleProviderKey:      request.Model.Provider,
+		jsonSessionIDKey:          request.SessionID,
+		"payload":                 cloneAnyMap(input.Payload),
+		"thinking_level":          request.ThinkingLevel,
+	}
+}
+
+func providerPayloadFromLifecycle(payload, fallback map[string]any) map[string]any {
+	if payload == nil {
+		return cloneAnyMap(fallback)
+	}
+	mutated, ok := payload["payload"].(map[string]any)
+	if !ok {
+		return cloneAnyMap(fallback)
+	}
+
+	return cloneAnyMap(mutated)
+}
+
+func mergeProviderHeaders(headers, additions map[string]string) map[string]string {
+	merged := cloneStringMap(headers)
+	for key, value := range additions {
+		merged[key] = value
+	}
+
+	return merged
+}
+
+func validateProviderRequestMutation(mutation extension.ProviderRequestMutation) error {
+	for header := range mutation.Headers {
+		if _, blocked := blockedProviderHeaderNames[strings.ToLower(strings.TrimSpace(header))]; blocked {
+			return oops.In("assistant").
+				Code("provider_hook_header_blocked").
+				With("header", header).
+				Errorf("provider hook cannot mutate sensitive header")
+		}
+	}
+
+	return nil
+}
+
+func redactedHeaders(headers map[string]string) map[string]string {
+	redacted := make(map[string]string, len(headers))
+	for key, value := range headers {
+		if _, blocked := blockedProviderHeaderNames[strings.ToLower(strings.TrimSpace(key))]; blocked {
+			redacted[key] = "[redacted]"
+			continue
+		}
+		redacted[key] = value
+	}
+
+	return redacted
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return map[string]string{}
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+
+	return cloned
+}

--- a/internal/assistant/provider_hooks.go
+++ b/internal/assistant/provider_hooks.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	providerRequestHeadersKey = "headers"
+	providerRequestPayloadKey = "payload"
 )
 
 var blockedProviderHeaderNames = map[string]struct{}{
@@ -51,11 +52,11 @@ func applyProviderRequestHook(
 	if request == nil {
 		return providerHookOutput{Payload: input.Payload, Headers: input.Headers}, nil
 	}
-	if request.OnProviderRequest != nil {
-		return request.OnProviderRequest(ctx, input)
-	}
 	if request.OnProviderObserve != nil {
 		request.OnProviderObserve(ctx, request, providerAttempt(request))
+	}
+	if request.OnProviderRequest != nil {
+		return request.OnProviderRequest(ctx, input)
 	}
 
 	return providerHookOutput{Payload: input.Payload, Headers: input.Headers}, nil
@@ -101,7 +102,7 @@ func providerRequestLifecyclePayload(input providerHookInput) map[string]any {
 		jsonModelKey:              request.Model.ID,
 		lifecycleProviderKey:      request.Model.Provider,
 		jsonSessionIDKey:          request.SessionID,
-		"payload":                 cloneAnyMap(input.Payload),
+		providerRequestPayloadKey: cloneAnyMap(input.Payload),
 		"thinking_level":          request.ThinkingLevel,
 	}
 }
@@ -110,7 +111,7 @@ func providerPayloadFromLifecycle(payload, fallback map[string]any) map[string]a
 	if payload == nil {
 		return cloneAnyMap(fallback)
 	}
-	mutated, ok := payload["payload"].(map[string]any)
+	mutated, ok := payload[providerRequestPayloadKey].(map[string]any)
 	if !ok {
 		return cloneAnyMap(fallback)
 	}

--- a/internal/assistant/provider_hooks_internal_test.go
+++ b/internal/assistant/provider_hooks_internal_test.go
@@ -1,0 +1,171 @@
+package assistant
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/extension"
+	"github.com/omarluq/librecode/internal/model"
+)
+
+const (
+	providerHookTestModelID = "test-model"
+	providerHookMessagesKey = "messages"
+)
+
+func TestRuntime_ProviderRequestHookMutatesPayloadAndHeaders(t *testing.T) {
+	t.Parallel()
+
+	runtime := newProviderHookTestRuntime(t, `
+local lc = require("librecode")
+lc.on("before_provider_request", function(event)
+  event.payload.payload.metadata = "from-extension"
+  return {
+    payload = event.payload,
+    provider_request = {
+      headers = {
+        ["X-Test-Header"] = "yes",
+      },
+    },
+  }
+end)
+`)
+	request := providerHookTestRequest()
+	input := providerHookInput{
+		Request: request,
+		Payload: map[string]any{providerHookMessagesKey: []any{}},
+		Headers: map[string]string{"Authorization": "Bearer secret"},
+		Attempt: 2,
+	}
+
+	result, err := runtime.dispatchProviderRequestHook(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.Equal(t, "from-extension", result.Payload["metadata"])
+	assert.Equal(t, "yes", result.Headers["X-Test-Header"])
+	assert.Equal(t, "Bearer secret", result.Headers["Authorization"])
+}
+
+func TestRuntime_ProviderRequestHookRedactsAndRejectsSensitiveHeaders(t *testing.T) {
+	t.Parallel()
+
+	manager := extension.NewManager(testProviderHookLogger())
+	t.Cleanup(manager.Shutdown)
+	loadProviderHookTestExtension(t, manager, `
+local lc = require("librecode")
+local seen = ""
+lc.on("before_provider_request", function(event)
+  seen = ""
+  for key, value in pairs(event.payload.headers) do
+    seen = seen .. key .. "=" .. tostring(value)
+  end
+  return {
+    provider_request = {
+      headers = {
+        Authorization = "Bearer nope",
+      },
+    },
+  }
+end)
+lc.register_command("seen_auth", "seen_auth", function()
+  return seen
+end)
+`)
+	runtime := &Runtime{
+		cfg:        nil,
+		sessions:   nil,
+		extensions: manager,
+		cache:      nil,
+		events:     nil,
+		models:     nil,
+		client:     nil,
+		logger:     testProviderHookLogger(),
+	}
+	request := providerHookTestRequest()
+	input := providerHookInput{
+		Request: request,
+		Payload: map[string]any{},
+		Headers: map[string]string{"authorization": "Bearer secret"},
+		Attempt: 1,
+	}
+
+	_, err := runtime.dispatchProviderRequestHook(context.Background(), input)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sensitive header")
+	seen, err := manager.ExecuteCommand(context.Background(), "seen_auth", "")
+	require.NoError(t, err)
+	assert.Contains(t, seen, "[redacted]")
+}
+
+func newProviderHookTestRuntime(t *testing.T, source string) *Runtime {
+	t.Helper()
+
+	manager := extension.NewManager(testProviderHookLogger())
+	t.Cleanup(manager.Shutdown)
+	loadProviderHookTestExtension(t, manager, source)
+
+	return &Runtime{
+		cfg:        nil,
+		sessions:   nil,
+		extensions: manager,
+		cache:      nil,
+		events:     nil,
+		models:     nil,
+		client:     nil,
+		logger:     testProviderHookLogger(),
+	}
+}
+
+func loadProviderHookTestExtension(t *testing.T, manager *extension.Manager, source string) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "provider_hook.lua")
+	require.NoError(t, os.WriteFile(path, []byte(source), 0o600))
+	require.NoError(t, manager.LoadFile(context.Background(), path))
+}
+
+func providerHookTestRequest() *CompletionRequest {
+	return &CompletionRequest{
+		OnEvent:           nil,
+		OnProviderObserve: nil,
+		OnProviderRequest: nil,
+		OnToolCall:        nil,
+		OnToolResult:      nil,
+		ToolRegistry:      nil,
+		SessionID:         "session-1",
+		SystemPrompt:      "",
+		ThinkingLevel:     "off",
+		CWD:               "/work",
+		Auth:              model.RequestAuth{Headers: map[string]string{}, APIKey: "", Error: "", OK: true},
+		Messages:          nil,
+		Usage:             model.EmptyTokenUsage(),
+		Model: model.Model{
+			ThinkingLevelMap: nil,
+			Headers:          nil,
+			Compat:           nil,
+			Provider:         "test-provider",
+			ID:               providerHookTestModelID,
+			Name:             providerHookTestModelID,
+			API:              "openai-completions",
+			BaseURL:          "",
+			Input:            nil,
+			Cost:             model.Cost{Input: 0, Output: 0, CacheRead: 0, CacheWrite: 0},
+			ContextWindow:    0,
+			MaxTokens:        0,
+			Reasoning:        false,
+		},
+		ProviderAttempt: 1,
+	}
+}
+
+func testProviderHookLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}

--- a/internal/assistant/provider_hooks_internal_test.go
+++ b/internal/assistant/provider_hooks_internal_test.go
@@ -53,6 +53,35 @@ end)
 	assert.Equal(t, "Bearer secret", result.Headers["Authorization"])
 }
 
+func TestRuntime_ProviderRequestHookFallsBackWhenPayloadMutationIsMissing(t *testing.T) {
+	t.Parallel()
+
+	runtime := newProviderHookTestRuntime(t, `
+local lc = require("librecode")
+lc.on("before_provider_request", function()
+  return {
+    provider_request = {
+      headers = {
+        ["X-Test-Header"] = "yes",
+      },
+    },
+  }
+end)
+`)
+	input := providerHookInput{
+		Request: providerHookTestRequest(),
+		Payload: map[string]any{"original": "value"},
+		Headers: map[string]string{},
+		Attempt: 1,
+	}
+
+	result, err := runtime.dispatchProviderRequestHook(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.Equal(t, "value", result.Payload["original"])
+	assert.Equal(t, "yes", result.Headers["X-Test-Header"])
+}
+
 func TestRuntime_ProviderRequestHookRedactsAndRejectsSensitiveHeaders(t *testing.T) {
 	t.Parallel()
 

--- a/internal/assistant/provider_payload_hook_internal_test.go
+++ b/internal/assistant/provider_payload_hook_internal_test.go
@@ -1,0 +1,95 @@
+package assistant
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/model"
+)
+
+const providerPayloadHookSystemPrompt = "system"
+
+var zeroTestTime = time.Time{}
+
+func TestHTTPCompletionClientAppliesProviderRequestHook(t *testing.T) {
+	t.Parallel()
+
+	var requestHeader string
+	var requestBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requestHeader = request.Header.Get("X-Test-Header")
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&requestBody))
+		_, err := writer.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+	completionRequest := providerPayloadHookRequest(server.URL)
+	completionRequest.OnProviderRequest = func(
+		_ context.Context,
+		input providerHookInput,
+	) (providerHookOutput, error) {
+		payload := cloneAnyMap(input.Payload)
+		payload["metadata"] = "mutated"
+		headers := cloneStringMap(input.Headers)
+		headers["X-Test-Header"] = "yes"
+
+		return providerHookOutput{Payload: payload, Headers: headers}, nil
+	}
+
+	result, err := NewHTTPCompletionClient().Complete(context.Background(), completionRequest)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result.Text)
+	assert.Equal(t, "yes", requestHeader)
+	assert.Equal(t, "mutated", requestBody["metadata"])
+}
+
+func providerPayloadHookRequest(baseURL string) *CompletionRequest {
+	return &CompletionRequest{
+		OnEvent:           nil,
+		OnProviderObserve: nil,
+		OnProviderRequest: nil,
+		OnToolCall:        nil,
+		OnToolResult:      nil,
+		ToolRegistry:      nil,
+		SessionID:         "session-1",
+		SystemPrompt:      providerPayloadHookSystemPrompt,
+		ThinkingLevel:     "off",
+		CWD:               "/work",
+		Auth:              model.RequestAuth{Headers: map[string]string{}, APIKey: "test-key", Error: "", OK: true},
+		Messages: []database.MessageEntity{
+			{
+				Timestamp: zeroTestTime,
+				Role:      database.RoleUser,
+				Content:   "hello",
+				Provider:  "",
+				Model:     "",
+			},
+		},
+		Usage:           model.EmptyTokenUsage(),
+		ProviderAttempt: 1,
+		Model: model.Model{
+			ThinkingLevelMap: nil,
+			Headers:          nil,
+			Compat:           nil,
+			Provider:         "openai",
+			ID:               providerHookTestModelID,
+			Name:             providerHookTestModelID,
+			API:              apiOpenAICompletions,
+			BaseURL:          baseURL,
+			Input:            []model.InputMode{model.InputText},
+			Cost:             model.Cost{Input: 0, Output: 0, CacheRead: 0, CacheWrite: 0},
+			ContextWindow:    0,
+			MaxTokens:        0,
+			Reasoning:        false,
+		},
+	}
+}

--- a/internal/assistant/provider_payload_hook_internal_test.go
+++ b/internal/assistant/provider_payload_hook_internal_test.go
@@ -88,7 +88,7 @@ func TestHTTPCompletionClientAppliesProviderRequestHookToOpenAIResponses(t *test
 	assert.Equal(t, "mutated", capture.Body["responses_metadata"])
 }
 
-func TestApplyProviderRequestHookObservesBeforeMutating(t *testing.T) {
+func TestApplyProviderRequestHookSkipsObserveWhenMutating(t *testing.T) {
 	t.Parallel()
 
 	request := providerPayloadHookRequest("https://example.test")
@@ -113,7 +113,7 @@ func TestApplyProviderRequestHookObservesBeforeMutating(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	assert.Equal(t, []string{"observe:1", "mutate:1"}, calls)
+	assert.Equal(t, []string{"mutate:1"}, calls)
 }
 
 func TestApplyProviderRequestHookHandlesNilRequest(t *testing.T) {

--- a/internal/assistant/provider_payload_hook_internal_test.go
+++ b/internal/assistant/provider_payload_hook_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -15,21 +16,24 @@ import (
 	"github.com/omarluq/librecode/internal/model"
 )
 
-const providerPayloadHookSystemPrompt = "system"
+const (
+	providerHookPayloadKey          = "payload"
+	providerPayloadHookSystemPrompt = "system"
+	providerPayloadHookHeaderValue  = "yes"
+)
 
 var zeroTestTime = time.Time{}
 
 func TestHTTPCompletionClientAppliesProviderRequestHook(t *testing.T) {
 	t.Parallel()
 
-	var requestHeader string
-	var requestBody map[string]any
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		requestHeader = request.Header.Get("X-Test-Header")
-		require.NoError(t, json.NewDecoder(request.Body).Decode(&requestBody))
-		_, err := writer.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
-		require.NoError(t, err)
-	}))
+	captures := make(chan providerHookCapture, 1)
+	server := newProviderHookCaptureServer(
+		t,
+		captures,
+		"X-Test-Header",
+		`{"choices":[{"message":{"content":"ok"}}]}`,
+	)
 	t.Cleanup(server.Close)
 	completionRequest := providerPayloadHookRequest(server.URL)
 	completionRequest.OnProviderRequest = func(
@@ -39,7 +43,7 @@ func TestHTTPCompletionClientAppliesProviderRequestHook(t *testing.T) {
 		payload := cloneAnyMap(input.Payload)
 		payload["metadata"] = "mutated"
 		headers := cloneStringMap(input.Headers)
-		headers["X-Test-Header"] = "yes"
+		headers["X-Test-Header"] = providerPayloadHookHeaderValue
 
 		return providerHookOutput{Payload: payload, Headers: headers}, nil
 	}
@@ -47,9 +51,116 @@ func TestHTTPCompletionClientAppliesProviderRequestHook(t *testing.T) {
 	result, err := NewHTTPCompletionClient().Complete(context.Background(), completionRequest)
 
 	require.NoError(t, err)
+	capture := <-captures
+	require.NoError(t, capture.Err)
 	assert.Equal(t, "ok", result.Text)
-	assert.Equal(t, "yes", requestHeader)
-	assert.Equal(t, "mutated", requestBody["metadata"])
+	assert.Equal(t, providerPayloadHookHeaderValue, capture.Header)
+	assert.Equal(t, "mutated", capture.Body["metadata"])
+}
+
+func TestHTTPCompletionClientAppliesProviderRequestHookToOpenAIResponses(t *testing.T) {
+	t.Parallel()
+
+	captures := make(chan providerHookCapture, 1)
+	server := newProviderHookCaptureServer(t, captures, "X-Responses-Hook", `{"output_text":"ok"}`)
+	t.Cleanup(server.Close)
+	completionRequest := providerPayloadHookRequest(server.URL)
+	completionRequest.Model.API = apiOpenAIResponses
+	completionRequest.OnProviderRequest = func(
+		_ context.Context,
+		input providerHookInput,
+	) (providerHookOutput, error) {
+		payload := cloneAnyMap(input.Payload)
+		payload["responses_metadata"] = "mutated"
+		headers := cloneStringMap(input.Headers)
+		headers["X-Responses-Hook"] = strconv.Itoa(input.Attempt)
+
+		return providerHookOutput{Payload: payload, Headers: headers}, nil
+	}
+
+	result, err := NewHTTPCompletionClient().Complete(context.Background(), completionRequest)
+
+	require.NoError(t, err)
+	capture := <-captures
+	require.NoError(t, capture.Err)
+	assert.Equal(t, "ok", result.Text)
+	assert.Equal(t, "1", capture.Header)
+	assert.Equal(t, "mutated", capture.Body["responses_metadata"])
+}
+
+func TestApplyProviderRequestHookObservesBeforeMutating(t *testing.T) {
+	t.Parallel()
+
+	request := providerPayloadHookRequest("https://example.test")
+	calls := []string{}
+	request.OnProviderObserve = func(_ context.Context, _ *CompletionRequest, attempt int) {
+		calls = append(calls, "observe:"+strconv.Itoa(attempt))
+	}
+	request.OnProviderRequest = func(
+		_ context.Context,
+		input providerHookInput,
+	) (providerHookOutput, error) {
+		calls = append(calls, "mutate:"+strconv.Itoa(input.Attempt))
+
+		return providerHookOutput{Payload: input.Payload, Headers: input.Headers}, nil
+	}
+
+	_, err := applyProviderRequestHook(
+		context.Background(),
+		request,
+		map[string]any{providerHookPayloadKey: true},
+		map[string]string{},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"observe:1", "mutate:1"}, calls)
+}
+
+func TestApplyProviderRequestHookHandlesNilRequest(t *testing.T) {
+	t.Parallel()
+
+	result, err := applyProviderRequestHook(
+		context.Background(),
+		nil,
+		map[string]any{providerHookPayloadKey: true},
+		map[string]string{"X-Test": providerPayloadHookHeaderValue},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{providerHookPayloadKey: true}, result.Payload)
+	assert.Equal(t, map[string]string{"X-Test": providerPayloadHookHeaderValue}, result.Headers)
+}
+
+type providerHookCapture struct {
+	Err    error
+	Body   map[string]any
+	Header string
+}
+
+func newProviderHookCaptureServer(
+	t *testing.T,
+	captures chan<- providerHookCapture,
+	header string,
+	response string,
+) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		capture := providerHookCapture{
+			Err:    nil,
+			Body:   map[string]any{},
+			Header: request.Header.Get(header),
+		}
+		if err := json.NewDecoder(request.Body).Decode(&capture.Body); err != nil {
+			capture.Err = err
+			captures <- capture
+			return
+		}
+		if _, err := writer.Write([]byte(response)); err != nil {
+			capture.Err = err
+		}
+		captures <- capture
+	}))
 }
 
 func providerPayloadHookRequest(baseURL string) *CompletionRequest {

--- a/internal/assistant/provider_tool_calls_test.go
+++ b/internal/assistant/provider_tool_calls_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -49,6 +50,79 @@ func TestCompleteOpenAIChatExecutesNativeToolCalls(t *testing.T) {
 	messages, ok := requests[1]["messages"].([]any)
 	require.True(t, ok)
 	assert.True(t, containsRoleMessage(messages, jsonToolRole))
+}
+
+func TestCompleteOpenAIResponsesAppliesProviderHookEachIteration(t *testing.T) {
+	t.Parallel()
+
+	workspace := testToolWorkspace(t)
+	captures := make(chan providerResponseHookCapture, 2)
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		capture := providerResponseHookCapture{
+			Err:    nil,
+			Body:   map[string]any{},
+			Header: request.Header.Get("X-Iteration"),
+		}
+		if err := json.NewDecoder(request.Body).Decode(&capture.Body); err != nil {
+			capture.Err = err
+			captures <- capture
+			return
+		}
+		requestCount++
+		captures <- capture
+		writer.Header().Set("Content-Type", "application/json")
+		if requestCount == 1 {
+			arguments, err := json.Marshal(map[string]string{jsonPathKey: "README.md"})
+			require.NoError(t, err)
+			writeTestProviderResponse(
+				t,
+				writer,
+				`{"output":[{"type":"function_call","call_id":"call_1","name":"read","arguments":`+
+					strconv.Quote(string(arguments))+
+					`}]}`,
+			)
+			return
+		}
+		writeTestProviderResponse(t, writer, `{"output_text":"done"}`)
+	}))
+	t.Cleanup(server.Close)
+
+	request := testCompletionRequestAuth("sk-test")
+	request.CWD = workspace
+	request.Model.Provider = "openai"
+	request.Model.API = apiOpenAIResponses
+	request.Model.BaseURL = server.URL
+	request.OnProviderRequest = func(
+		_ context.Context,
+		input providerHookInput,
+	) (providerHookOutput, error) {
+		payload := cloneAnyMap(input.Payload)
+		payload["iteration"] = input.Attempt
+		headers := cloneStringMap(input.Headers)
+		headers["X-Iteration"] = strconv.Itoa(input.Attempt)
+
+		return providerHookOutput{Payload: payload, Headers: headers}, nil
+	}
+
+	result, err := NewHTTPCompletionClient().completeOpenAIResponses(context.Background(), request)
+
+	require.NoError(t, err)
+	assert.Equal(t, "done", result.Text)
+	first := <-captures
+	second := <-captures
+	require.NoError(t, first.Err)
+	require.NoError(t, second.Err)
+	assert.Equal(t, "1", first.Header)
+	assert.Equal(t, "1", second.Header)
+	assert.Equal(t, float64(1), first.Body["iteration"])
+	assert.Equal(t, float64(1), second.Body["iteration"])
+}
+
+type providerResponseHookCapture struct {
+	Err    error
+	Body   map[string]any
+	Header string
 }
 
 func TestCompleteAnthropicExecutesTextToolUseFallback(t *testing.T) {

--- a/internal/assistant/provider_tool_calls_test.go
+++ b/internal/assistant/provider_tool_calls_test.go
@@ -58,6 +58,7 @@ func TestCompleteOpenAIResponsesAppliesProviderHookEachIteration(t *testing.T) {
 	workspace := testToolWorkspace(t)
 	captures := make(chan providerResponseHookCapture, 2)
 	var requestCount int
+	var hookIterations []int
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		capture := providerResponseHookCapture{
 			Err:    nil,
@@ -97,10 +98,12 @@ func TestCompleteOpenAIResponsesAppliesProviderHookEachIteration(t *testing.T) {
 		_ context.Context,
 		input providerHookInput,
 	) (providerHookOutput, error) {
+		iteration := len(hookIterations) + 1
+		hookIterations = append(hookIterations, iteration)
 		payload := cloneAnyMap(input.Payload)
-		payload["iteration"] = input.Attempt
+		payload["iteration"] = iteration
 		headers := cloneStringMap(input.Headers)
-		headers["X-Iteration"] = strconv.Itoa(input.Attempt)
+		headers["X-Iteration"] = strconv.Itoa(iteration)
 
 		return providerHookOutput{Payload: payload, Headers: headers}, nil
 	}
@@ -113,10 +116,11 @@ func TestCompleteOpenAIResponsesAppliesProviderHookEachIteration(t *testing.T) {
 	second := <-captures
 	require.NoError(t, first.Err)
 	require.NoError(t, second.Err)
+	assert.Equal(t, []int{1, 2}, hookIterations)
 	assert.Equal(t, "1", first.Header)
-	assert.Equal(t, "1", second.Header)
+	assert.Equal(t, "2", second.Header)
 	assert.Equal(t, float64(1), first.Body["iteration"])
-	assert.Equal(t, float64(1), second.Body["iteration"])
+	assert.Equal(t, float64(2), second.Body["iteration"])
 }
 
 type providerResponseHookCapture struct {

--- a/internal/assistant/runtime.go
+++ b/internal/assistant/runtime.go
@@ -824,18 +824,21 @@ func (runtime *Runtime) modelCompletionRequest(
 	onEvent func(StreamEvent),
 ) *CompletionRequest {
 	return &CompletionRequest{
-		OnEvent:       onEvent,
-		OnToolCall:    runtime.emitToolCall,
-		OnToolResult:  runtime.emitToolResult,
-		ToolRegistry:  registry,
-		SessionID:     sessionID,
-		SystemPrompt:  systemPrompt,
-		ThinkingLevel: runtime.cfg.Assistant.ThinkingLevel,
-		CWD:           cwd,
-		Auth:          auth,
-		Messages:      messages,
-		Usage:         usage,
-		Model:         *selectedModel,
+		OnEvent:           onEvent,
+		OnProviderObserve: runtime.emitProviderRequest,
+		OnProviderRequest: runtime.dispatchProviderRequestHook,
+		OnToolCall:        runtime.emitToolCall,
+		OnToolResult:      runtime.emitToolResult,
+		ToolRegistry:      registry,
+		SessionID:         sessionID,
+		SystemPrompt:      systemPrompt,
+		ThinkingLevel:     runtime.cfg.Assistant.ThinkingLevel,
+		CWD:               cwd,
+		Auth:              auth,
+		Messages:          messages,
+		Usage:             usage,
+		Model:             *selectedModel,
+		ProviderAttempt:   0,
 	}
 }
 
@@ -846,7 +849,7 @@ func (runtime *Runtime) completeWithRetry(
 ) (*CompletionResult, error) {
 	retry := retryConfig(runtime.cfg)
 	if !retry.Enabled || retry.MaxAttempts <= 1 {
-		runtime.emitProviderRequest(ctx, request, 1)
+		request.ProviderAttempt = 1
 		result, err := runtime.client.Complete(ctx, request)
 		if err != nil {
 			runtime.emitProviderError(ctx, request, 1, err)
@@ -858,7 +861,7 @@ func (runtime *Runtime) completeWithRetry(
 
 	var lastErr error
 	for attempt := 1; attempt <= retry.MaxAttempts; attempt++ {
-		runtime.emitProviderRequest(ctx, request, attempt)
+		request.ProviderAttempt = attempt
 		result, err := runtime.client.Complete(ctx, request)
 		if err == nil {
 			runtime.emitProviderResponse(ctx, request, attempt, result)

--- a/internal/assistant/runtime_events.go
+++ b/internal/assistant/runtime_events.go
@@ -18,12 +18,13 @@ func (runtime *Runtime) emitProviderRequest(ctx context.Context, request *Comple
 		return
 	}
 	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleBeforeProviderRequest, map[string]any{
-		lifecycleAPIKey:      request.Model.API,
-		lifecycleAttemptKey:  attempt,
-		jsonModelKey:         request.Model.ID,
-		lifecycleProviderKey: request.Model.Provider,
-		jsonSessionIDKey:     request.SessionID,
-		"thinking_level":     request.ThinkingLevel,
+		lifecycleAPIKey:           request.Model.API,
+		lifecycleAttemptKey:       attempt,
+		providerRequestHeadersKey: redactedHeaders(request.Auth.Headers),
+		jsonModelKey:              request.Model.ID,
+		lifecycleProviderKey:      request.Model.Provider,
+		jsonSessionIDKey:          request.SessionID,
+		"thinking_level":          request.ThinkingLevel,
 	})
 }
 

--- a/internal/assistant/runtime_events.go
+++ b/internal/assistant/runtime_events.go
@@ -17,7 +17,7 @@ func (runtime *Runtime) emitProviderRequest(ctx context.Context, request *Comple
 	if request == nil {
 		return
 	}
-	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleBeforeProviderRequest, map[string]any{
+	runtime.emit(ctx, string(extension.LifecycleBeforeProviderRequest), map[string]any{
 		lifecycleAPIKey:           request.Model.API,
 		lifecycleAttemptKey:       attempt,
 		providerRequestHeadersKey: redactedHeaders(request.Auth.Headers),

--- a/internal/assistant/runtime_lifecycle_test.go
+++ b/internal/assistant/runtime_lifecycle_test.go
@@ -257,9 +257,12 @@ type staticCompletionClient struct {
 }
 
 func (client staticCompletionClient) Complete(
-	_ context.Context,
-	_ *assistant.CompletionRequest,
+	ctx context.Context,
+	request *assistant.CompletionRequest,
 ) (*assistant.CompletionResult, error) {
+	if request.OnProviderObserve != nil {
+		request.OnProviderObserve(ctx, request, request.ProviderAttempt)
+	}
 	if client.err != nil {
 		return nil, client.err
 	}

--- a/internal/extension/lifecycle.go
+++ b/internal/extension/lifecycle.go
@@ -165,10 +165,7 @@ func applyLifecycleLuaResult(result *LifecycleDispatchResult, value lua.LValue) 
 	}
 }
 
-func mergeProviderRequestMutation(
-	base ProviderRequestMutation,
-	override ProviderRequestMutation,
-) ProviderRequestMutation {
+func mergeProviderRequestMutation(base, override ProviderRequestMutation) ProviderRequestMutation {
 	merged := ProviderRequestMutation{Headers: map[string]string{}}
 	for key, value := range base.Headers {
 		merged.Headers[key] = value

--- a/internal/extension/lifecycle.go
+++ b/internal/extension/lifecycle.go
@@ -65,13 +65,19 @@ type LifecycleEvent struct {
 
 // LifecycleDispatchResult describes the outcome of lifecycle handler dispatch.
 type LifecycleDispatchResult struct {
-	Payload      map[string]any `json:"payload"`
-	Name         string         `json:"name"`
-	Errors       []string       `json:"errors"`
-	Duration     time.Duration  `json:"duration"`
-	HandlerCount int            `json:"handler_count"`
-	Consumed     bool           `json:"consumed"`
-	Stopped      bool           `json:"stopped"`
+	Payload         map[string]any          `json:"payload"`
+	ProviderRequest ProviderRequestMutation `json:"provider_request"`
+	Name            string                  `json:"name"`
+	Errors          []string                `json:"errors"`
+	Duration        time.Duration           `json:"duration"`
+	HandlerCount    int                     `json:"handler_count"`
+	Consumed        bool                    `json:"consumed"`
+	Stopped         bool                    `json:"stopped"`
+}
+
+// ProviderRequestMutation contains conservative provider request changes returned by lifecycle handlers.
+type ProviderRequestMutation struct {
+	Headers map[string]string `json:"headers"`
 }
 
 // LifecycleDispatcher emits runtime-neutral lifecycle events.
@@ -86,13 +92,14 @@ func (manager *Manager) DispatchLifecycle(ctx context.Context, event LifecycleEv
 	}
 
 	result := LifecycleDispatchResult{
-		Name:         string(event.Name),
-		Payload:      cloneMap(event.Payload),
-		Errors:       []string{},
-		HandlerCount: 0,
-		Duration:     0,
-		Consumed:     false,
-		Stopped:      false,
+		Payload:         cloneMap(event.Payload),
+		ProviderRequest: ProviderRequestMutation{Headers: map[string]string{}},
+		Name:            string(event.Name),
+		Errors:          []string{},
+		Duration:        0,
+		HandlerCount:    0,
+		Consumed:        false,
+		Stopped:         false,
 	}
 	startedAt := time.Now()
 
@@ -152,4 +159,38 @@ func applyLifecycleLuaResult(result *LifecycleDispatchResult, value lua.LValue) 
 	if payload, ok := luaValueToGo(payloadValue).(map[string]any); ok {
 		result.Payload = payload
 	}
+	providerRequestValue := table.RawGetString("provider_request")
+	if providerRequest, ok := providerRequestMutationFromLua(providerRequestValue); ok {
+		result.ProviderRequest = providerRequest
+	}
+}
+
+func providerRequestMutationFromLua(value lua.LValue) (ProviderRequestMutation, bool) {
+	payload, ok := luaValueToGo(value).(map[string]any)
+	if !ok {
+		return ProviderRequestMutation{Headers: map[string]string{}}, false
+	}
+	headers := stringMapValue(payload["headers"])
+	if len(headers) == 0 {
+		return ProviderRequestMutation{Headers: map[string]string{}}, false
+	}
+
+	return ProviderRequestMutation{Headers: headers}, true
+}
+
+func stringMapValue(value any) map[string]string {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return map[string]string{}
+	}
+	output := make(map[string]string, len(object))
+	for key, item := range object {
+		text, ok := item.(string)
+		if !ok {
+			continue
+		}
+		output[key] = text
+	}
+
+	return output
 }

--- a/internal/extension/lifecycle.go
+++ b/internal/extension/lifecycle.go
@@ -161,8 +161,23 @@ func applyLifecycleLuaResult(result *LifecycleDispatchResult, value lua.LValue) 
 	}
 	providerRequestValue := table.RawGetString("provider_request")
 	if providerRequest, ok := providerRequestMutationFromLua(providerRequestValue); ok {
-		result.ProviderRequest = providerRequest
+		result.ProviderRequest = mergeProviderRequestMutation(result.ProviderRequest, providerRequest)
 	}
+}
+
+func mergeProviderRequestMutation(
+	base ProviderRequestMutation,
+	override ProviderRequestMutation,
+) ProviderRequestMutation {
+	merged := ProviderRequestMutation{Headers: map[string]string{}}
+	for key, value := range base.Headers {
+		merged.Headers[key] = value
+	}
+	for key, value := range override.Headers {
+		merged.Headers[key] = value
+	}
+
+	return merged
 }
 
 func providerRequestMutationFromLua(value lua.LValue) (ProviderRequestMutation, bool) {

--- a/internal/extension/lifecycle_test.go
+++ b/internal/extension/lifecycle_test.go
@@ -90,13 +90,24 @@ func TestManager_DispatchLifecycleCollectsProviderRequestMutation(t *testing.T) 
 
 	manager := loadTestExtension(t, `
 local lc = require("librecode")
-lc.on("before_provider_request", function(event)
+lc.on("before_provider_request", { priority = 10 }, function(event)
   event.payload.payload.marker = "changed"
   return {
     payload = event.payload,
     provider_request = {
       headers = {
         ["X-Debug"] = "yes",
+        ["X-Shared"] = "first",
+      },
+    },
+  }
+end)
+lc.on("before_provider_request", { priority = 1 }, function(event)
+  return {
+    provider_request = {
+      headers = {
+        ["X-Trace"] = "trace-id",
+        ["X-Shared"] = "second",
       },
     },
   }
@@ -113,7 +124,11 @@ end)
 	payload, ok := result.Payload["payload"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "changed", payload["marker"])
-	assert.Equal(t, map[string]string{"X-Debug": "yes"}, result.ProviderRequest.Headers)
+	assert.Equal(t, map[string]string{
+		"X-Debug":  "yes",
+		"X-Shared": "second",
+		"X-Trace":  "trace-id",
+	}, result.ProviderRequest.Headers)
 }
 
 func TestManager_DispatchLifecycleRequiresName(t *testing.T) {

--- a/internal/extension/lifecycle_test.go
+++ b/internal/extension/lifecycle_test.go
@@ -85,6 +85,37 @@ end)
 	assert.Contains(t, result.Errors[0], "boom")
 }
 
+func TestManager_DispatchLifecycleCollectsProviderRequestMutation(t *testing.T) {
+	t.Parallel()
+
+	manager := loadTestExtension(t, `
+local lc = require("librecode")
+lc.on("before_provider_request", function(event)
+  event.payload.payload.marker = "changed"
+  return {
+    payload = event.payload,
+    provider_request = {
+      headers = {
+        ["X-Debug"] = "yes",
+      },
+    },
+  }
+end)
+`)
+	result, err := manager.DispatchLifecycle(context.Background(), extension.LifecycleEvent{
+		Name: extension.LifecycleBeforeProviderRequest,
+		Payload: map[string]any{
+			"payload": map[string]any{},
+		},
+	})
+
+	require.NoError(t, err)
+	payload, ok := result.Payload["payload"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "changed", payload["marker"])
+	assert.Equal(t, map[string]string{"X-Debug": "yes"}, result.ProviderRequest.Headers)
+}
+
 func TestManager_DispatchLifecycleRequiresName(t *testing.T) {
 	t.Parallel()
 

--- a/internal/extension/lua_values.go
+++ b/internal/extension/lua_values.go
@@ -36,6 +36,8 @@ func goValueToLua(state *lua.LState, value any) lua.LValue {
 	switch typedValue := value.(type) {
 	case map[string]any:
 		return mapToLuaTable(state, typedValue)
+	case map[string]string:
+		return stringMapToLuaTable(state, typedValue)
 	case []any:
 		return sliceToLuaTable(state, typedValue)
 	case []string:
@@ -68,6 +70,15 @@ func sliceToLuaTable(state *lua.LState, values []any) *lua.LTable {
 	table := state.NewTable()
 	for valueIndex, value := range values {
 		state.RawSetInt(table, valueIndex+1, goValueToLua(state, value))
+	}
+
+	return table
+}
+
+func stringMapToLuaTable(state *lua.LState, values map[string]string) *lua.LTable {
+	table := state.NewTable()
+	for key, value := range values {
+		state.SetField(table, key, lua.LString(value))
 	}
 
 	return table


### PR DESCRIPTION
## Summary
- add provider request lifecycle hook with bounded payload/header mutation
- expose provider request data to extension lifecycle handlers with sensitive header redaction
- wire provider request hooks into OpenAI Chat, OpenAI Responses, and Anthropic request paths

## Validation
- mise exec -- go test ./...
- mise exec -- task build
- mise exec -- task ci