### PR TITLE
feat(database): migrate session ids to uuidv7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gdamore/tcell/v3 v3.4.0
 	github.com/go-viper/mapstructure/v2 v2.5.0
-	github.com/google/uuid v1.6.0
+	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/rs/zerolog v1.35.1
 	github.com/samber/do/v2 v2.0.0
@@ -40,6 +40,7 @@ require (
 	github.com/dlclark/regexp2/v2 v2.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/gdamore/encoding v1.0.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/Oudwins/zog v0.22.2 h1:neSFVFsn7cd4azB9+2hK1sn1By5UZGc8o28vNWJhUIE=
 github.com/Oudwins/zog v0.22.2/go.mod h1:c4ADJ2zNkJp37ZViNy1o3ZZoeMvO7UQVO7BaPtRoocg=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/chroma/v2 v2.26.0 h1:XJhMkCDBUrAAjX0TdzRzIwO9HWa3ynS3hHk5EIP+LbQ=
-github.com/alecthomas/chroma/v2 v2.26.0/go.mod h1:+95AZrRWlpW9g6qXD7S7UdHviopsGP/kCIrtJcU3QoQ=
 github.com/alecthomas/chroma/v2 v2.26.1 h1:2X21EdxGZNv5GF9mG5u+uzc02GCFyGxbcBm3Grd9A78=
 github.com/alecthomas/chroma/v2 v2.26.1/go.mod h1:lxhRRa9H4hPmRLOOdYga4zkQIQjq3dtrrdwQeCfu78Y=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
@@ -21,8 +19,6 @@ github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJ
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dlclark/regexp2/v2 v2.1.0 h1:jHXRmHRZGbuQzDZjMlCAXOvQb75iv3HyLDzXGj5H1AY=
-github.com/dlclark/regexp2/v2 v2.1.0/go.mod h1:Bz5TMy5d8fPK0ximH0Yi9KvsRHNnvXqUx9XG6a4wB+I=
 github.com/dlclark/regexp2/v2 v2.1.1 h1:LCUGyd9Wf+r+VVOl8Ny38JTpWJcAsdVnCIuhhtthmKw=
 github.com/dlclark/regexp2/v2 v2.1.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -37,6 +33,8 @@ github.com/gdamore/tcell/v3 v3.4.0 h1:VUym1HQZiYodA5PGQrqLxF7QwqQndcAUwQD7G7XUy5
 github.com/gdamore/tcell/v3 v3.4.0/go.mod h1:fjKxNiIFwbzTxDU+i+AAMz+xPOgXVaZq5tbShsKseHc=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/gofrs/uuid/v5 v5.4.0 h1:EfbpCTjqMuGyq5ZJwxqzn3Cbr2d0rUZU7v5ycAk/e/0=
+github.com/gofrs/uuid/v5 v5.4.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/internal/database/ids.go
+++ b/internal/database/ids.go
@@ -1,0 +1,7 @@
+package database
+
+import "github.com/gofrs/uuid/v5"
+
+func newUUIDv7() string {
+	return uuid.Must(uuid.NewV7()).String()
+}

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -52,6 +52,5 @@ func Migrate(ctx context.Context, database *sql.DB) error {
 	if _, err := provider.Up(ctx); err != nil {
 		return fmt.Errorf("database: apply migrations: %w", err)
 	}
-
-	return nil
+	return BackfillUUIDv7IDs(ctx, database)
 }

--- a/internal/database/migrations/00005_validate_uuid_ids.sql
+++ b/internal/database/migrations/00005_validate_uuid_ids.sql
@@ -1,0 +1,222 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_sessions_id_uuid_insert
+BEFORE INSERT ON sessions
+FOR EACH ROW
+WHEN NEW.id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'sessions.id must be a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_sessions_id_uuid_update
+BEFORE UPDATE OF id ON sessions
+FOR EACH ROW
+WHEN NEW.id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'sessions.id must be a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_sessions_parent_session_uuid_insert
+BEFORE INSERT ON sessions
+FOR EACH ROW
+WHEN NEW.parent_session <> '' AND NEW.parent_session NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'sessions.parent_session must be empty or a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_sessions_parent_session_uuid_update
+BEFORE UPDATE OF parent_session ON sessions
+FOR EACH ROW
+WHEN NEW.parent_session <> '' AND NEW.parent_session NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'sessions.parent_session must be empty or a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_entries_session_id_uuid_insert
+BEFORE INSERT ON session_entries
+FOR EACH ROW
+WHEN NEW.session_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_entries.session_id must be a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_entries_session_id_uuid_update
+BEFORE UPDATE OF session_id ON session_entries
+FOR EACH ROW
+WHEN NEW.session_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_entries.session_id must be a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_entries_id_uuid_insert
+BEFORE INSERT ON session_entries
+FOR EACH ROW
+WHEN NEW.id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_entries.id must be a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_entries_id_uuid_update
+BEFORE UPDATE OF id ON session_entries
+FOR EACH ROW
+WHEN NEW.id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_entries.id must be a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_entries_parent_id_uuid_insert
+BEFORE INSERT ON session_entries
+FOR EACH ROW
+WHEN NEW.parent_id IS NOT NULL AND NEW.parent_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_entries.parent_id must be NULL or a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_entries_parent_id_uuid_update
+BEFORE UPDATE OF parent_id ON session_entries
+FOR EACH ROW
+WHEN NEW.parent_id IS NOT NULL AND NEW.parent_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_entries.parent_id must be NULL or a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_entries_compaction_first_kept_entry_id_uuid_insert
+BEFORE INSERT ON session_entries
+FOR EACH ROW
+WHEN NEW.compaction_first_kept_entry_id <> '' AND NEW.compaction_first_kept_entry_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_entries.compaction_first_kept_entry_id must be empty or a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_entries_compaction_first_kept_entry_id_uuid_update
+BEFORE UPDATE OF compaction_first_kept_entry_id ON session_entries
+FOR EACH ROW
+WHEN NEW.compaction_first_kept_entry_id <> '' AND NEW.compaction_first_kept_entry_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_entries.compaction_first_kept_entry_id must be empty or a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_entries_branch_from_entry_id_uuid_insert
+BEFORE INSERT ON session_entries
+FOR EACH ROW
+WHEN NEW.branch_from_entry_id <> '' AND NEW.branch_from_entry_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_entries.branch_from_entry_id must be empty or a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_entries_branch_from_entry_id_uuid_update
+BEFORE UPDATE OF branch_from_entry_id ON session_entries
+FOR EACH ROW
+WHEN NEW.branch_from_entry_id <> '' AND NEW.branch_from_entry_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_entries.branch_from_entry_id must be empty or a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_messages_id_uuid_insert
+BEFORE INSERT ON session_messages
+FOR EACH ROW
+WHEN NEW.id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_messages.id must be a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_messages_id_uuid_update
+BEFORE UPDATE OF id ON session_messages
+FOR EACH ROW
+WHEN NEW.id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_messages.id must be a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_messages_session_id_uuid_insert
+BEFORE INSERT ON session_messages
+FOR EACH ROW
+WHEN NEW.session_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_messages.session_id must be a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_messages_session_id_uuid_update
+BEFORE UPDATE OF session_id ON session_messages
+FOR EACH ROW
+WHEN NEW.session_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_messages.session_id must be a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_messages_entry_id_uuid_insert
+BEFORE INSERT ON session_messages
+FOR EACH ROW
+WHEN NEW.entry_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_messages.entry_id must be a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS validate_session_messages_entry_id_uuid_update
+BEFORE UPDATE OF entry_id ON session_messages
+FOR EACH ROW
+WHEN NEW.entry_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+BEGIN
+    SELECT RAISE(ABORT, 'session_messages.entry_id must be a UUIDv7');
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+DROP TRIGGER IF EXISTS validate_session_messages_entry_id_uuid_update;
+DROP TRIGGER IF EXISTS validate_session_messages_entry_id_uuid_insert;
+DROP TRIGGER IF EXISTS validate_session_messages_session_id_uuid_update;
+DROP TRIGGER IF EXISTS validate_session_messages_session_id_uuid_insert;
+DROP TRIGGER IF EXISTS validate_session_messages_id_uuid_update;
+DROP TRIGGER IF EXISTS validate_session_messages_id_uuid_insert;
+DROP TRIGGER IF EXISTS validate_session_entries_branch_from_entry_id_uuid_update;
+DROP TRIGGER IF EXISTS validate_session_entries_branch_from_entry_id_uuid_insert;
+DROP TRIGGER IF EXISTS validate_session_entries_compaction_first_kept_entry_id_uuid_update;
+DROP TRIGGER IF EXISTS validate_session_entries_compaction_first_kept_entry_id_uuid_insert;
+DROP TRIGGER IF EXISTS validate_session_entries_parent_id_uuid_update;
+DROP TRIGGER IF EXISTS validate_session_entries_parent_id_uuid_insert;
+DROP TRIGGER IF EXISTS validate_session_entries_session_id_uuid_update;
+DROP TRIGGER IF EXISTS validate_session_entries_session_id_uuid_insert;
+DROP TRIGGER IF EXISTS validate_session_entries_id_uuid_update;
+DROP TRIGGER IF EXISTS validate_session_entries_id_uuid_insert;
+DROP TRIGGER IF EXISTS validate_sessions_parent_session_uuid_update;
+DROP TRIGGER IF EXISTS validate_sessions_parent_session_uuid_insert;
+DROP TRIGGER IF EXISTS validate_sessions_id_uuid_update;
+DROP TRIGGER IF EXISTS validate_sessions_id_uuid_insert;

--- a/internal/database/migrations/00005_validate_uuid_ids.sql
+++ b/internal/database/migrations/00005_validate_uuid_ids.sql
@@ -1,9 +1,12 @@
 -- +goose Up
+CREATE TABLE IF NOT EXISTS uuid_v7_pattern (pattern TEXT NOT NULL);
+INSERT INTO uuid_v7_pattern (pattern) VALUES ('[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]');
+
 -- +goose StatementBegin
 CREATE TRIGGER IF NOT EXISTS validate_sessions_id_uuid_insert
 BEFORE INSERT ON sessions
 FOR EACH ROW
-WHEN NEW.id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'sessions.id must be a UUIDv7');
 END;
@@ -13,7 +16,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_sessions_id_uuid_update
 BEFORE UPDATE OF id ON sessions
 FOR EACH ROW
-WHEN NEW.id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'sessions.id must be a UUIDv7');
 END;
@@ -23,7 +26,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_sessions_parent_session_uuid_insert
 BEFORE INSERT ON sessions
 FOR EACH ROW
-WHEN NEW.parent_session <> '' AND NEW.parent_session NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.parent_session <> '' AND NEW.parent_session NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'sessions.parent_session must be empty or a UUIDv7');
 END;
@@ -33,7 +36,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_sessions_parent_session_uuid_update
 BEFORE UPDATE OF parent_session ON sessions
 FOR EACH ROW
-WHEN NEW.parent_session <> '' AND NEW.parent_session NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.parent_session <> '' AND NEW.parent_session NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'sessions.parent_session must be empty or a UUIDv7');
 END;
@@ -43,7 +46,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_entries_session_id_uuid_insert
 BEFORE INSERT ON session_entries
 FOR EACH ROW
-WHEN NEW.session_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.session_id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_entries.session_id must be a UUIDv7');
 END;
@@ -53,7 +56,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_entries_session_id_uuid_update
 BEFORE UPDATE OF session_id ON session_entries
 FOR EACH ROW
-WHEN NEW.session_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.session_id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_entries.session_id must be a UUIDv7');
 END;
@@ -63,7 +66,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_entries_id_uuid_insert
 BEFORE INSERT ON session_entries
 FOR EACH ROW
-WHEN NEW.id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_entries.id must be a UUIDv7');
 END;
@@ -73,7 +76,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_entries_id_uuid_update
 BEFORE UPDATE OF id ON session_entries
 FOR EACH ROW
-WHEN NEW.id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_entries.id must be a UUIDv7');
 END;
@@ -83,7 +86,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_entries_parent_id_uuid_insert
 BEFORE INSERT ON session_entries
 FOR EACH ROW
-WHEN NEW.parent_id IS NOT NULL AND NEW.parent_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.parent_id IS NOT NULL AND NEW.parent_id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_entries.parent_id must be NULL or a UUIDv7');
 END;
@@ -93,7 +96,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_entries_parent_id_uuid_update
 BEFORE UPDATE OF parent_id ON session_entries
 FOR EACH ROW
-WHEN NEW.parent_id IS NOT NULL AND NEW.parent_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.parent_id IS NOT NULL AND NEW.parent_id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_entries.parent_id must be NULL or a UUIDv7');
 END;
@@ -103,7 +106,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_entries_compaction_first_kept_entry_id_uuid_insert
 BEFORE INSERT ON session_entries
 FOR EACH ROW
-WHEN NEW.compaction_first_kept_entry_id <> '' AND NEW.compaction_first_kept_entry_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.compaction_first_kept_entry_id <> '' AND NEW.compaction_first_kept_entry_id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_entries.compaction_first_kept_entry_id must be empty or a UUIDv7');
 END;
@@ -113,7 +116,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_entries_compaction_first_kept_entry_id_uuid_update
 BEFORE UPDATE OF compaction_first_kept_entry_id ON session_entries
 FOR EACH ROW
-WHEN NEW.compaction_first_kept_entry_id <> '' AND NEW.compaction_first_kept_entry_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.compaction_first_kept_entry_id <> '' AND NEW.compaction_first_kept_entry_id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_entries.compaction_first_kept_entry_id must be empty or a UUIDv7');
 END;
@@ -123,7 +126,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_entries_branch_from_entry_id_uuid_insert
 BEFORE INSERT ON session_entries
 FOR EACH ROW
-WHEN NEW.branch_from_entry_id <> '' AND NEW.branch_from_entry_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.branch_from_entry_id <> '' AND NEW.branch_from_entry_id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_entries.branch_from_entry_id must be empty or a UUIDv7');
 END;
@@ -133,7 +136,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_entries_branch_from_entry_id_uuid_update
 BEFORE UPDATE OF branch_from_entry_id ON session_entries
 FOR EACH ROW
-WHEN NEW.branch_from_entry_id <> '' AND NEW.branch_from_entry_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.branch_from_entry_id <> '' AND NEW.branch_from_entry_id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_entries.branch_from_entry_id must be empty or a UUIDv7');
 END;
@@ -143,7 +146,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_messages_id_uuid_insert
 BEFORE INSERT ON session_messages
 FOR EACH ROW
-WHEN NEW.id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_messages.id must be a UUIDv7');
 END;
@@ -153,7 +156,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_messages_id_uuid_update
 BEFORE UPDATE OF id ON session_messages
 FOR EACH ROW
-WHEN NEW.id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_messages.id must be a UUIDv7');
 END;
@@ -163,7 +166,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_messages_session_id_uuid_insert
 BEFORE INSERT ON session_messages
 FOR EACH ROW
-WHEN NEW.session_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.session_id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_messages.session_id must be a UUIDv7');
 END;
@@ -173,7 +176,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_messages_session_id_uuid_update
 BEFORE UPDATE OF session_id ON session_messages
 FOR EACH ROW
-WHEN NEW.session_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.session_id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_messages.session_id must be a UUIDv7');
 END;
@@ -183,7 +186,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_messages_entry_id_uuid_insert
 BEFORE INSERT ON session_messages
 FOR EACH ROW
-WHEN NEW.entry_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.entry_id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_messages.entry_id must be a UUIDv7');
 END;
@@ -193,13 +196,14 @@ END;
 CREATE TRIGGER IF NOT EXISTS validate_session_messages_entry_id_uuid_update
 BEFORE UPDATE OF entry_id ON session_messages
 FOR EACH ROW
-WHEN NEW.entry_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-7[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[89aAbB][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+WHEN NEW.entry_id NOT GLOB (SELECT pattern FROM uuid_v7_pattern LIMIT 1)
 BEGIN
     SELECT RAISE(ABORT, 'session_messages.entry_id must be a UUIDv7');
 END;
 -- +goose StatementEnd
 
 -- +goose Down
+DROP TABLE IF EXISTS uuid_v7_pattern;
 DROP TRIGGER IF EXISTS validate_session_messages_entry_id_uuid_update;
 DROP TRIGGER IF EXISTS validate_session_messages_entry_id_uuid_insert;
 DROP TRIGGER IF EXISTS validate_session_messages_session_id_uuid_update;

--- a/internal/database/session_entry_repository.go
+++ b/internal/database/session_entry_repository.go
@@ -2,14 +2,11 @@ package database
 
 import (
 	"context"
-	"crypto/rand"
 	"database/sql"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/samber/oops"
 )
 
@@ -379,12 +376,7 @@ func boolToInt(value bool) int {
 }
 
 func newEntryID() string {
-	buffer := make([]byte, 4)
-	if _, err := rand.Read(buffer); err != nil {
-		return uuid.NewString()[:8]
-	}
-
-	return hex.EncodeToString(buffer)
+	return newUUIDv7()
 }
 
 func normalizeDataJSON(dataJSON string) string {

--- a/internal/database/session_metadata_test.go
+++ b/internal/database/session_metadata_test.go
@@ -89,13 +89,14 @@ func TestSessionRepository_BackfillsEntryMetadataMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	createdAt := time.Now().UTC().Format(time.RFC3339Nano)
+	legacyEntryID := "019aced0-f39d-7d31-a522-b8d50af94d6a"
 	_, err = connection.ExecContext(
 		ctx,
 		`INSERT INTO session_entries (
 			id, session_id, parent_id, entry_type, role, content,
 			provider, model, custom_type, data_json, summary, created_at
 		) VALUES (?, ?, NULL, ?, ?, ?, '', '', '', '{}', '', ?)`,
-		"legacy-tool",
+		legacyEntryID,
 		session.ID,
 		string(database.EntryTypeMessage),
 		string(database.RoleToolResult),
@@ -106,7 +107,7 @@ func TestSessionRepository_BackfillsEntryMetadataMigration(t *testing.T) {
 
 	require.NoError(t, database.Migrate(ctx, connection))
 
-	entry, found, err := repository.Entry(ctx, session.ID, "legacy-tool")
+	entry, found, err := repository.Entry(ctx, session.ID, legacyEntryID)
 	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, "bash", entry.ToolName)

--- a/internal/database/session_repository.go
+++ b/internal/database/session_repository.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/samber/oops"
 )
 
@@ -25,6 +24,10 @@ func NewSessionRepository(connection *sql.DB) *SessionRepository {
 	}
 }
 
+func newSessionID() string {
+	return newUUIDv7()
+}
+
 // CreateSession creates a new persisted session for a working directory.
 func (repository *SessionRepository) CreateSession(
 	ctx context.Context,
@@ -36,7 +39,7 @@ func (repository *SessionRepository) CreateSession(
 	createdSession := SessionEntity{
 		CreatedAt:     timestamp,
 		UpdatedAt:     timestamp,
-		ID:            uuid.NewString(),
+		ID:            newSessionID(),
 		CWD:           cwd,
 		Name:          name,
 		ParentSession: parentSession,

--- a/internal/database/session_repository_test.go
+++ b/internal/database/session_repository_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite"
@@ -28,6 +29,7 @@ func TestSessionRepository_AppendsMessagesInSessionTree(t *testing.T) {
 
 	createdSession, err := repository.CreateSession(ctx, "/work", "port", "")
 	require.NoError(t, err)
+	assertUUIDV7(t, createdSession.ID)
 
 	firstMessage := database.MessageEntity{
 		Timestamp: time.Now().UTC(),
@@ -38,6 +40,7 @@ func TestSessionRepository_AppendsMessagesInSessionTree(t *testing.T) {
 	}
 	firstEntry, err := repository.AppendMessage(ctx, createdSession.ID, nil, &firstMessage)
 	require.NoError(t, err)
+	assertUUIDV7(t, firstEntry.ID)
 
 	secondMessage := database.MessageEntity{
 		Timestamp: time.Now().UTC(),
@@ -48,6 +51,7 @@ func TestSessionRepository_AppendsMessagesInSessionTree(t *testing.T) {
 	}
 	secondEntry, err := repository.AppendMessage(ctx, createdSession.ID, &firstEntry.ID, &secondMessage)
 	require.NoError(t, err)
+	assertUUIDV7(t, secondEntry.ID)
 
 	latestSession, found, err := repository.LatestSession(ctx, "/work")
 	require.NoError(t, err)
@@ -330,6 +334,14 @@ func newMigratedThroughVersion(t *testing.T, version int64) *sql.DB {
 	require.NoError(t, err)
 
 	return connection
+}
+
+func assertUUIDV7(t *testing.T, value string) {
+	t.Helper()
+
+	parsed, err := uuid.FromString(value)
+	require.NoError(t, err)
+	assert.Equal(t, byte(7), parsed.Version())
 }
 
 func sqliteDriver() string {

--- a/internal/database/uuid_backfill.go
+++ b/internal/database/uuid_backfill.go
@@ -1,0 +1,456 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+type sessionIDRow struct {
+	ID            string
+	ParentSession string
+}
+
+type entryIDRow struct {
+	ID                         string
+	SessionID                  string
+	CompactionFirstKeptEntryID string
+	BranchFromEntryID          string
+	DataJSON                   string
+	ParentID                   sql.NullString
+}
+
+type messageIDRow struct {
+	ID        string
+	SessionID string
+	EntryID   string
+}
+
+// BackfillUUIDv7IDs rewrites existing session graph identifiers to UUIDv7 while preserving relationships.
+func BackfillUUIDv7IDs(ctx context.Context, connection *sql.DB) (err error) {
+	sessions, entries, messages, err := loadIDRows(ctx, connection)
+	if err != nil {
+		return err
+	}
+
+	sessionIDs := uuidV7ReplacementMap(sessionIDsFromRows(sessions))
+	entryIDs := uuidV7ReplacementMap(entryIDsFromRows(entries))
+	messageIDs := uuidV7ReplacementMap(messageIDsFromRows(messages))
+	if noUUIDv7BackfillNeeded(sessionIDs, entryIDs, messageIDs) {
+		return nil
+	}
+
+	foreignKeysEnabled, err := disableForeignKeysForUUIDv7Backfill(ctx, connection)
+	if err != nil {
+		return err
+	}
+	restoreForeignKeys := true
+	defer func() {
+		if restoreForeignKeys {
+			err = errors.Join(err, restoreForeignKeySetting(context.WithoutCancel(ctx), connection, foreignKeysEnabled))
+		}
+	}()
+
+	if err := runUUIDv7BackfillTransaction(
+		ctx,
+		connection,
+		sessions,
+		entries,
+		messages,
+		sessionIDs,
+		entryIDs,
+		messageIDs,
+	); err != nil {
+		return err
+	}
+	if err := restoreForeignKeySetting(ctx, connection, foreignKeysEnabled); err != nil {
+		return err
+	}
+	restoreForeignKeys = false
+
+	return checkForeignKeys(ctx, connection)
+}
+
+func noUUIDv7BackfillNeeded(sessionIDs, entryIDs, messageIDs map[string]string) bool {
+	return len(sessionIDs) == 0 && len(entryIDs) == 0 && len(messageIDs) == 0
+}
+
+func runUUIDv7BackfillTransaction(
+	ctx context.Context,
+	connection *sql.DB,
+	sessions []sessionIDRow,
+	entries []entryIDRow,
+	messages []messageIDRow,
+	sessionIDs map[string]string,
+	entryIDs map[string]string,
+	messageIDs map[string]string,
+) error {
+	transaction, err := connection.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("database: begin UUIDv7 backfill: %w", err)
+	}
+	if err := backfillUUIDv7IDsTx(
+		ctx,
+		transaction,
+		sessions,
+		entries,
+		messages,
+		sessionIDs,
+		entryIDs,
+		messageIDs,
+	); err != nil {
+		rollbackErr := transaction.Rollback()
+		if rollbackErr != nil {
+			return fmt.Errorf("database: rollback UUIDv7 backfill: %w", rollbackErr)
+		}
+		return err
+	}
+	if err := transaction.Commit(); err != nil {
+		return fmt.Errorf("database: commit UUIDv7 backfill: %w", err)
+	}
+
+	return nil
+}
+
+func loadIDRows(
+	ctx context.Context,
+	connection *sql.DB,
+) ([]sessionIDRow, []entryIDRow, []messageIDRow, error) {
+	sessions, err := queryRows(ctx, connection, `SELECT id, parent_session FROM sessions`, scanSessionIDRow)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	entries, err := queryRows(
+		ctx,
+		connection,
+		`SELECT id, session_id, parent_id, data_json,
+compaction_first_kept_entry_id, branch_from_entry_id
+FROM session_entries`,
+		scanEntryIDRow,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	messages, err := queryRows(
+		ctx,
+		connection,
+		`SELECT id, session_id, entry_id FROM session_messages`,
+		scanMessageIDRow,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return sessions, entries, messages, nil
+}
+
+func scanSessionIDRow(scanner rowScanner) (*sessionIDRow, error) {
+	row := sessionIDRow{
+		ID:            "",
+		ParentSession: "",
+	}
+	return &row, scanner.Scan(&row.ID, &row.ParentSession)
+}
+
+func scanEntryIDRow(scanner rowScanner) (*entryIDRow, error) {
+	row := entryIDRow{
+		ParentID:                   sql.NullString{},
+		ID:                         "",
+		SessionID:                  "",
+		CompactionFirstKeptEntryID: "",
+		BranchFromEntryID:          "",
+		DataJSON:                   "",
+	}
+	return &row, scanner.Scan(
+		&row.ID,
+		&row.SessionID,
+		&row.ParentID,
+		&row.DataJSON,
+		&row.CompactionFirstKeptEntryID,
+		&row.BranchFromEntryID,
+	)
+}
+
+func scanMessageIDRow(scanner rowScanner) (*messageIDRow, error) {
+	row := messageIDRow{
+		ID:        "",
+		SessionID: "",
+		EntryID:   "",
+	}
+	return &row, scanner.Scan(&row.ID, &row.SessionID, &row.EntryID)
+}
+
+func queryRows[T any](
+	ctx context.Context,
+	connection *sql.DB,
+	query string,
+	scan func(rowScanner) (*T, error),
+) ([]T, error) {
+	rows, err := connection.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("database: query UUIDv7 backfill rows: %w", err)
+	}
+
+	return collectRows(rows, scan, &rowErrorInfo{
+		scanCode:  "scan_uuid_backfill",
+		scanMsg:   "scan UUIDv7 backfill row",
+		iterCode:  "iterate_uuid_backfill",
+		iterMsg:   "iterate UUIDv7 backfill rows",
+		closeCode: "close_uuid_backfill",
+		closeMsg:  "close UUIDv7 backfill rows",
+	})
+}
+
+func uuidV7ReplacementMap(ids []string) map[string]string {
+	replacements := make(map[string]string)
+	for _, id := range ids {
+		if id == "" || isUUIDv7(id) {
+			continue
+		}
+		replacements[id] = newUUIDv7()
+	}
+
+	return replacements
+}
+
+func sessionIDsFromRows(rows []sessionIDRow) []string {
+	ids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.ID)
+	}
+
+	return ids
+}
+
+func entryIDsFromRows(rows []entryIDRow) []string {
+	ids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.ID)
+	}
+
+	return ids
+}
+
+func messageIDsFromRows(rows []messageIDRow) []string {
+	ids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.ID)
+	}
+
+	return ids
+}
+
+func backfillUUIDv7IDsTx(
+	ctx context.Context,
+	transaction *sql.Tx,
+	sessions []sessionIDRow,
+	entries []entryIDRow,
+	messages []messageIDRow,
+	sessionIDs map[string]string,
+	entryIDs map[string]string,
+	messageIDs map[string]string,
+) error {
+	if err := backfillSessionUUIDv7IDsTx(ctx, transaction, sessions, sessionIDs); err != nil {
+		return err
+	}
+	if err := backfillEntryUUIDv7IDsTx(ctx, transaction, entries, sessionIDs, entryIDs); err != nil {
+		return err
+	}
+
+	return backfillMessageUUIDv7IDsTx(ctx, transaction, messages, sessionIDs, entryIDs, messageIDs)
+}
+
+func backfillSessionUUIDv7IDsTx(
+	ctx context.Context,
+	transaction *sql.Tx,
+	rows []sessionIDRow,
+	sessionIDs map[string]string,
+) error {
+	for _, row := range rows {
+		if _, err := transaction.ExecContext(
+			ctx,
+			`UPDATE sessions SET id = ?, parent_session = ? WHERE id = ?`,
+			replaceID(sessionIDs, row.ID),
+			replaceID(sessionIDs, row.ParentSession),
+			row.ID,
+		); err != nil {
+			return fmt.Errorf("database: backfill session UUIDv7 IDs: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func backfillEntryUUIDv7IDsTx(
+	ctx context.Context,
+	transaction *sql.Tx,
+	rows []entryIDRow,
+	sessionIDs map[string]string,
+	entryIDs map[string]string,
+) error {
+	for index := range rows {
+		if err := backfillEntryUUIDv7IDTx(ctx, transaction, &rows[index], sessionIDs, entryIDs); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func backfillEntryUUIDv7IDTx(
+	ctx context.Context,
+	transaction *sql.Tx,
+	row *entryIDRow,
+	sessionIDs map[string]string,
+	entryIDs map[string]string,
+) error {
+	parentID := sql.NullString{}
+	if row.ParentID.Valid {
+		parentID = sql.NullString{String: replaceID(entryIDs, row.ParentID.String), Valid: true}
+	}
+	dataJSON, err := replaceEntryDataIDs(row.DataJSON, entryIDs)
+	if err != nil {
+		return err
+	}
+	_, err = transaction.ExecContext(
+		ctx,
+		`UPDATE session_entries
+SET id = ?, session_id = ?, parent_id = ?, data_json = ?, compaction_first_kept_entry_id = ?, branch_from_entry_id = ?
+WHERE id = ?`,
+		replaceID(entryIDs, row.ID),
+		replaceID(sessionIDs, row.SessionID),
+		parentID,
+		dataJSON,
+		replaceID(entryIDs, row.CompactionFirstKeptEntryID),
+		replaceID(entryIDs, row.BranchFromEntryID),
+		row.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("database: backfill entry UUIDv7 IDs: %w", err)
+	}
+
+	return nil
+}
+
+func backfillMessageUUIDv7IDsTx(
+	ctx context.Context,
+	transaction *sql.Tx,
+	rows []messageIDRow,
+	sessionIDs map[string]string,
+	entryIDs map[string]string,
+	messageIDs map[string]string,
+) error {
+	for _, row := range rows {
+		if _, err := transaction.ExecContext(
+			ctx,
+			`UPDATE session_messages SET id = ?, session_id = ?, entry_id = ? WHERE id = ?`,
+			replaceID(messageIDs, row.ID),
+			replaceID(sessionIDs, row.SessionID),
+			replaceID(entryIDs, row.EntryID),
+			row.ID,
+		); err != nil {
+			return fmt.Errorf("database: backfill message UUIDv7 IDs: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func replaceEntryDataIDs(dataJSON string, entryIDs map[string]string) (string, error) {
+	if dataJSON == "" || dataJSON == "{}" || len(entryIDs) == 0 {
+		return normalizeDataJSON(dataJSON), nil
+	}
+	var data map[string]any
+	if err := json.Unmarshal([]byte(dataJSON), &data); err != nil {
+		return "", fmt.Errorf("database: decode UUIDv7 backfill entry data: %w", err)
+	}
+	for _, key := range []string{
+		"fromId",
+		"targetId",
+		"firstKeptEntryId",
+		"compactionFirstKeptEntryId",
+		"branchFromEntryId",
+	} {
+		value, ok := data[key].(string)
+		if !ok {
+			continue
+		}
+		data[key] = replaceID(entryIDs, value)
+	}
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		return "", fmt.Errorf("database: encode UUIDv7 backfill entry data: %w", err)
+	}
+
+	return string(encoded), nil
+}
+
+func replaceID(replacements map[string]string, id string) string {
+	if replacement, ok := replacements[id]; ok {
+		return replacement
+	}
+
+	return id
+}
+
+func disableForeignKeysForUUIDv7Backfill(ctx context.Context, connection *sql.DB) (bool, error) {
+	foreignKeysEnabled, err := currentForeignKeySetting(ctx, connection)
+	if err != nil {
+		return false, err
+	}
+	_, execErr := connection.ExecContext(ctx, `PRAGMA foreign_keys = OFF`)
+	if execErr != nil {
+		return false, fmt.Errorf("database: disable foreign keys for UUIDv7 backfill: %w", execErr)
+	}
+
+	return foreignKeysEnabled, nil
+}
+
+func currentForeignKeySetting(ctx context.Context, connection *sql.DB) (bool, error) {
+	var enabled int
+	if err := connection.QueryRowContext(ctx, `PRAGMA foreign_keys`).Scan(&enabled); err != nil {
+		return false, fmt.Errorf("database: read foreign key setting: %w", err)
+	}
+
+	return enabled != 0, nil
+}
+
+func restoreForeignKeySetting(ctx context.Context, connection *sql.DB, enabled bool) error {
+	if enabled {
+		if _, err := connection.ExecContext(ctx, `PRAGMA foreign_keys = ON`); err != nil {
+			return fmt.Errorf("database: restore foreign keys: %w", err)
+		}
+		return nil
+	}
+	if _, err := connection.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
+		return fmt.Errorf("database: restore foreign keys: %w", err)
+	}
+
+	return nil
+}
+
+func checkForeignKeys(ctx context.Context, connection *sql.DB) error {
+	rows, err := connection.QueryContext(ctx, `PRAGMA foreign_key_check`)
+	if err != nil {
+		return fmt.Errorf("database: check foreign keys after UUIDv7 backfill: %w", err)
+	}
+	if rows.Next() {
+		if closeErr := rows.Close(); closeErr != nil {
+			return fmt.Errorf("database: close UUIDv7 foreign key check rows: %w", closeErr)
+		}
+		return fmt.Errorf("database: UUIDv7 backfill left invalid foreign keys")
+	}
+	if err := rows.Err(); err != nil {
+		if closeErr := rows.Close(); closeErr != nil {
+			return fmt.Errorf("database: close UUIDv7 foreign key check rows: %w", closeErr)
+		}
+		return fmt.Errorf("database: iterate UUIDv7 foreign key check: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("database: close UUIDv7 foreign key check rows: %w", err)
+	}
+
+	return nil
+}

--- a/internal/database/uuid_backfill.go
+++ b/internal/database/uuid_backfill.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 )
 
+const closeUUIDv7ForeignKeyCheckRowsError = "database: close UUIDv7 foreign key check rows: %w"
+
 type sessionIDRow struct {
 	ID            string
 	ParentSession string
@@ -28,17 +30,27 @@ type messageIDRow struct {
 	EntryID   string
 }
 
+type uuidV7BackfillRows struct {
+	sessions []sessionIDRow
+	entries  []entryIDRow
+	messages []messageIDRow
+}
+
+type uuidV7BackfillReplacements struct {
+	sessions map[string]string
+	entries  map[string]string
+	messages map[string]string
+}
+
 // BackfillUUIDv7IDs rewrites existing session graph identifiers to UUIDv7 while preserving relationships.
 func BackfillUUIDv7IDs(ctx context.Context, connection *sql.DB) (err error) {
-	sessions, entries, messages, err := loadIDRows(ctx, connection)
+	rows, err := loadIDRows(ctx, connection)
 	if err != nil {
 		return err
 	}
 
-	sessionIDs := uuidV7ReplacementMap(sessionIDsFromRows(sessions))
-	entryIDs := uuidV7ReplacementMap(entryIDsFromRows(entries))
-	messageIDs := uuidV7ReplacementMap(messageIDsFromRows(messages))
-	if noUUIDv7BackfillNeeded(sessionIDs, entryIDs, messageIDs) {
+	replacements := uuidV7ReplacementMaps(rows)
+	if replacements.none() {
 		return nil
 	}
 
@@ -53,16 +65,7 @@ func BackfillUUIDv7IDs(ctx context.Context, connection *sql.DB) (err error) {
 		}
 	}()
 
-	if err := runUUIDv7BackfillTransaction(
-		ctx,
-		connection,
-		sessions,
-		entries,
-		messages,
-		sessionIDs,
-		entryIDs,
-		messageIDs,
-	); err != nil {
+	if err := runUUIDv7BackfillTransaction(ctx, connection, rows, replacements); err != nil {
 		return err
 	}
 	if err := restoreForeignKeySetting(ctx, connection, foreignKeysEnabled); err != nil {
@@ -73,34 +76,29 @@ func BackfillUUIDv7IDs(ctx context.Context, connection *sql.DB) (err error) {
 	return checkForeignKeys(ctx, connection)
 }
 
-func noUUIDv7BackfillNeeded(sessionIDs, entryIDs, messageIDs map[string]string) bool {
-	return len(sessionIDs) == 0 && len(entryIDs) == 0 && len(messageIDs) == 0
+func uuidV7ReplacementMaps(rows uuidV7BackfillRows) uuidV7BackfillReplacements {
+	return uuidV7BackfillReplacements{
+		sessions: uuidV7ReplacementMap(sessionIDsFromRows(rows.sessions)),
+		entries:  uuidV7ReplacementMap(entryIDsFromRows(rows.entries)),
+		messages: uuidV7ReplacementMap(messageIDsFromRows(rows.messages)),
+	}
+}
+
+func (replacements uuidV7BackfillReplacements) none() bool {
+	return len(replacements.sessions) == 0 && len(replacements.entries) == 0 && len(replacements.messages) == 0
 }
 
 func runUUIDv7BackfillTransaction(
 	ctx context.Context,
 	connection *sql.DB,
-	sessions []sessionIDRow,
-	entries []entryIDRow,
-	messages []messageIDRow,
-	sessionIDs map[string]string,
-	entryIDs map[string]string,
-	messageIDs map[string]string,
+	rows uuidV7BackfillRows,
+	replacements uuidV7BackfillReplacements,
 ) error {
 	transaction, err := connection.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("database: begin UUIDv7 backfill: %w", err)
 	}
-	if err := backfillUUIDv7IDsTx(
-		ctx,
-		transaction,
-		sessions,
-		entries,
-		messages,
-		sessionIDs,
-		entryIDs,
-		messageIDs,
-	); err != nil {
+	if err := backfillUUIDv7IDsTx(ctx, transaction, rows, replacements); err != nil {
 		rollbackErr := transaction.Rollback()
 		if rollbackErr != nil {
 			return fmt.Errorf("database: rollback UUIDv7 backfill: %w", rollbackErr)
@@ -114,13 +112,10 @@ func runUUIDv7BackfillTransaction(
 	return nil
 }
 
-func loadIDRows(
-	ctx context.Context,
-	connection *sql.DB,
-) ([]sessionIDRow, []entryIDRow, []messageIDRow, error) {
+func loadIDRows(ctx context.Context, connection *sql.DB) (uuidV7BackfillRows, error) {
 	sessions, err := queryRows(ctx, connection, `SELECT id, parent_session FROM sessions`, scanSessionIDRow)
 	if err != nil {
-		return nil, nil, nil, err
+		return uuidV7BackfillRows{}, err
 	}
 	entries, err := queryRows(
 		ctx,
@@ -131,7 +126,7 @@ FROM session_entries`,
 		scanEntryIDRow,
 	)
 	if err != nil {
-		return nil, nil, nil, err
+		return uuidV7BackfillRows{}, err
 	}
 	messages, err := queryRows(
 		ctx,
@@ -140,10 +135,14 @@ FROM session_entries`,
 		scanMessageIDRow,
 	)
 	if err != nil {
-		return nil, nil, nil, err
+		return uuidV7BackfillRows{}, err
 	}
 
-	return sessions, entries, messages, nil
+	return uuidV7BackfillRows{
+		sessions: sessions,
+		entries:  entries,
+		messages: messages,
+	}, nil
 }
 
 func scanSessionIDRow(scanner rowScanner) (*sessionIDRow, error) {
@@ -245,21 +244,17 @@ func messageIDsFromRows(rows []messageIDRow) []string {
 func backfillUUIDv7IDsTx(
 	ctx context.Context,
 	transaction *sql.Tx,
-	sessions []sessionIDRow,
-	entries []entryIDRow,
-	messages []messageIDRow,
-	sessionIDs map[string]string,
-	entryIDs map[string]string,
-	messageIDs map[string]string,
+	rows uuidV7BackfillRows,
+	replacements uuidV7BackfillReplacements,
 ) error {
-	if err := backfillSessionUUIDv7IDsTx(ctx, transaction, sessions, sessionIDs); err != nil {
+	if err := backfillSessionUUIDv7IDsTx(ctx, transaction, rows.sessions, replacements.sessions); err != nil {
 		return err
 	}
-	if err := backfillEntryUUIDv7IDsTx(ctx, transaction, entries, sessionIDs, entryIDs); err != nil {
+	if err := backfillEntryUUIDv7IDsTx(ctx, transaction, rows.entries, replacements); err != nil {
 		return err
 	}
 
-	return backfillMessageUUIDv7IDsTx(ctx, transaction, messages, sessionIDs, entryIDs, messageIDs)
+	return backfillMessageUUIDv7IDsTx(ctx, transaction, rows.messages, replacements)
 }
 
 func backfillSessionUUIDv7IDsTx(
@@ -287,11 +282,10 @@ func backfillEntryUUIDv7IDsTx(
 	ctx context.Context,
 	transaction *sql.Tx,
 	rows []entryIDRow,
-	sessionIDs map[string]string,
-	entryIDs map[string]string,
+	replacements uuidV7BackfillReplacements,
 ) error {
 	for index := range rows {
-		if err := backfillEntryUUIDv7IDTx(ctx, transaction, &rows[index], sessionIDs, entryIDs); err != nil {
+		if err := backfillEntryUUIDv7IDTx(ctx, transaction, &rows[index], replacements); err != nil {
 			return err
 		}
 	}
@@ -303,14 +297,13 @@ func backfillEntryUUIDv7IDTx(
 	ctx context.Context,
 	transaction *sql.Tx,
 	row *entryIDRow,
-	sessionIDs map[string]string,
-	entryIDs map[string]string,
+	replacements uuidV7BackfillReplacements,
 ) error {
 	parentID := sql.NullString{}
 	if row.ParentID.Valid {
-		parentID = sql.NullString{String: replaceID(entryIDs, row.ParentID.String), Valid: true}
+		parentID = sql.NullString{String: replaceID(replacements.entries, row.ParentID.String), Valid: true}
 	}
-	dataJSON, err := replaceEntryDataIDs(row.DataJSON, entryIDs)
+	dataJSON, err := replaceEntryDataIDs(row.DataJSON, replacements.entries)
 	if err != nil {
 		return err
 	}
@@ -319,12 +312,12 @@ func backfillEntryUUIDv7IDTx(
 		`UPDATE session_entries
 SET id = ?, session_id = ?, parent_id = ?, data_json = ?, compaction_first_kept_entry_id = ?, branch_from_entry_id = ?
 WHERE id = ?`,
-		replaceID(entryIDs, row.ID),
-		replaceID(sessionIDs, row.SessionID),
+		replaceID(replacements.entries, row.ID),
+		replaceID(replacements.sessions, row.SessionID),
 		parentID,
 		dataJSON,
-		replaceID(entryIDs, row.CompactionFirstKeptEntryID),
-		replaceID(entryIDs, row.BranchFromEntryID),
+		replaceID(replacements.entries, row.CompactionFirstKeptEntryID),
+		replaceID(replacements.entries, row.BranchFromEntryID),
 		row.ID,
 	)
 	if err != nil {
@@ -338,17 +331,15 @@ func backfillMessageUUIDv7IDsTx(
 	ctx context.Context,
 	transaction *sql.Tx,
 	rows []messageIDRow,
-	sessionIDs map[string]string,
-	entryIDs map[string]string,
-	messageIDs map[string]string,
+	replacements uuidV7BackfillReplacements,
 ) error {
 	for _, row := range rows {
 		if _, err := transaction.ExecContext(
 			ctx,
 			`UPDATE session_messages SET id = ?, session_id = ?, entry_id = ? WHERE id = ?`,
-			replaceID(messageIDs, row.ID),
-			replaceID(sessionIDs, row.SessionID),
-			replaceID(entryIDs, row.EntryID),
+			replaceID(replacements.messages, row.ID),
+			replaceID(replacements.sessions, row.SessionID),
+			replaceID(replacements.entries, row.EntryID),
 			row.ID,
 		); err != nil {
 			return fmt.Errorf("database: backfill message UUIDv7 IDs: %w", err)
@@ -438,18 +429,18 @@ func checkForeignKeys(ctx context.Context, connection *sql.DB) error {
 	}
 	if rows.Next() {
 		if closeErr := rows.Close(); closeErr != nil {
-			return fmt.Errorf("database: close UUIDv7 foreign key check rows: %w", closeErr)
+			return fmt.Errorf(closeUUIDv7ForeignKeyCheckRowsError, closeErr)
 		}
 		return fmt.Errorf("database: UUIDv7 backfill left invalid foreign keys")
 	}
 	if err := rows.Err(); err != nil {
 		if closeErr := rows.Close(); closeErr != nil {
-			return fmt.Errorf("database: close UUIDv7 foreign key check rows: %w", closeErr)
+			return fmt.Errorf(closeUUIDv7ForeignKeyCheckRowsError, closeErr)
 		}
 		return fmt.Errorf("database: iterate UUIDv7 foreign key check: %w", err)
 	}
 	if err := rows.Close(); err != nil {
-		return fmt.Errorf("database: close UUIDv7 foreign key check rows: %w", err)
+		return fmt.Errorf(closeUUIDv7ForeignKeyCheckRowsError, err)
 	}
 
 	return nil

--- a/internal/database/uuid_backfill_test.go
+++ b/internal/database/uuid_backfill_test.go
@@ -1,0 +1,239 @@
+package database_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/database"
+)
+
+const legacyEntryDataJSON = `{"fromId":"entry-root","targetId":"entry-root",` +
+	`"firstKeptEntryId":"entry-root","compactionFirstKeptEntryId":"entry-root",` +
+	`"branchFromEntryId":"entry-root"}`
+
+func TestBackfillUUIDv7IDsRewritesSessionGraph(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	connection := newMigratedThroughVersion(t, 4)
+	insertLegacySessionGraph(ctx, t, connection)
+
+	require.NoError(t, database.Migrate(ctx, connection))
+
+	oldIDs := []string{"session-old", "entry-root", "entry-child", "message-root", "message-child"}
+	for _, oldID := range oldIDs {
+		assertNoRowWithID(ctx, t, connection, oldID)
+	}
+
+	var sessionID string
+	require.NoError(t, connection.QueryRowContext(ctx, `SELECT id FROM sessions`).Scan(&sessionID))
+	assertUUIDV7(t, sessionID)
+
+	entries := queryEntryBackfillRows(ctx, t, connection)
+	require.Len(t, entries, 2)
+	rootID := entries[0].id
+	childID := entries[1].id
+	assertUUIDV7(t, rootID)
+	assertUUIDV7(t, childID)
+	require.True(t, entries[1].parentID.Valid)
+	assert.Equal(t, rootID, entries[1].parentID.String)
+	assert.Equal(t, rootID, entries[1].compactionFirstKeptEntryID)
+	assert.Equal(t, rootID, entries[1].branchFromEntryID)
+
+	var data map[string]any
+	require.NoError(t, json.Unmarshal([]byte(entries[1].dataJSON), &data))
+	assert.Equal(t, rootID, data["fromId"])
+	assert.Equal(t, rootID, data["targetId"])
+	assert.Equal(t, rootID, data["firstKeptEntryId"])
+	assert.Equal(t, rootID, data["compactionFirstKeptEntryId"])
+	assert.Equal(t, rootID, data["branchFromEntryId"])
+
+	messages := queryMessageBackfillRows(ctx, t, connection)
+	require.Len(t, messages, 2)
+	assertUUIDV7(t, messages[0].id)
+	assertUUIDV7(t, messages[1].id)
+	assert.Equal(t, sessionID, messages[0].sessionID)
+	assert.Equal(t, rootID, messages[0].entryID)
+	assert.Equal(t, childID, messages[1].entryID)
+}
+
+func TestBackfillUUIDv7IDsIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	connection := newMigratedThroughVersion(t, 5)
+	repository := database.NewSessionRepository(connection)
+	session, err := repository.CreateSession(ctx, "/work", "", "")
+	require.NoError(t, err)
+	entry := appendTestMessage(ctx, t, repository, session.ID, nil, database.RoleUser, "hello")
+
+	require.NoError(t, database.BackfillUUIDv7IDs(ctx, connection))
+
+	foundEntry, found, err := repository.Entry(ctx, session.ID, entry.ID)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, entry.ID, foundEntry.ID)
+}
+
+func insertLegacySessionGraph(ctx context.Context, t *testing.T, connection *sql.DB) {
+	t.Helper()
+
+	createdAt := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := connection.ExecContext(
+		ctx,
+		`INSERT INTO sessions (id, cwd, name, parent_session, created_at, updated_at)
+VALUES ('session-old', '/work', '', '', ?, ?)`,
+		createdAt,
+		createdAt,
+	)
+	require.NoError(t, err)
+	insertLegacyEntries(ctx, t, connection, createdAt)
+	insertLegacyMessages(ctx, t, connection, createdAt)
+}
+
+func insertLegacyEntries(ctx context.Context, t *testing.T, connection *sql.DB, createdAt string) {
+	t.Helper()
+
+	_, err := connection.ExecContext(
+		ctx,
+		`INSERT INTO session_entries (
+    id, session_id, parent_id, entry_type, role, content,
+    provider, model, custom_type, data_json, summary, created_at,
+    tool_name, tool_status, tool_args_json, token_estimate, model_facing, display,
+    compaction_first_kept_entry_id, compaction_tokens_before, branch_from_entry_id
+) VALUES (
+    'entry-root', 'session-old', NULL, 'message', 'user', 'hello',
+    '', '', '', '{}', '', ?,
+    '', '', '', 1, 1, 1, '', 0, ''
+), (
+    'entry-child', 'session-old', 'entry-root', 'message', 'assistant', 'hi',
+    '', '', '', ?, '', ?,
+    '', '', '', 1, 1, 1, 'entry-root', 10, 'entry-root'
+)`,
+		createdAt,
+		legacyEntryDataJSON,
+		createdAt,
+	)
+	require.NoError(t, err)
+}
+
+func insertLegacyMessages(ctx context.Context, t *testing.T, connection *sql.DB, createdAt string) {
+	t.Helper()
+
+	_, err := connection.ExecContext(
+		ctx,
+		`INSERT INTO session_messages (id, session_id, entry_id, sender, role, content, provider, model, created_at)
+VALUES
+    ('message-root', 'session-old', 'entry-root', 'user', 'user', 'hello', '', '', ?),
+    ('message-child', 'session-old', 'entry-child', 'assistant', 'assistant', 'hi', '', '', ?)`,
+		createdAt,
+		createdAt,
+	)
+	require.NoError(t, err)
+}
+
+type entryBackfillRow struct {
+	id                         string
+	dataJSON                   string
+	compactionFirstKeptEntryID string
+	branchFromEntryID          string
+	parentID                   sql.NullString
+}
+
+func queryEntryBackfillRows(ctx context.Context, t *testing.T, connection *sql.DB) []entryBackfillRow {
+	t.Helper()
+
+	rows, err := connection.QueryContext(
+		ctx,
+		`SELECT id, parent_id, data_json, compaction_first_kept_entry_id, branch_from_entry_id
+FROM session_entries ORDER BY created_at ASC, role DESC`,
+	)
+	require.NoError(t, err)
+
+	entries := []entryBackfillRow{}
+	for rows.Next() {
+		entry := entryBackfillRow{
+			parentID:                   sql.NullString{},
+			id:                         "",
+			dataJSON:                   "",
+			compactionFirstKeptEntryID: "",
+			branchFromEntryID:          "",
+		}
+		require.NoError(t, rows.Scan(
+			&entry.id,
+			&entry.parentID,
+			&entry.dataJSON,
+			&entry.compactionFirstKeptEntryID,
+			&entry.branchFromEntryID,
+		))
+		entries = append(entries, entry)
+	}
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+
+	return entries
+}
+
+type messageBackfillRow struct {
+	id        string
+	sessionID string
+	entryID   string
+}
+
+func queryMessageBackfillRows(ctx context.Context, t *testing.T, connection *sql.DB) []messageBackfillRow {
+	t.Helper()
+
+	rows, err := connection.QueryContext(
+		ctx,
+		`SELECT id, session_id, entry_id FROM session_messages ORDER BY created_at ASC`,
+	)
+	require.NoError(t, err)
+
+	messages := []messageBackfillRow{}
+	for rows.Next() {
+		message := messageBackfillRow{
+			id:        "",
+			sessionID: "",
+			entryID:   "",
+		}
+		require.NoError(t, rows.Scan(&message.id, &message.sessionID, &message.entryID))
+		messages = append(messages, message)
+	}
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+
+	return messages
+}
+
+func assertNoRowWithID(ctx context.Context, t *testing.T, connection *sql.DB, oldID string) {
+	t.Helper()
+
+	queries := []string{
+		`SELECT count(*) FROM sessions WHERE id = ? OR parent_session = ?`,
+		`SELECT count(*) FROM session_entries
+WHERE id = ? OR session_id = ? OR parent_id = ? OR compaction_first_kept_entry_id = ? OR branch_from_entry_id = ?`,
+		`SELECT count(*) FROM session_messages WHERE id = ? OR session_id = ? OR entry_id = ?`,
+	}
+	for _, query := range queries {
+		args := repeatedArgs(oldID, strings.Count(query, "?"))
+		var count int
+		require.NoError(t, connection.QueryRowContext(ctx, query, args...).Scan(&count))
+		assert.Zero(t, count)
+	}
+}
+
+func repeatedArgs(value string, count int) []any {
+	args := make([]any, count)
+	for index := range args {
+		args[index] = value
+	}
+
+	return args
+}

--- a/internal/database/uuid_backfill_test.go
+++ b/internal/database/uuid_backfill_test.go
@@ -192,7 +192,7 @@ func queryMessageBackfillRows(ctx context.Context, t *testing.T, connection *sql
 
 	rows, err := connection.QueryContext(
 		ctx,
-		`SELECT id, session_id, entry_id FROM session_messages ORDER BY created_at ASC`,
+		`SELECT id, session_id, entry_id FROM session_messages ORDER BY created_at ASC, id ASC`,
 	)
 	require.NoError(t, err)
 

--- a/internal/database/validation.go
+++ b/internal/database/validation.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	zog "github.com/Oudwins/zog"
+	"github.com/gofrs/uuid/v5"
 )
 
 func validateSessionEntity(entity *SessionEntity) error {
-	if err := validateRequiredText("session.id", entity.ID); err != nil {
+	if err := validateUUIDv7("session.id", entity.ID); err != nil {
 		return err
 	}
 	if err := validateRequiredText("session.cwd", entity.CWD); err != nil {
@@ -24,11 +25,16 @@ func validateSessionEntity(entity *SessionEntity) error {
 }
 
 func validateEntryEntity(entity *EntryEntity) error {
-	if err := validateRequiredText("entry.id", entity.ID); err != nil {
+	if err := validateUUIDv7("entry.id", entity.ID); err != nil {
 		return err
 	}
-	if err := validateRequiredText("entry.session_id", entity.SessionID); err != nil {
+	if err := validateUUIDv7("entry.session_id", entity.SessionID); err != nil {
 		return err
+	}
+	if entity.ParentID != nil {
+		if err := validateUUIDv7("entry.parent_id", *entity.ParentID); err != nil {
+			return err
+		}
 	}
 	if err := validateRequiredText("entry.type", string(entity.Type)); err != nil {
 		return err
@@ -44,13 +50,13 @@ func validateEntryEntity(entity *EntryEntity) error {
 }
 
 func validateSessionMessageEntity(entity *SessionMessageEntity) error {
-	if err := validateRequiredText("message.id", entity.ID); err != nil {
+	if err := validateUUIDv7("message.id", entity.ID); err != nil {
 		return err
 	}
-	if err := validateRequiredText("message.session_id", entity.SessionID); err != nil {
+	if err := validateUUIDv7("message.session_id", entity.SessionID); err != nil {
 		return err
 	}
-	if err := validateRequiredText("message.entry_id", entity.EntryID); err != nil {
+	if err := validateUUIDv7("message.entry_id", entity.EntryID); err != nil {
 		return err
 	}
 	if err := validateRequiredText("message.sender", entity.Sender); err != nil {
@@ -79,6 +85,27 @@ func validateDocumentEntity(entity *DocumentEntity) error {
 
 func validateKSQLRequestEntity(entity *KSQLRequestEntity) error {
 	return validateRequiredText("ksql.statement", entity.KSQL)
+}
+
+func validateUUIDv7(name, value string) error {
+	trimmed := strings.TrimSpace(value)
+	parsed, err := uuid.FromString(trimmed)
+	if trimmed == "" {
+		return fmt.Errorf("%s is required", name)
+	}
+	if err != nil {
+		return fmt.Errorf("%s must be a UUIDv7", name)
+	}
+	if parsed.Version() != 7 {
+		return fmt.Errorf("%s must be a UUIDv7", name)
+	}
+
+	return nil
+}
+
+func isUUIDv7(value string) bool {
+	parsed, err := uuid.FromString(strings.TrimSpace(value))
+	return err == nil && parsed.Version() == 7
 }
 
 func validateRequiredText(name, value string) error {

--- a/internal/database/validation_test.go
+++ b/internal/database/validation_test.go
@@ -12,34 +12,62 @@ import (
 	"github.com/omarluq/librecode/internal/database"
 )
 
+type invalidUUIDCase struct {
+	args      func(*testing.T, *database.SessionEntity, *database.EntryEntity) []any
+	query     string
+	name      string
+	wantError string
+}
+
 func TestRepositoryRejectsInvalidUUIDs(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	connection := newMigratedThroughVersion(t, 5)
-	repository := database.NewSessionRepository(connection)
-	session, err := repository.CreateSession(ctx, "/work", "uuid", "")
-	require.NoError(t, err)
+	for _, test := range invalidUUIDCases() {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-	validEntry := appendTestMessage(ctx, t, repository, session.ID, nil, database.RoleUser, "hello")
-	now := time.Now().UTC().Format(time.RFC3339Nano)
+			ctx := context.Background()
+			connection := newMigratedThroughVersion(t, 5)
+			repository := database.NewSessionRepository(connection)
+			session, err := repository.CreateSession(ctx, "/work", "uuid", "")
+			require.NoError(t, err)
 
-	tests := []struct {
-		query     string
-		name      string
-		wantError string
-		args      []any
-	}{
-		{
-			name: "session id trigger",
-			query: `INSERT INTO sessions (id, cwd, name, parent_session, created_at, updated_at)
+			entry := appendTestMessage(ctx, t, repository, session.ID, nil, database.RoleUser, "hello")
+			_, err = connection.ExecContext(ctx, test.query, test.args(t, session, entry)...)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantError)
+		})
+	}
+}
+
+func invalidUUIDCases() []invalidUUIDCase {
+	return []invalidUUIDCase{
+		invalidSessionIDCase(),
+		invalidEntryIDCase(),
+		invalidMessageEntryIDCase(),
+		invalidMessageIDCase(),
+	}
+}
+
+func invalidSessionIDCase() invalidUUIDCase {
+	return invalidUUIDCase{
+		name: "session id trigger",
+		query: `INSERT INTO sessions (id, cwd, name, parent_session, created_at, updated_at)
 VALUES ('legacy-session', '/work', '', '', ?, ?)`,
-			args:      []any{now, now},
-			wantError: "sessions.id must be a UUIDv7",
+		args: func(_ *testing.T, _ *database.SessionEntity, _ *database.EntryEntity) []any {
+			now := time.Now().UTC().Format(time.RFC3339Nano)
+
+			return []any{now, now}
 		},
-		{
-			name: "entry id trigger",
-			query: `INSERT INTO session_entries (
+		wantError: "sessions.id must be a UUIDv7",
+	}
+}
+
+func invalidEntryIDCase() invalidUUIDCase {
+	return invalidUUIDCase{
+		name: "entry id trigger",
+		query: `INSERT INTO session_entries (
     id, session_id, parent_id, entry_type, role, content,
     provider, model, custom_type, data_json, summary, created_at,
     tool_name, tool_status, tool_args_json, token_estimate, model_facing, display,
@@ -48,36 +76,38 @@ VALUES ('legacy-session', '/work', '', '', ?, ?)`,
     'legacy-entry', ?, NULL, 'message', 'user', 'hello',
     '', '', '', '{}', '', ?, '', '', '', 1, 1, 1, '', 0, ''
 )`,
-			args:      []any{session.ID, now},
-			wantError: "session_entries.id must be a UUIDv7",
+		args: func(_ *testing.T, session *database.SessionEntity, _ *database.EntryEntity) []any {
+			return []any{session.ID, time.Now().UTC().Format(time.RFC3339Nano)}
 		},
-		{
-			name: "message entry id trigger",
-			query: `INSERT INTO session_messages (
+		wantError: "session_entries.id must be a UUIDv7",
+	}
+}
+
+func invalidMessageEntryIDCase() invalidUUIDCase {
+	return invalidUUIDCase{
+		name: "message entry id trigger",
+		query: `INSERT INTO session_messages (
     id, session_id, entry_id, sender, role, content, provider, model, created_at
 ) VALUES (?, ?, 'legacy-entry', 'user', 'user', 'hello', '', '', ?)`,
-			args:      []any{testUUIDV7(t), session.ID, now},
-			wantError: "session_messages.entry_id must be a UUIDv7",
+		args: func(t *testing.T, session *database.SessionEntity, _ *database.EntryEntity) []any {
+			t.Helper()
+
+			return []any{testUUIDV7(t), session.ID, time.Now().UTC().Format(time.RFC3339Nano)}
 		},
-		{
-			name: "message id trigger",
-			query: `INSERT INTO session_messages (
+		wantError: "session_messages.entry_id must be a UUIDv7",
+	}
+}
+
+func invalidMessageIDCase() invalidUUIDCase {
+	return invalidUUIDCase{
+		name: "message id trigger",
+		query: `INSERT INTO session_messages (
     id, session_id, entry_id, sender, role, content, provider, model, created_at
 ) VALUES ('legacy-message', ?, ?, 'user', 'user', 'hello', '', '', ?)`,
-			args:      []any{session.ID, validEntry.ID, now},
-			wantError: "session_messages.id must be a UUIDv7",
+		args: func(_ *testing.T, session *database.SessionEntity, entry *database.EntryEntity) []any {
+			return []any{session.ID, entry.ID, time.Now().UTC().Format(time.RFC3339Nano)}
 		},
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
-			_, err := connection.ExecContext(ctx, test.query, test.args...)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), test.wantError)
-		})
+		wantError: "session_messages.id must be a UUIDv7",
 	}
 }
 

--- a/internal/database/validation_test.go
+++ b/internal/database/validation_test.go
@@ -1,0 +1,91 @@
+package database_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/database"
+)
+
+func TestRepositoryRejectsInvalidUUIDs(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	connection := newMigratedThroughVersion(t, 5)
+	repository := database.NewSessionRepository(connection)
+	session, err := repository.CreateSession(ctx, "/work", "uuid", "")
+	require.NoError(t, err)
+
+	validEntry := appendTestMessage(ctx, t, repository, session.ID, nil, database.RoleUser, "hello")
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	tests := []struct {
+		query     string
+		name      string
+		wantError string
+		args      []any
+	}{
+		{
+			name: "session id trigger",
+			query: `INSERT INTO sessions (id, cwd, name, parent_session, created_at, updated_at)
+VALUES ('legacy-session', '/work', '', '', ?, ?)`,
+			args:      []any{now, now},
+			wantError: "sessions.id must be a UUIDv7",
+		},
+		{
+			name: "entry id trigger",
+			query: `INSERT INTO session_entries (
+    id, session_id, parent_id, entry_type, role, content,
+    provider, model, custom_type, data_json, summary, created_at,
+    tool_name, tool_status, tool_args_json, token_estimate, model_facing, display,
+    compaction_first_kept_entry_id, compaction_tokens_before, branch_from_entry_id
+) VALUES (
+    'legacy-entry', ?, NULL, 'message', 'user', 'hello',
+    '', '', '', '{}', '', ?, '', '', '', 1, 1, 1, '', 0, ''
+)`,
+			args:      []any{session.ID, now},
+			wantError: "session_entries.id must be a UUIDv7",
+		},
+		{
+			name: "message entry id trigger",
+			query: `INSERT INTO session_messages (
+    id, session_id, entry_id, sender, role, content, provider, model, created_at
+) VALUES (?, ?, 'legacy-entry', 'user', 'user', 'hello', '', '', ?)`,
+			args:      []any{testUUIDV7(t), session.ID, now},
+			wantError: "session_messages.entry_id must be a UUIDv7",
+		},
+		{
+			name: "message id trigger",
+			query: `INSERT INTO session_messages (
+    id, session_id, entry_id, sender, role, content, provider, model, created_at
+) VALUES ('legacy-message', ?, ?, 'user', 'user', 'hello', '', '', ?)`,
+			args:      []any{session.ID, validEntry.ID, now},
+			wantError: "session_messages.id must be a UUIDv7",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := connection.ExecContext(ctx, test.query, test.args...)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantError)
+		})
+	}
+}
+
+func testUUIDV7(t *testing.T) string {
+	t.Helper()
+
+	id, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	return id.String()
+}


### PR DESCRIPTION
## Summary
- generate sessions, entries, and session message IDs as UUIDv7
- add UUIDv7 validation triggers for durable session IDs
- backfill existing session graph IDs while preserving relationships

## Validation
- backed up the live DB before migration
- dry-ran migration on a copied DB and verified integrity/foreign keys
- ran live migration successfully
- `mise exec -- task ci`