### PR TITLE
test(assistant): cover failed progress persistence

### DIFF
--- a/internal/assistant/runtime_test.go
+++ b/internal/assistant/runtime_test.go
@@ -249,17 +249,26 @@ func TestRuntime_PromptPersistsPartialProgressOnProviderFailure(t *testing.T) {
 
 	require.Error(t, err)
 	assert.EqualError(t, err, "provider returned an empty response")
-	require.NotEmpty(t, request.SessionID)
-	messages, err := repository.Messages(context.Background(), request.SessionID)
-	require.NoError(t, err)
-	require.Len(t, messages, 4)
-	assert.Equal(t, database.RoleUser, messages[0].Role)
-	assert.Equal(t, database.RoleAssistant, messages[1].Role)
-	assert.Equal(t, "partial answer\n\nwith whitespace", messages[1].Content)
-	assert.Equal(t, database.RoleToolResult, messages[2].Role)
-	assert.Contains(t, messages[2].Content, "tool: read")
-	assert.Equal(t, database.RoleCustom, messages[3].Role)
-	assert.Contains(t, messages[3].Content, "provider returned an empty response")
+	assertPersistedPartialFailure(t, repository, request.SessionID)
+}
+
+func TestRuntime_PromptReportsPersistenceFailureWhenFailedProgressCannotPersist(t *testing.T) {
+	t.Parallel()
+
+	client := partialFailureCompletionClient{}
+	runtime, _ := newTestRuntimeWithClient(t, client)
+	request := newRuntimePromptRequest(testRuntimeCWD, "fail persistence", "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	request.OnEvent = func(assistant.StreamEvent) {
+		cancel()
+	}
+
+	_, err := runtime.Prompt(ctx, request)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "persist failed prompt progress")
+	assert.Contains(t, err.Error(), "append partial prompt progress")
 }
 
 func TestRuntime_PromptDoesNotRetryNonTransientModelErrors(t *testing.T) {
@@ -553,6 +562,26 @@ func (partialFailureCompletionClient) Complete(
 	})
 
 	return nil, errors.New("provider returned an empty response")
+}
+
+func assertPersistedPartialFailure(
+	t *testing.T,
+	repository *database.SessionRepository,
+	sessionID string,
+) {
+	t.Helper()
+
+	require.NotEmpty(t, sessionID)
+	messages, err := repository.Messages(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.Len(t, messages, 4)
+	assert.Equal(t, database.RoleUser, messages[0].Role)
+	assert.Equal(t, database.RoleAssistant, messages[1].Role)
+	assert.Equal(t, "partial answer\n\nwith whitespace", messages[1].Content)
+	assert.Equal(t, database.RoleToolResult, messages[2].Role)
+	assert.Contains(t, messages[2].Content, "tool: read")
+	assert.Equal(t, database.RoleCustom, messages[3].Role)
+	assert.Contains(t, messages[3].Content, "provider returned an empty response")
 }
 
 type testCompletionClient struct{}

--- a/internal/terminal/render_test.go
+++ b/internal/terminal/render_test.go
@@ -80,21 +80,39 @@ func TestApplyPromptErrorKeepsStreamedProgressVisible(t *testing.T) {
 	app.working = true
 	app.activePrompt = newTestActivePrompt(nil)
 	app.handlePromptStreamEvent(context.Background(), newTestAsyncEvent(asyncEventPromptDelta, "partial"))
+	app.handlePromptStreamEvent(context.Background(), newTestAsyncEvent(asyncEventPromptThinkingDelta, "\n\n"))
+	app.streamingBlocks = append(app.streamingBlocks,
+		newChatMessage(database.RoleUser, "ignored user echo"),
+		newChatMessage(database.RoleBashExecution, "bash output"),
+		newChatMessage(database.RoleCustom, "custom progress"),
+		newChatMessage(database.RoleBranchSummary, "ignored branch"),
+		newChatMessage(database.RoleCompactionSummary, "ignored compaction"),
+	)
 	toolEvent := newTestAsyncEvent(asyncEventPromptToolResult, "")
 	toolEvent.ToolEvent = newTestToolEvent("read", "file content")
 	app.handlePromptStreamEvent(context.Background(), toolEvent)
 
 	app.applyPromptError("provider returned an empty response", app.activePrompt.ID)
 
+	assertPromptErrorMessages(t, app)
+	assert.Empty(t, app.streamingBlocks)
+}
+
+func assertPromptErrorMessages(t *testing.T, app *App) {
+	t.Helper()
+
 	assert.False(t, app.working)
-	require.Len(t, app.messages, 3)
+	require.Len(t, app.messages, 5)
 	assert.Equal(t, database.RoleAssistant, app.messages[0].Role)
 	assert.Equal(t, "partial", app.messages[0].Content)
-	assert.Equal(t, database.RoleToolResult, app.messages[1].Role)
-	assert.Contains(t, app.messages[1].Content, "tool: read")
+	assert.Equal(t, database.RoleBashExecution, app.messages[1].Role)
+	assert.Equal(t, "bash output", app.messages[1].Content)
 	assert.Equal(t, database.RoleCustom, app.messages[2].Role)
-	assert.Equal(t, "provider returned an empty response", app.messages[2].Content)
-	assert.Empty(t, app.streamingBlocks)
+	assert.Equal(t, "custom progress", app.messages[2].Content)
+	assert.Equal(t, database.RoleToolResult, app.messages[3].Role)
+	assert.Contains(t, app.messages[3].Content, "tool: read")
+	assert.Equal(t, database.RoleCustom, app.messages[4].Role)
+	assert.Equal(t, "provider returned an empty response", app.messages[4].Content)
 }
 
 func TestFooterLinesIgnoreTransientStatus(t *testing.T) {


### PR DESCRIPTION
## Summary
- add coverage for persisting partial streamed progress on provider failure
- cover UI handling of streamed side-effect blocks when a prompt fails

## Validation
- mise exec -- task ci