### PR TITLE
fix(extension): let vim mode yield shortcuts

### DIFF
--- a/extensions/vim-mode/vim.lua
+++ b/extensions/vim-mode/vim.lua
@@ -296,10 +296,10 @@ local function handle_insert(ev)
     set_composer(chars, move_right(chars, cursor))
     return true
   elseif key == "up" then
-    set_composer(chars, move_line_delta(chars, cursor, -1))
+    lc.action.run("history.prev")
     return true
   elseif key == "down" then
-    set_composer(chars, move_line_delta(chars, cursor, 1))
+    lc.action.run("history.next")
     return true
   elseif key == "home" or key == "ctrl+a" then
     set_composer(chars, line_start(chars, cursor))
@@ -556,7 +556,7 @@ local function handle_normal(ev)
     return true
   end
 
-  return true
+  return false
 end
 
 local function handle_visual(ev)
@@ -619,7 +619,7 @@ local function handle_visual(ev)
     return true
   end
 
-  return true
+  return false
 end
 
 local function setup(api)

--- a/extensions/vim-mode/vim.lua
+++ b/extensions/vim-mode/vim.lua
@@ -556,6 +556,10 @@ local function handle_normal(ev)
     return true
   end
 
+  if ev.text and ev.text ~= "" and not ev.ctrl and not ev.alt then
+    return true
+  end
+
   return false
 end
 


### PR DESCRIPTION
## Summary
- let Vim insert-mode up/down use prompt history
- allow unknown normal/visual keys to fall through to native shortcuts like ctrl+o

## Validation
- mise exec -- task ci