### PR TITLE
feat: harden provider seam diagnostics

### DIFF
--- a/internal/assistant/lifecycle_diagnostics.go
+++ b/internal/assistant/lifecycle_diagnostics.go
@@ -41,15 +41,67 @@ func durationMilliseconds(duration time.Duration) float64 {
 }
 
 func providerHookDiagnostics(input providerHookInput, output providerHookOutput) map[string]any {
-	return map[string]any{
-		lifecycleAPIKey:             input.Request.Model.API,
-		lifecycleAttemptKey:         input.Attempt,
-		jsonModelKey:                input.Request.Model.ID,
-		lifecycleProviderKey:        input.Request.Model.Provider,
-		jsonSessionIDKey:            input.Request.SessionID,
-		"mutated_header_count":      changedStringMapCount(input.Headers, output.Headers),
-		"mutated_payload_key_count": changedAnyMapCount(input.Payload, output.Payload),
+	diagnostics := providerBaseDiagnostics(input.Request, input.Attempt)
+	diagnostics["mutated_header_count"] = changedStringMapCount(input.Headers, output.Headers)
+	diagnostics["mutated_payload_key_count"] = changedAnyMapCount(input.Payload, output.Payload)
+
+	return diagnostics
+}
+
+func providerBaseDiagnostics(request *CompletionRequest, attempt int) map[string]any {
+	if request == nil {
+		return map[string]any{}
 	}
+
+	return map[string]any{
+		lifecycleAPIKey:      request.Model.API,
+		lifecycleAttemptKey:  attempt,
+		jsonModelKey:         request.Model.ID,
+		lifecycleProviderKey: request.Model.Provider,
+		jsonSessionIDKey:     request.SessionID,
+	}
+}
+
+func providerResponseDiagnostics(
+	request *CompletionRequest,
+	attempt int,
+	result *CompletionResult,
+) map[string]any {
+	if result == nil {
+		return map[string]any{}
+	}
+	diagnostics := providerBaseDiagnostics(request, attempt)
+	diagnostics["response_text_bytes"] = len(result.Text)
+	diagnostics["thinking_count"] = len(result.Thinking)
+	diagnostics["tool_event_count"] = len(result.ToolEvents)
+	diagnostics[jsonContextTokensKey] = result.Usage.ContextTokens
+	diagnostics[jsonContextWindowKey] = result.Usage.ContextWindow
+	diagnostics[jsonInputTokensKey] = result.Usage.InputTokens
+	diagnostics[jsonOutputTokensKey] = result.Usage.OutputTokens
+
+	return diagnostics
+}
+
+func providerErrorDiagnostics(
+	request *CompletionRequest,
+	attempt int,
+	err error,
+) map[string]any {
+	if err == nil {
+		return map[string]any{}
+	}
+
+	diagnostics := providerBaseDiagnostics(request, attempt)
+	diagnostics[lifecycleErrorKey] = err.Error()
+	diagnostics["retryable"] = ShouldRetryModelError(err)
+	if code, ok := providerErrorCode(err); ok {
+		diagnostics["error_code"] = code
+	}
+	if status, ok := providerErrorStatus(err); ok {
+		diagnostics["status"] = status
+	}
+
+	return diagnostics
 }
 
 func toolCallDiagnostics(call *ToolCallEvent) map[string]any {

--- a/internal/assistant/provider_seam_hardening_test.go
+++ b/internal/assistant/provider_seam_hardening_test.go
@@ -1,0 +1,125 @@
+package assistant_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/samber/oops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/assistant"
+	"github.com/omarluq/librecode/internal/extension"
+	"github.com/omarluq/librecode/internal/model"
+)
+
+func TestRuntime_ProviderLifecycleEmitsDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	runtime, _, _ := newTestRuntimeWithManager(t, staticCompletionClient{
+		result: &assistant.CompletionResult{
+			Text:     "provider response",
+			Thinking: []string{"thinking"},
+			ToolEvents: []assistant.ToolEvent{{
+				Name:          "read",
+				ArgumentsJSON: `{}`,
+				DetailsJSON:   `{}`,
+				Result:        "ok",
+				Error:         "",
+			}},
+			Usage: model.TokenUsage{
+				Breakdown:     nil,
+				ContextWindow: 1000,
+				ContextTokens: 100,
+				InputTokens:   80,
+				OutputTokens:  20,
+			},
+		},
+		err: nil,
+	})
+	responseDiagnostics := collectRuntimeDiagnosticPayloads(
+		t,
+		runtime.EventBus(),
+		string(extension.LifecycleAfterProviderResponse)+"_diagnostic",
+	)
+
+	_, err := runtime.Prompt(context.Background(), newRuntimePromptRequest(testRuntimeCWD, "provider diagnostics", ""))
+
+	require.NoError(t, err)
+	require.Len(t, *responseDiagnostics, 1)
+	response := (*responseDiagnostics)[0]
+	assert.Equal(t, 0, response["hook_count"])
+	assert.Equal(t, "test-provider", response["provider"])
+	assert.Equal(t, "test-model", response["model"])
+	assert.Equal(t, len("provider response"), response["response_text_bytes"])
+	assert.Equal(t, 1, response["thinking_count"])
+	assert.Equal(t, 1, response["tool_event_count"])
+	assert.Equal(t, 100, response["context_tokens"])
+	assert.Equal(t, 1000, response["context_window"])
+	assert.Equal(t, 80, response["input_tokens"])
+	assert.Equal(t, 20, response["output_tokens"])
+}
+
+func TestRuntime_ProviderErrorDiagnosticsIncludeRetryAndErrorMetadata(t *testing.T) {
+	t.Parallel()
+
+	providerErr := oops.In("assistant").
+		Code("responses_status").
+		With("status", 503).
+		Errorf("service unavailable")
+	runtime, _, _ := newTestRuntimeWithManager(t, staticCompletionClient{
+		result: nil,
+		err:    providerErr,
+	})
+	errorDiagnostics := collectRuntimeDiagnosticPayloads(
+		t,
+		runtime.EventBus(),
+		string(extension.LifecycleProviderError)+"_diagnostic",
+	)
+
+	_, err := runtime.Prompt(context.Background(), newRuntimePromptRequest(testRuntimeCWD, "provider error", ""))
+
+	require.Error(t, err)
+	require.Len(t, *errorDiagnostics, 3)
+	for _, diagnostic := range *errorDiagnostics {
+		assert.Equal(t, "test-provider", diagnostic["provider"])
+		assert.Equal(t, "test-model", diagnostic["model"])
+		assert.Equal(t, true, diagnostic["retryable"])
+		assert.Equal(t, "responses_status", diagnostic["error_code"])
+		assert.Equal(t, 503, diagnostic["status"])
+		assert.NotEmpty(t, diagnostic["error"])
+	}
+}
+
+func TestRuntime_ProviderErrorDiagnosticsCaptureHookErrors(t *testing.T) {
+	t.Parallel()
+
+	runtime, _, manager := newTestRuntimeWithManager(t, staticCompletionClient{
+		result: nil,
+		err:    errors.New("provider unavailable"),
+	})
+	loadRuntimeExtension(t, manager, `
+local lc = require("librecode")
+lc.on("provider_error", function()
+  error("provider error hook failed")
+end)
+`)
+	errorDiagnostics := collectRuntimeDiagnosticPayloads(
+		t,
+		runtime.EventBus(),
+		string(extension.LifecycleProviderError)+"_diagnostic",
+	)
+
+	_, err := runtime.Prompt(context.Background(), newRuntimePromptRequest(testRuntimeCWD, "provider hook error", ""))
+
+	require.Error(t, err)
+	require.Len(t, *errorDiagnostics, 1)
+	for _, diagnostic := range *errorDiagnostics {
+		assert.Equal(t, 1, diagnostic["hook_count"])
+		hookErrors, ok := diagnostic["hook_errors"].([]string)
+		require.True(t, ok)
+		require.NotEmpty(t, hookErrors)
+		assert.Contains(t, hookErrors[0], "provider error hook failed")
+	}
+}

--- a/internal/assistant/runtime_events.go
+++ b/internal/assistant/runtime_events.go
@@ -37,7 +37,7 @@ func (runtime *Runtime) emitProviderResponse(
 	if request == nil || result == nil {
 		return
 	}
-	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleAfterProviderResponse, map[string]any{
+	payload := map[string]any{
 		lifecycleAPIKey:      request.Model.API,
 		lifecycleAttemptKey:  attempt,
 		jsonModelKey:         request.Model.ID,
@@ -47,21 +47,41 @@ func (runtime *Runtime) emitProviderResponse(
 		"thinking_count":     len(result.Thinking),
 		"tool_event_count":   len(result.ToolEvents),
 		jsonUsageKey:         tokenUsageLifecyclePayload(result.Usage),
-	})
+	}
+	dispatchResult, dispatchErr := runtime.dispatchLifecycle(ctx, extension.LifecycleAfterProviderResponse, payload)
+	if dispatchErr != nil && runtime.logger != nil {
+		runtime.logger.Debug("provider response lifecycle failed", "error", dispatchErr)
+	}
+	runtime.emitLifecycleDiagnostics(
+		ctx,
+		extension.LifecycleAfterProviderResponse,
+		&dispatchResult,
+		providerResponseDiagnostics(request, attempt, result),
+	)
 }
 
 func (runtime *Runtime) emitProviderError(ctx context.Context, request *CompletionRequest, attempt int, err error) {
 	if request == nil || err == nil {
 		return
 	}
-	runtime.dispatchObservationalLifecycle(ctx, extension.LifecycleProviderError, map[string]any{
+	payload := map[string]any{
 		lifecycleAPIKey:      request.Model.API,
 		lifecycleAttemptKey:  attempt,
 		jsonModelKey:         request.Model.ID,
 		lifecycleProviderKey: request.Model.Provider,
 		jsonSessionIDKey:     request.SessionID,
 		lifecycleErrorKey:    err.Error(),
-	})
+	}
+	dispatchResult, dispatchErr := runtime.dispatchLifecycle(ctx, extension.LifecycleProviderError, payload)
+	if dispatchErr != nil && runtime.logger != nil {
+		runtime.logger.Debug("provider error lifecycle failed", "error", dispatchErr)
+	}
+	runtime.emitLifecycleDiagnostics(
+		ctx,
+		extension.LifecycleProviderError,
+		&dispatchResult,
+		providerErrorDiagnostics(request, attempt, err),
+	)
 }
 
 func toolCallPayload(call ToolCallEvent) map[string]any {


### PR DESCRIPTION
## Summary
- add richer provider response/error diagnostics
- dispatch provider response/error lifecycle handlers and emit hook diagnostics
- cover provider response, retryable error metadata, and hook failure diagnostics

## Validation
- mise exec -- go test ./internal/assistant
- mise exec -- task ci
- cr review --agent -t uncommitted --base main (timed out before findings)

Note: docs/refactoring/* remain local/uncommitted and are not part of this PR.