### PR TITLE
fix(terminal): estimate empty context command

### DIFF
--- a/internal/assistant/context_build.go
+++ b/internal/assistant/context_build.go
@@ -51,6 +51,38 @@ type modelContextBase struct {
 	HistoryTokens    int
 }
 
+// ContextUsage estimates the current model-facing context without executing a prompt.
+// It is intended for diagnostics such as /context and intentionally avoids
+// prompt-dependent skill activation and extension context mutation.
+func (runtime *Runtime) ContextUsage(ctx context.Context, sessionID, cwd string) (model.TokenUsage, error) {
+	selectedModel, err := runtime.selectedModel()
+	if err != nil {
+		return model.EmptyTokenUsage(), err
+	}
+
+	messages := []database.MessageEntity{}
+	if strings.TrimSpace(sessionID) != "" {
+		messages, err = runtime.modelContextMessages(ctx, sessionID)
+		if err != nil {
+			return model.EmptyTokenUsage(), err
+		}
+	}
+
+	basePrompt := baseSystemPrompt(cwd)
+	skillPrompt := ""
+	if skills := core.LoadSkills(cwd, nil, true).Skills; len(skills) > 0 {
+		skillPrompt = core.FormatSkillsForPrompt(skills)
+	}
+	breakdown := contextBreakdown(
+		estimateTokens(basePrompt),
+		estimateTokens(skillPrompt),
+		estimateMessageTokens(messages),
+		nil,
+	)
+
+	return estimateContextBuildUsage(basePrompt+skillPrompt, messages, nil, &selectedModel, breakdown), nil
+}
+
 func (runtime *Runtime) buildModelContext(
 	ctx context.Context,
 	sessionID string,

--- a/internal/terminal/context_commands.go
+++ b/internal/terminal/context_commands.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/model"
 )
 
 func (app *App) showContextInfo(ctx context.Context, original string) error {
@@ -15,16 +16,17 @@ func (app *App) showContextInfo(ctx context.Context, original string) error {
 		return nil
 	}
 
+	usage := app.contextUsage(ctx)
 	lines := []string{"context:"}
-	if summary := formatContextUsage(app.tokenUsage); summary != "" {
+	if summary := formatContextUsage(usage); summary != "" {
 		lines = append(lines, "- "+summary)
 	}
-	breakdownLines := contextBreakdownLines(app.tokenUsage.Breakdown)
+	breakdownLines := contextBreakdownLines(usage.Breakdown)
 	if len(breakdownLines) > 0 {
 		lines = append(lines, "- breakdown:")
 		lines = append(lines, breakdownLines...)
 	}
-	contributorLines := contextContributorLines(app.tokenUsage.TopContributors)
+	contributorLines := contextContributorLines(usage.TopContributors)
 	if len(contributorLines) > 0 {
 		lines = append(lines, "- top contributors:")
 		lines = append(lines, contributorLines...)
@@ -58,4 +60,18 @@ func contextBreakdownLines(breakdown map[string]int) []string {
 	}
 
 	return lines
+}
+
+func (app *App) contextUsage(ctx context.Context) model.TokenUsage {
+	if app.tokenUsage.HasAny() {
+		return app.tokenUsage
+	}
+	if app.runtime == nil {
+		return model.EmptyTokenUsage()
+	}
+	usage, err := app.runtime.ContextUsage(ctx, app.sessionID, app.cwd)
+	if err != nil {
+		return model.EmptyTokenUsage()
+	}
+	return usage
 }


### PR DESCRIPTION
## Summary
- estimate current context on demand when /context has no cached usage
- keep cached usage behavior unchanged after prompt execution

## Validation
- mise exec -- go test ./internal/assistant ./internal/terminal
- mise exec -- task ci