### PR TITLE
feat(extension): harden provider and tool runtime seams

### DIFF
--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -1,11 +1,11 @@
 # Extension Lua API
 
 
-## Agent lifecycle seams (planned)
+## Agent lifecycle seams
 
-The extension host is moving toward explicit lifecycle/tool/context seams while keeping the default UI and assistant loop Go-owned. New APIs should be runtime-neutral first and then exposed through Lua.
+The extension host exposes explicit lifecycle/tool/context seams while keeping the default UI and assistant loop Go-owned. New APIs are designed as runtime-neutral host contracts first and then exposed through Lua.
 
-Planned lifecycle events include:
+Current lifecycle events include:
 
 | Event | Purpose | Mutation policy |
 | --- | --- | --- |
@@ -14,15 +14,15 @@ Planned lifecycle events include:
 | `turn_start` / `turn_end` / `agent_end` | Observe one assistant turn. | Observational initially. |
 | `context_build` | Add bounded, labeled context blocks and inspect context budgets. | Bounded contributions only. |
 | `before_provider_request` / `after_provider_response` / `provider_error` | Observe provider traffic with redacted payloads. | Conservative typed mutation only. |
-| `tool_call` / `tool_result` / `tool_error` | Mediate tool execution and results. | Allow, reject, modify, synthesize, or redact per documented contract. |
+| `tool_call` / `tool_result` / `tool_error` | Mediate tool execution and results. | Normalize arguments; rewrite/redact results; surface hook errors as tool errors. |
 | `message_append` | Observe durable message writes. | Observational initially. |
 
-All lifecycle payloads must be bounded. Provider events must redact auth headers and secrets. Tool middleware decisions should be visible in diagnostics.
+All lifecycle payloads must be bounded. Provider events must redact auth headers and secrets. Tool hook decisions should be visible in diagnostics.
 
 librecode separates two event mechanisms:
 
 - the **ro-backed event stream** for observational async/fanout events such as lifecycle telemetry, headless JSON output, timers, retry notifications, and future watchers
-- the **ordered middleware dispatcher** for hooks that return decisions or mutations, such as tool allow/reject, context contributions, and provider request changes
+- the **ordered middleware dispatcher** for hooks that return mutations, such as tool normalization/redaction, context contributions, and provider request changes
 
 Extensions may observe lifecycle events through Lua handlers, while core Go services can subscribe to the reactive stream for telemetry and integrations. Do not use the observational stream for state mutations that require deterministic ordering.
 
@@ -157,6 +157,40 @@ Current commonly emitted events include:
 - `tick`
 - `before_agent_start`
 - `agent_end`
+- `context_build`
+- `before_provider_request`
+- `after_provider_response`
+- `provider_error`
+- `tool_call`
+- `tool_result`
+- `tool_error`
+
+Tool lifecycle handlers may return small, explicit mutations. librecode stays YOLO by default; these hooks are for formatting, observability, redaction, or argument normalization rather than built-in permission gates.
+
+```lua
+lc.on("tool_call", function(ev)
+  if ev.payload.name == "read" then
+    return {
+      tool_call = {
+        arguments = {
+          path = ev.payload.arguments.path,
+          limit = 200,
+        },
+      },
+    }
+  end
+end)
+
+lc.on("tool_result", function(ev)
+  if ev.payload.name == "bash" then
+    return {
+      tool_result = {
+        result = ev.payload.result:gsub("SECRET=[^\\n]+", "SECRET=<redacted>"),
+      },
+    }
+  end
+end)
+```
 
 ## Diagnostics
 

--- a/docs/extension-roadmap.md
+++ b/docs/extension-roadmap.md
@@ -263,15 +263,15 @@ Events should have structured payloads, bounded data, clear mutation contracts, 
 
 Goal: let extensions and hooks influence tool execution through explicit middleware contracts.
 
-### Phase 6.1: built-in tool middleware
+### Phase 6.1: tool runtime hooks
 
-Run tool middleware around built-in tool execution first. Middleware should support:
+Run tool lifecycle hooks around tool execution. librecode stays YOLO by default: hooks are not a built-in permission gate, but they can normalize arguments, annotate calls, redact or rewrite results, and add diagnostics. Users who want policy gates can implement them as extensions that return tool errors or synthetic results.
 
-- observe and continue
-- reject with a synthetic result
-- modify tool input
-- synthesize a result without executing the tool
-- redact or rewrite tool output before the model sees it
+Implemented contract:
+
+- `tool_call` can return `tool_call.arguments` to replace/merge tool arguments before execution
+- `tool_result` can return `tool_result.result`, `tool_result.details_json`, and/or `tool_result.error` before the model sees the result
+- hook failures are surfaced as tool errors instead of silently mutating state
 
 ### Phase 6.2: unified tool registry
 

--- a/internal/assistant/lifecycle.go
+++ b/internal/assistant/lifecycle.go
@@ -236,6 +236,7 @@ func (runtime *Runtime) dispatchToolCallLifecycle(ctx context.Context, call *Too
 	payload := toolCallPayload(*call)
 	result, err := runtime.dispatchLifecycle(ctx, extension.LifecycleToolCall, payload)
 	if err != nil {
+		runtime.emitLifecycleDiagnostics(ctx, extension.LifecycleToolCall, &result, toolCallDiagnostics(call))
 		return err
 	}
 	applyToolCallMutation(call, result.ToolCall)
@@ -251,6 +252,7 @@ func (runtime *Runtime) dispatchToolResultLifecycle(ctx context.Context, event *
 	payload := toolEventPayload(event)
 	result, err := runtime.dispatchLifecycle(ctx, extension.LifecycleToolResult, payload)
 	if err != nil {
+		runtime.emitLifecycleDiagnostics(ctx, extension.LifecycleToolResult, &result, toolResultDiagnostics(event))
 		return err
 	}
 	applyToolResultMutation(event, result.ToolResult)
@@ -267,10 +269,10 @@ func (runtime *Runtime) dispatchToolErrorLifecycle(ctx context.Context, event *T
 		return
 	}
 	result, err := runtime.dispatchLifecycle(ctx, extension.LifecycleToolError, toolEventPayload(event))
+	runtime.emitLifecycleDiagnostics(ctx, extension.LifecycleToolError, &result, toolResultDiagnostics(event))
 	if err != nil {
 		return
 	}
-	runtime.emitLifecycleDiagnostics(ctx, extension.LifecycleToolError, &result, toolResultDiagnostics(event))
 }
 
 func applyToolCallMutation(call *ToolCallEvent, mutation extension.ToolCallMutation) {

--- a/internal/assistant/lifecycle.go
+++ b/internal/assistant/lifecycle.go
@@ -234,19 +234,12 @@ func (runtime *Runtime) dispatchToolCallLifecycle(ctx context.Context, call *Too
 		return nil
 	}
 	payload := toolCallPayload(*call)
-	runtime.emit(ctx, string(extension.LifecycleToolCall), payload)
-	if runtime.extensions == nil {
-		return nil
-	}
-
-	result, err := runtime.extensions.DispatchLifecycle(ctx, extension.LifecycleEvent{
-		Name:    extension.LifecycleToolCall,
-		Payload: payload,
-	})
+	result, err := runtime.dispatchLifecycle(ctx, extension.LifecycleToolCall, payload)
 	if err != nil {
 		return err
 	}
 	applyToolCallMutation(call, result.ToolCall)
+	runtime.emitLifecycleDiagnostics(ctx, extension.LifecycleToolCall, &result, toolCallDiagnostics(call))
 
 	return nil
 }
@@ -256,22 +249,28 @@ func (runtime *Runtime) dispatchToolResultLifecycle(ctx context.Context, event *
 		return nil
 	}
 	payload := toolEventPayload(event)
-	runtime.emit(ctx, string(extension.LifecycleToolResult), payload)
-	if runtime.extensions != nil {
-		result, err := runtime.extensions.DispatchLifecycle(ctx, extension.LifecycleEvent{
-			Name:    extension.LifecycleToolResult,
-			Payload: payload,
-		})
-		if err != nil {
-			return err
-		}
-		applyToolResultMutation(event, result.ToolResult)
+	result, err := runtime.dispatchLifecycle(ctx, extension.LifecycleToolResult, payload)
+	if err != nil {
+		return err
 	}
+	applyToolResultMutation(event, result.ToolResult)
+	runtime.emitLifecycleDiagnostics(ctx, extension.LifecycleToolResult, &result, toolResultDiagnostics(event))
 	if event.Error != "" {
-		runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleToolError, toolEventPayload(event))
+		runtime.dispatchToolErrorLifecycle(ctx, event)
 	}
 
 	return nil
+}
+
+func (runtime *Runtime) dispatchToolErrorLifecycle(ctx context.Context, event *ToolEvent) {
+	if event == nil || event.Error == "" {
+		return
+	}
+	result, err := runtime.dispatchLifecycle(ctx, extension.LifecycleToolError, toolEventPayload(event))
+	if err != nil {
+		return
+	}
+	runtime.emitLifecycleDiagnostics(ctx, extension.LifecycleToolError, &result, toolResultDiagnostics(event))
 }
 
 func applyToolCallMutation(call *ToolCallEvent, mutation extension.ToolCallMutation) {

--- a/internal/assistant/lifecycle_diagnostics.go
+++ b/internal/assistant/lifecycle_diagnostics.go
@@ -1,0 +1,117 @@
+package assistant
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/omarluq/librecode/internal/extension"
+)
+
+const (
+	lifecycleHookCountKey  = "hook_count"
+	lifecycleDurationMsKey = "duration_ms"
+	lifecycleErrorsKey     = "hook_errors"
+)
+
+func (runtime *Runtime) emitLifecycleDiagnostics(
+	ctx context.Context,
+	name extension.LifecycleEventName,
+	result *extension.LifecycleDispatchResult,
+	extra map[string]any,
+) {
+	payload := map[string]any{
+		"event":                string(name),
+		lifecycleHookCountKey:  result.HandlerCount,
+		lifecycleDurationMsKey: durationMilliseconds(result.Duration),
+	}
+	if len(result.Errors) > 0 {
+		payload[lifecycleErrorsKey] = append([]string{}, result.Errors...)
+	}
+	for key, value := range extra {
+		payload[key] = value
+	}
+
+	runtime.emit(ctx, string(name)+"_diagnostic", payload)
+}
+
+func durationMilliseconds(duration time.Duration) float64 {
+	return float64(duration.Microseconds()) / 1000
+}
+
+func providerHookDiagnostics(input providerHookInput, output providerHookOutput) map[string]any {
+	return map[string]any{
+		lifecycleAPIKey:             input.Request.Model.API,
+		lifecycleAttemptKey:         input.Attempt,
+		jsonModelKey:                input.Request.Model.ID,
+		lifecycleProviderKey:        input.Request.Model.Provider,
+		jsonSessionIDKey:            input.Request.SessionID,
+		"mutated_header_count":      changedStringMapCount(input.Headers, output.Headers),
+		"mutated_payload_key_count": changedAnyMapCount(input.Payload, output.Payload),
+	}
+}
+
+func toolCallDiagnostics(call *ToolCallEvent) map[string]any {
+	return map[string]any{
+		"call_id":       call.ID,
+		jsonToolNameKey: call.Name,
+		"argument_keys": sortedAnyMapKeys(call.Arguments),
+	}
+}
+
+func sortedAnyMapKeys(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	return keys
+}
+
+func toolResultDiagnostics(event *ToolEvent) map[string]any {
+	return map[string]any{
+		jsonToolNameKey:       event.Name,
+		"has_error":           event.Error != "",
+		"result_bytes":        len(event.Result),
+		"details_json_bytes":  len(event.DetailsJSON),
+		lifecycleToolErrorKey: event.Error,
+	}
+}
+
+func changedStringMapCount(before, after map[string]string) int {
+	changed := 0
+	seen := map[string]struct{}{}
+	for key, beforeValue := range before {
+		seen[key] = struct{}{}
+		if after[key] != beforeValue {
+			changed++
+		}
+	}
+	for key := range after {
+		if _, ok := seen[key]; !ok {
+			changed++
+		}
+	}
+
+	return changed
+}
+
+func changedAnyMapCount(before, after map[string]any) int {
+	changed := 0
+	seen := map[string]struct{}{}
+	for key, beforeValue := range before {
+		seen[key] = struct{}{}
+		if fmt.Sprint(after[key]) != fmt.Sprint(beforeValue) {
+			changed++
+		}
+	}
+	for key := range after {
+		if _, ok := seen[key]; !ok {
+			changed++
+		}
+	}
+
+	return changed
+}

--- a/internal/assistant/provider_diagnostics_internal_test.go
+++ b/internal/assistant/provider_diagnostics_internal_test.go
@@ -1,0 +1,103 @@
+package assistant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samber/ro"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/event"
+	"github.com/omarluq/librecode/internal/extension"
+)
+
+func TestRuntime_ProviderRequestHookEmitsDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	runtime := newProviderHookTestRuntime(t, `
+local lc = require("librecode")
+lc.on("before_provider_request", { priority = 10 }, function(event)
+  event.payload.payload.metadata = "changed"
+  return {
+    payload = event.payload,
+    provider_request = {
+      headers = {
+        ["X-Debug"] = "yes",
+      },
+    },
+  }
+end)
+`)
+	events := collectAssistantDiagnostics(
+		t,
+		runtime.EventBus(),
+		string(extension.LifecycleBeforeProviderRequest)+"_diagnostic",
+	)
+	input := providerHookInput{
+		Request: providerHookTestRequest(),
+		Payload: map[string]any{providerHookMessagesKey: []any{}},
+		Headers: map[string]string{},
+		Attempt: 3,
+	}
+
+	_, err := runtime.dispatchProviderRequestHook(context.Background(), input)
+
+	require.NoError(t, err)
+	require.Len(t, *events, 1)
+	diagnostic := (*events)[0]
+	assert.Equal(t, string(extension.LifecycleBeforeProviderRequest), diagnostic["event"])
+	assert.Equal(t, 1, diagnostic[lifecycleHookCountKey])
+	assert.Equal(t, 3, diagnostic[lifecycleAttemptKey])
+	assert.Equal(t, providerHookTestModelID, diagnostic[jsonModelKey])
+	assert.Equal(t, 1, diagnostic["mutated_header_count"])
+	assert.Equal(t, 2, diagnostic["mutated_payload_key_count"])
+}
+
+func TestRuntime_ProviderRequestHookEmitsDiagnosticsForNoopHandler(t *testing.T) {
+	t.Parallel()
+
+	runtime := newProviderHookTestRuntime(t, `
+local lc = require("librecode")
+lc.on("before_provider_request", function()
+  return { provider_request = {} }
+end)
+`)
+	events := collectAssistantDiagnostics(
+		t,
+		runtime.EventBus(),
+		string(extension.LifecycleBeforeProviderRequest)+"_diagnostic",
+	)
+	input := providerHookInput{
+		Request: providerHookTestRequest(),
+		Payload: map[string]any{"original": "value"},
+		Headers: map[string]string{},
+		Attempt: 1,
+	}
+
+	result, err := runtime.dispatchProviderRequestHook(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.Equal(t, "value", result.Payload["original"])
+	require.Len(t, *events, 1)
+	assert.Equal(t, 1, (*events)[0][lifecycleHookCountKey])
+}
+
+func collectAssistantDiagnostics(t *testing.T, bus *event.Bus, channel string) *[]map[string]any {
+	t.Helper()
+
+	diagnostics := []map[string]any{}
+	subscription := bus.Channel(channel).Subscribe(ro.NewObserver(
+		func(envelope event.Envelope) {
+			payload, ok := envelope.Data.(map[string]any)
+			if ok {
+				diagnostics = append(diagnostics, payload)
+			}
+		},
+		func(error) {},
+		func() {},
+	))
+	t.Cleanup(subscription.Unsubscribe)
+
+	return &diagnostics
+}

--- a/internal/assistant/provider_diagnostics_internal_test.go
+++ b/internal/assistant/provider_diagnostics_internal_test.go
@@ -70,7 +70,7 @@ end)
 	)
 	input := providerHookInput{
 		Request: providerHookTestRequest(),
-		Payload: map[string]any{"original": "value"},
+		Payload: map[string]any{providerHookOriginalKey: providerHookOriginalValue},
 		Headers: map[string]string{},
 		Attempt: 1,
 	}
@@ -78,9 +78,39 @@ end)
 	result, err := runtime.dispatchProviderRequestHook(context.Background(), input)
 
 	require.NoError(t, err)
-	assert.Equal(t, "value", result.Payload["original"])
+	assert.Equal(t, providerHookOriginalValue, result.Payload[providerHookOriginalKey])
 	require.Len(t, *events, 1)
 	assert.Equal(t, 1, (*events)[0][lifecycleHookCountKey])
+}
+
+func TestRuntime_ProviderRequestHookEmitsDiagnosticsOnHandlerError(t *testing.T) {
+	t.Parallel()
+
+	runtime := newProviderHookTestRuntime(t, `
+local lc = require("librecode")
+lc.on("before_provider_request", function()
+  error("provider hook failed")
+end)
+`)
+	events := collectAssistantDiagnostics(
+		t,
+		runtime.EventBus(),
+		string(extension.LifecycleBeforeProviderRequest)+"_diagnostic",
+	)
+	input := providerHookInput{
+		Request: providerHookTestRequest(),
+		Payload: map[string]any{providerHookOriginalKey: providerHookOriginalValue},
+		Headers: map[string]string{},
+		Attempt: 1,
+	}
+
+	_, err := runtime.dispatchProviderRequestHook(context.Background(), input)
+
+	require.Error(t, err)
+	require.Len(t, *events, 1)
+	diagnostic := (*events)[0]
+	assert.Equal(t, 1, diagnostic[lifecycleHookCountKey])
+	require.Contains(t, diagnostic, lifecycleErrorsKey)
 }
 
 func collectAssistantDiagnostics(t *testing.T, bus *event.Bus, channel string) *[]map[string]any {

--- a/internal/assistant/provider_hooks.go
+++ b/internal/assistant/provider_hooks.go
@@ -82,17 +82,6 @@ func (runtime *Runtime) dispatchProviderRequestHook(
 ) (providerHookOutput, error) {
 	payload := providerRequestLifecyclePayload(input)
 	result, err := runtime.dispatchLifecycle(ctx, extension.LifecycleBeforeProviderRequest, payload)
-	if err != nil {
-		return providerHookOutput{}, oops.In("assistant").
-			Code("before_provider_request_dispatch_failed").
-			Wrapf(err, "dispatch before_provider_request lifecycle")
-	}
-	if err := validateProviderRequestMutation(result.ProviderRequest); err != nil {
-		return providerHookOutput{}, oops.In("assistant").
-			Code("provider_request_mutation_invalid").
-			Wrapf(err, "validate provider_request mutation")
-	}
-
 	output := providerHookOutput{
 		Payload: providerPayloadFromLifecycle(result.Payload, input.Payload),
 		Headers: mergeProviderHeaders(input.Headers, result.ProviderRequest.Headers),
@@ -103,6 +92,16 @@ func (runtime *Runtime) dispatchProviderRequestHook(
 		&result,
 		providerHookDiagnostics(input, output),
 	)
+	if err != nil {
+		return providerHookOutput{}, oops.In("assistant").
+			Code("before_provider_request_dispatch_failed").
+			Wrapf(err, "dispatch before_provider_request lifecycle")
+	}
+	if err := validateProviderRequestMutation(result.ProviderRequest); err != nil {
+		return providerHookOutput{}, oops.In("assistant").
+			Code("provider_request_mutation_invalid").
+			Wrapf(err, "validate provider_request mutation")
+	}
 
 	return output, nil
 }

--- a/internal/assistant/provider_hooks.go
+++ b/internal/assistant/provider_hooks.go
@@ -93,10 +93,18 @@ func (runtime *Runtime) dispatchProviderRequestHook(
 			Wrapf(err, "validate provider_request mutation")
 	}
 
-	return providerHookOutput{
+	output := providerHookOutput{
 		Payload: providerPayloadFromLifecycle(result.Payload, input.Payload),
 		Headers: mergeProviderHeaders(input.Headers, result.ProviderRequest.Headers),
-	}, nil
+	}
+	runtime.emitLifecycleDiagnostics(
+		ctx,
+		extension.LifecycleBeforeProviderRequest,
+		&result,
+		providerHookDiagnostics(input, output),
+	)
+
+	return output, nil
 }
 
 func providerRequestLifecyclePayload(input providerHookInput) map[string]any {

--- a/internal/assistant/provider_hooks_internal_test.go
+++ b/internal/assistant/provider_hooks_internal_test.go
@@ -17,8 +17,10 @@ import (
 )
 
 const (
-	providerHookTestModelID = "test-model"
-	providerHookMessagesKey = "messages"
+	providerHookOriginalKey   = "original"
+	providerHookOriginalValue = "value"
+	providerHookTestModelID   = "test-model"
+	providerHookMessagesKey   = "messages"
 )
 
 func TestRuntime_ProviderRequestHookMutatesPayloadAndHeaders(t *testing.T) {
@@ -71,7 +73,7 @@ end)
 `)
 	input := providerHookInput{
 		Request: providerHookTestRequest(),
-		Payload: map[string]any{"original": "value"},
+		Payload: map[string]any{providerHookOriginalKey: providerHookOriginalValue},
 		Headers: map[string]string{},
 		Attempt: 1,
 	}
@@ -79,7 +81,7 @@ end)
 	result, err := runtime.dispatchProviderRequestHook(context.Background(), input)
 
 	require.NoError(t, err)
-	assert.Equal(t, "value", result.Payload["original"])
+	assert.Equal(t, providerHookOriginalValue, result.Payload[providerHookOriginalKey])
 	assert.Equal(t, "yes", result.Headers["X-Test-Header"])
 }
 

--- a/internal/assistant/provider_hooks_internal_test.go
+++ b/internal/assistant/provider_hooks_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/omarluq/librecode/internal/event"
 	"github.com/omarluq/librecode/internal/extension"
 	"github.com/omarluq/librecode/internal/model"
 )
@@ -146,7 +147,7 @@ func newProviderHookTestRuntime(t *testing.T, source string) *Runtime {
 		sessions:   nil,
 		extensions: manager,
 		cache:      nil,
-		events:     nil,
+		events:     event.NewBus(testProviderHookLogger()),
 		models:     nil,
 		client:     nil,
 		logger:     testProviderHookLogger(),

--- a/internal/assistant/runtime_events_test.go
+++ b/internal/assistant/runtime_events_test.go
@@ -18,8 +18,11 @@ import (
 const (
 	testCompletionText = "done"
 	testToolName       = "read"
+	testToolPath       = "README.md"
 	testToolPathKey    = "path"
 	testToolArgsJSON   = `{"path":"README.md"}`
+	testToolCallID     = "call-1"
+	testToolResult     = "contents"
 )
 
 func TestRuntime_ProviderLifecyclePublishesReactiveEvents(t *testing.T) {
@@ -103,8 +106,8 @@ func (toolCallbackClient) Complete(
 ) (*assistant.CompletionResult, error) {
 	if request.OnToolCall != nil {
 		toolCall := assistant.ToolCallEvent{
-			Arguments:     map[string]any{"path": "README.md"},
-			ID:            "call-1",
+			Arguments:     map[string]any{testToolPathKey: testToolPath},
+			ID:            testToolCallID,
 			Name:          testToolName,
 			ArgumentsJSON: testToolArgsJSON,
 		}
@@ -117,7 +120,7 @@ func (toolCallbackClient) Complete(
 			Name:          testToolName,
 			ArgumentsJSON: testToolArgsJSON,
 			DetailsJSON:   "",
-			Result:        "contents",
+			Result:        testToolResult,
 			Error:         "",
 		}
 		if err := request.OnToolResult(ctx, &toolResult); err != nil {

--- a/internal/assistant/runtime_lifecycle_test.go
+++ b/internal/assistant/runtime_lifecycle_test.go
@@ -197,7 +197,7 @@ func TestRuntime_PromptEmitsSideEffectMessageAppendEvents(t *testing.T) {
 					Name:          testToolName,
 					ArgumentsJSON: testToolArgsJSON,
 					DetailsJSON:   "",
-					Result:        "contents",
+					Result:        testToolResult,
 					Error:         "",
 				},
 			},

--- a/internal/assistant/tool_diagnostics_test.go
+++ b/internal/assistant/tool_diagnostics_test.go
@@ -1,0 +1,94 @@
+package assistant_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samber/ro"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/assistant"
+	"github.com/omarluq/librecode/internal/event"
+	"github.com/omarluq/librecode/internal/extension"
+)
+
+func TestRuntime_ToolLifecycleEmitsDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	runtime, _, manager := newTestRuntimeWithManager(t, testCompletionClient{})
+	loadRuntimeExtension(t, manager, `
+local lc = require("librecode")
+lc.on("tool_call", function(event)
+  return {
+    tool_call = {
+      arguments = {
+        path = "changed.txt",
+      },
+    },
+  }
+end)
+lc.on("tool_result", function(event)
+  return {
+    tool_result = {
+      result = "redacted",
+    },
+  }
+end)
+`)
+	toolCallDiagnostics := collectRuntimeDiagnosticPayloads(
+		t,
+		runtime.EventBus(),
+		string(extension.LifecycleToolCall)+"_diagnostic",
+	)
+	toolResultDiagnostics := collectRuntimeDiagnosticPayloads(
+		t,
+		runtime.EventBus(),
+		string(extension.LifecycleToolResult)+"_diagnostic",
+	)
+	call := assistant.ToolCallEvent{
+		Arguments:     map[string]any{testToolPathKey: testToolPath},
+		ID:            testToolCallID,
+		Name:          testToolName,
+		ArgumentsJSON: testToolArgsJSON,
+	}
+	toolEvent := &assistant.ToolEvent{
+		Name:          testToolName,
+		ArgumentsJSON: testToolArgsJSON,
+		DetailsJSON:   "{}",
+		Result:        "secret",
+		Error:         "",
+	}
+
+	require.NoError(t, runtime.DispatchToolCallLifecycleForTest(context.Background(), &call))
+	require.NoError(t, runtime.DispatchToolResultLifecycleForTest(context.Background(), toolEvent))
+
+	require.Len(t, *toolCallDiagnostics, 1)
+	assert.Equal(t, 1, (*toolCallDiagnostics)[0]["hook_count"])
+	assert.Equal(t, testToolName, (*toolCallDiagnostics)[0]["name"])
+	assert.Equal(t, []string{"path"}, (*toolCallDiagnostics)[0]["argument_keys"])
+	require.Len(t, *toolResultDiagnostics, 1)
+	assert.Equal(t, 1, (*toolResultDiagnostics)[0]["hook_count"])
+	assert.Equal(t, testToolName, (*toolResultDiagnostics)[0]["name"])
+	assert.Equal(t, false, (*toolResultDiagnostics)[0]["has_error"])
+	assert.Equal(t, len("redacted"), (*toolResultDiagnostics)[0]["result_bytes"])
+}
+
+func collectRuntimeDiagnosticPayloads(t *testing.T, bus *event.Bus, channel string) *[]map[string]any {
+	t.Helper()
+
+	payloads := []map[string]any{}
+	subscription := bus.Channel(channel).Subscribe(ro.NewObserver(
+		func(envelope event.Envelope) {
+			payload, ok := envelope.Data.(map[string]any)
+			if ok {
+				payloads = append(payloads, payload)
+			}
+		},
+		func(error) {},
+		func() {},
+	))
+	t.Cleanup(subscription.Unsubscribe)
+
+	return &payloads
+}

--- a/internal/assistant/tool_lifecycle_test.go
+++ b/internal/assistant/tool_lifecycle_test.go
@@ -160,6 +160,54 @@ func TestRuntime_ToolLifecycleEmitsDiagnosticsWithoutHandlers(t *testing.T) {
 	assert.Equal(t, 0, (*toolResultDiagnostics)[0]["hook_count"])
 }
 
+func TestRuntime_ToolLifecycleEmitsDiagnosticsOnHandlerError(t *testing.T) {
+	t.Parallel()
+
+	runtime, _, manager := newTestRuntimeWithManager(t, testCompletionClient{})
+	loadRuntimeExtension(t, manager, `
+local lc = require("librecode")
+lc.on("tool_call", function()
+  error("tool hook failed")
+end)
+lc.on("tool_result", function()
+  error("tool result hook failed")
+end)
+`)
+	toolCallDiagnostics := collectRuntimeDiagnosticPayloads(
+		t,
+		runtime.EventBus(),
+		"tool_call_diagnostic",
+	)
+	toolResultDiagnostics := collectRuntimeDiagnosticPayloads(
+		t,
+		runtime.EventBus(),
+		"tool_result_diagnostic",
+	)
+	call := assistant.ToolCallEvent{
+		Arguments:     map[string]any{testToolPathKey: testToolPath},
+		ID:            testToolCallID,
+		Name:          testToolName,
+		ArgumentsJSON: testToolArgsJSON,
+	}
+	event := &assistant.ToolEvent{
+		Name:          testToolName,
+		ArgumentsJSON: testToolArgsJSON,
+		DetailsJSON:   "{}",
+		Result:        testToolResult,
+		Error:         "",
+	}
+
+	callErr := runtime.DispatchToolCallLifecycleForTest(context.Background(), &call)
+	resultErr := runtime.DispatchToolResultLifecycleForTest(context.Background(), event)
+
+	require.Error(t, callErr)
+	require.Error(t, resultErr)
+	require.Len(t, *toolCallDiagnostics, 1)
+	require.Contains(t, (*toolCallDiagnostics)[0], "hook_errors")
+	require.Len(t, *toolResultDiagnostics, 1)
+	require.Contains(t, (*toolResultDiagnostics)[0], "hook_errors")
+}
+
 func TestRuntime_ToolResultLifecycleDispatchesToolErrorHandlers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/assistant/tool_lifecycle_test.go
+++ b/internal/assistant/tool_lifecycle_test.go
@@ -24,7 +24,7 @@ func TestRuntime_ToolCallLifecycleAppliesArgumentMutation(t *testing.T) {
 	}{
 		{
 			name:             "rewrites path and adds limit",
-			initialArguments: map[string]any{testToolPathKey: "README.md"},
+			initialArguments: map[string]any{testToolPathKey: testToolPath},
 			lua: `
 local lc = require("librecode")
 lc.on("tool_call", function(event)
@@ -54,7 +54,7 @@ end)
 			loadRuntimeExtension(t, manager, testCase.lua)
 			call := assistant.ToolCallEvent{
 				Arguments:     testCase.initialArguments,
-				ID:            "call-1",
+				ID:            testToolCallID,
 				Name:          testToolName,
 				ArgumentsJSON: testToolArgsJSON,
 			}
@@ -123,6 +123,43 @@ end)
 	}
 }
 
+func TestRuntime_ToolLifecycleEmitsDiagnosticsWithoutHandlers(t *testing.T) {
+	t.Parallel()
+
+	runtime, _, _ := newTestRuntimeWithManager(t, testCompletionClient{})
+	toolCallDiagnostics := collectRuntimeDiagnosticPayloads(
+		t,
+		runtime.EventBus(),
+		"tool_call_diagnostic",
+	)
+	toolResultDiagnostics := collectRuntimeDiagnosticPayloads(
+		t,
+		runtime.EventBus(),
+		"tool_result_diagnostic",
+	)
+	call := assistant.ToolCallEvent{
+		Arguments:     map[string]any{testToolPathKey: testToolPath},
+		ID:            testToolCallID,
+		Name:          testToolName,
+		ArgumentsJSON: testToolArgsJSON,
+	}
+	event := &assistant.ToolEvent{
+		Name:          testToolName,
+		ArgumentsJSON: testToolArgsJSON,
+		DetailsJSON:   "{}",
+		Result:        testToolResult,
+		Error:         "",
+	}
+
+	require.NoError(t, runtime.DispatchToolCallLifecycleForTest(context.Background(), &call))
+	require.NoError(t, runtime.DispatchToolResultLifecycleForTest(context.Background(), event))
+
+	require.Len(t, *toolCallDiagnostics, 1)
+	assert.Equal(t, 0, (*toolCallDiagnostics)[0]["hook_count"])
+	require.Len(t, *toolResultDiagnostics, 1)
+	assert.Equal(t, 0, (*toolResultDiagnostics)[0]["hook_count"])
+}
+
 func TestRuntime_ToolResultLifecycleDispatchesToolErrorHandlers(t *testing.T) {
 	t.Parallel()
 
@@ -137,6 +174,11 @@ lc.register_command("seen_tool_error", "seen_tool_error", function()
   return seen
 end)
 `)
+	errorDiagnostics := collectRuntimeDiagnosticPayloads(
+		t,
+		runtime.EventBus(),
+		"tool_error_diagnostic",
+	)
 	event := &assistant.ToolEvent{
 		Name:          testToolName,
 		ArgumentsJSON: testToolArgsJSON,
@@ -151,4 +193,6 @@ end)
 	output, err := manager.ExecuteCommand(context.Background(), "seen_tool_error", "")
 	require.NoError(t, err)
 	assert.Equal(t, "read:boom", output)
+	require.Len(t, *errorDiagnostics, 1)
+	assert.Equal(t, 1, (*errorDiagnostics)[0]["hook_count"])
 }

--- a/internal/extension/lifecycle.go
+++ b/internal/extension/lifecycle.go
@@ -268,12 +268,8 @@ func providerRequestMutationFromLua(value lua.LValue) (ProviderRequestMutation, 
 	if !ok {
 		return ProviderRequestMutation{Headers: map[string]string{}}, false
 	}
-	headers := stringMapValue(payload["headers"])
-	if len(headers) == 0 {
-		return ProviderRequestMutation{Headers: map[string]string{}}, false
-	}
 
-	return ProviderRequestMutation{Headers: headers}, true
+	return ProviderRequestMutation{Headers: stringMapValue(payload["headers"])}, true
 }
 
 func stringMapValue(value any) map[string]string {


### PR DESCRIPTION
## Summary
- add lifecycle diagnostics for provider and tool hooks
- dispatch tool_error through lifecycle handlers
- document provider/tool seam hardening behavior

## Validation
- mise exec -- task ci

Note: docs/refactoring/* remain local and are intentionally excluded.