### PR TITLE
perf(terminal): lazily render expanded tools

### DIFF
--- a/internal/terminal/app.go
+++ b/internal/terminal/app.go
@@ -429,7 +429,7 @@ func (app *App) messageCacheWarmTick(timer *time.Timer) <-chan time.Time {
 	if timer == nil {
 		return nil
 	}
-	if app.messageCacheWarm || app.working || app.authWorking || app.scrollOffset != 0 {
+	if app.messageCacheWarm || app.working || app.authWorking || app.scrollOffset != 0 || app.toolsExpanded {
 		app.messageCacheWarmQueued = false
 		stopTimer(timer)
 		return nil

--- a/internal/terminal/render_messages.go
+++ b/internal/terminal/render_messages.go
@@ -70,10 +70,8 @@ func (app *App) bottomMessageLines(width, maxRows int, dynamicGroups [][]styledL
 	staticMaxRows := max(0, maxRows-reservedRows)
 	groups := make([][]styledLine, 0, len(app.messages)+len(dynamicGroups))
 	if staticMaxRows > 0 {
-		start := app.tailStaticMessageRange(width, staticMaxRows)
-		for index := start; index < len(app.messages); index++ {
-			groups = append(groups, app.cachedMessageLines(width, index))
-		}
+		staticGroups, _ := app.tailStaticMessageGroups(width, staticMaxRows)
+		groups = append(groups, staticGroups...)
 	}
 	groups = append(groups, dynamicGroups...)
 
@@ -141,16 +139,39 @@ func (app *App) tailStaticMessageGroups(width, rowsNeeded int) ([][]styledLine, 
 	}
 	rows := 0
 	start := len(app.messages)
+	var partial []styledLine
 	for start > 0 && rows < rowsNeeded {
 		start--
-		rows += len(app.cachedMessageLines(width, start))
+		remaining := rowsNeeded - rows
+		lines, complete := app.cachedMessageTailLines(width, start, remaining)
+		if !complete {
+			partial = lines
+			break
+		}
+		rows += len(lines)
 	}
 	groups := make([][]styledLine, 0, len(app.messages)-start)
+	if partial != nil {
+		groups = append(groups, partial)
+		start++
+	}
 	for index := start; index < len(app.messages); index++ {
 		groups = append(groups, app.cachedMessageLines(width, index))
 	}
 
-	return groups, start == 0
+	return groups, start == 0 && partial == nil
+}
+
+func (app *App) cachedMessageTailLines(width, index, rowsNeeded int) ([]styledLine, bool) {
+	if rowsNeeded <= 0 {
+		return nil, true
+	}
+	if app.toolsExpanded && app.messages[index].Role == database.RoleToolResult {
+		return app.renderToolMessageTail(width, app.messages[index], rowsNeeded)
+	}
+	lines := app.cachedMessageLines(width, index)
+
+	return lines, true
 }
 
 func (app *App) staticMessageLinesForRows(width, startRow, endRow int) []styledLine {
@@ -249,18 +270,6 @@ func (app *App) currentLineCacheState(width int) messageLineCacheState {
 	}
 }
 
-func (app *App) tailStaticMessageRange(width, maxRows int) int {
-	remainingRows := maxRows
-	for index := len(app.messages) - 1; index >= 0; index-- {
-		remainingRows -= len(app.cachedMessageLines(width, index))
-		if remainingRows <= 0 {
-			return index
-		}
-	}
-
-	return 0
-}
-
 func (app *App) rebuildMessageRowPrefixSums(width int) {
 	app.ensureMessageLineCache(width)
 	prefixSums := make([]int, len(app.messageLineCache)+1)
@@ -285,7 +294,7 @@ func (app *App) warmMessageLineCache() {
 }
 
 func (app *App) warmMessageLineCacheStep() {
-	if app.messageCacheWarm || len(app.messages) == 0 || app.lastMessageMaxRows <= 0 {
+	if app.messageCacheWarm || app.toolsExpanded || len(app.messages) == 0 || app.lastMessageMaxRows <= 0 {
 		return
 	}
 	width := app.currentLineCacheStateWidth()

--- a/internal/terminal/render_test.go
+++ b/internal/terminal/render_test.go
@@ -569,6 +569,40 @@ func TestScrolledMessageLinesBeforeWarmCacheUsesVisibleTail(t *testing.T) {
 	}
 }
 
+func TestBottomMessageLinesExpandedToolUsesTailWithoutFullRender(t *testing.T) {
+	t.Parallel()
+
+	app := newRenderTestApp(t)
+	app.toolsExpanded = true
+	output := strings.Join([]string{
+		"line 0",
+		"line 1",
+		"line 2",
+		"line 3",
+		"line 4",
+		"line 5",
+	}, "\n")
+	app.addMessage(database.RoleToolResult, formatToolEventForUI(&assistant.ToolEvent{
+		Name:          "read",
+		ArgumentsJSON: "{}",
+		DetailsJSON:   "",
+		Result:        output,
+		Error:         "",
+	}))
+
+	lines := app.messageLines(80, 4)
+	texts := lineTexts(lines)
+	if lineIndexContaining(lines, "line 5") == -1 {
+		t.Fatalf("expected latest tool output tail, got %v", texts)
+	}
+	if lineIndexContaining(lines, "line 0") != -1 {
+		t.Fatalf("expected old tool output to stay unrendered in bottom tail, got %v", texts)
+	}
+	if len(app.messageLineCache) > 0 && app.messageLineCache[0].Valid {
+		t.Fatal("bottom tail render should not populate full expanded tool cache")
+	}
+}
+
 func TestMessageLineCacheInvalidatesForThinkingVisibility(t *testing.T) {
 	t.Parallel()
 

--- a/internal/terminal/tool_blocks.go
+++ b/internal/terminal/tool_blocks.go
@@ -146,6 +146,136 @@ func tailIndentedLines(width int, content string, style tcell.Style, limit int) 
 	return lines[hiddenLines:], hiddenLines
 }
 
+func (app *App) renderToolMessageTail(width int, message chatMessage, rowsNeeded int) ([]styledLine, bool) {
+	if rowsNeeded <= 0 {
+		return nil, true
+	}
+	event := parseToolEventContent(message.Content, string(message.Role))
+	style := app.toolBlockStyle(&event)
+	footer := newStyledLine(tcell.StyleDefault, "")
+	tailBudget := max(0, rowsNeeded-1)
+	if tailBudget == 0 {
+		return []styledLine{footer}, false
+	}
+	tail, hidden := tailExpandedToolLines(width, &event, style, tailBudget)
+	if hidden {
+		return append(tail, footer), false
+	}
+	prefix := app.expandedToolPrefixLines(width, &event, style)
+	lines := make([]styledLine, 0, len(prefix)+len(tail)+1)
+	lines = append(lines, prefix...)
+	lines = append(lines, tail...)
+	lines = append(lines, footer)
+	if len(lines) <= rowsNeeded {
+		return lines, true
+	}
+
+	return lines[len(lines)-rowsNeeded:], false
+}
+
+func (app *App) expandedToolPrefixLines(width int, event *parsedToolEvent, style tcell.Style) []styledLine {
+	label := fmt.Sprintf("%s  %s collapse", toolTitle(event), app.keys.hint(actionToolsExpand))
+	lines := make([]styledLine, 0, 2)
+	lines = append(lines,
+		newStyledLine(tcell.StyleDefault, ""),
+		newStyledLine(style.Bold(true), padRight(label, width)),
+	)
+	lines = append(lines, app.toolArgumentLines(width, event, style)...)
+	lines = append(lines, app.toolDiffLines(width, event, style)...)
+
+	return lines
+}
+
+func tailExpandedToolLines(width int, event *parsedToolEvent, style tcell.Style, rowsNeeded int) ([]styledLine, bool) {
+	if event.Output != "" {
+		return tailSectionLinesFromEnd(width, "output", event.Output, style, rowsNeeded)
+	}
+	if event.Error != "" {
+		return tailSectionLinesFromEnd(width, "error", event.Error, style, rowsNeeded)
+	}
+	if event.DetailsJSON != "" {
+		return tailSectionLinesFromEnd(width, "details", compactJSON(event.DetailsJSON), style, rowsNeeded)
+	}
+	if event.ArgumentsJSON != "" {
+		return tailSectionLinesFromEnd(width, "args", compactJSON(event.ArgumentsJSON), style, rowsNeeded)
+	}
+
+	return nil, false
+}
+
+func tailSectionLinesFromEnd(width int, label, content string, style tcell.Style, rowsNeeded int) ([]styledLine, bool) {
+	if rowsNeeded <= 0 || strings.TrimSpace(content) == "" {
+		return nil, false
+	}
+	if rowsNeeded == 1 {
+		return []styledLine{newStyledLine(style.Bold(true), padRight(label+":", width))}, true
+	}
+	tail, hidden := tailIndentedLinesFromEnd(width, content, style, rowsNeeded-1)
+	lines := make([]styledLine, 0, len(tail)+1)
+	lines = append(lines, newStyledLine(style.Bold(true), padRight(label+":", width)))
+	lines = append(lines, tail...)
+
+	return lines, hidden
+}
+
+func tailIndentedLinesFromEnd(width int, content string, style tcell.Style, limit int) ([]styledLine, bool) {
+	if limit <= 0 || strings.TrimSpace(content) == "" {
+		return nil, false
+	}
+	collector := tailLineCollector{
+		Style:  style,
+		Lines:  make([]styledLine, 0, limit),
+		Width:  width,
+		Limit:  limit,
+		Hidden: false,
+	}
+	collector.Collect(strings.Trim(content, "\n"))
+	reverseStyledLines(collector.Lines)
+
+	return collector.Lines, collector.Hidden
+}
+
+type tailLineCollector struct {
+	Style  tcell.Style
+	Lines  []styledLine
+	Width  int
+	Limit  int
+	Hidden bool
+}
+
+func (collector *tailLineCollector) Collect(content string) {
+	for end := len(content); end >= 0 && len(collector.Lines) < collector.Limit; {
+		start := strings.LastIndexByte(content[:end], '\n') + 1
+		collector.collectWrappedLine(content[start:end])
+		if start == 0 {
+			return
+		}
+		end = start - 1
+	}
+	collector.Hidden = true
+}
+
+func (collector *tailLineCollector) collectWrappedLine(line string) {
+	wrapped := wrapTextPreserveWhitespace(line, max(1, collector.Width-2))
+	added := 0
+	for index := len(wrapped) - 1; index >= 0 && len(collector.Lines) < collector.Limit; index-- {
+		collector.Lines = append(collector.Lines, newStyledLine(
+			collector.Style,
+			padRight("  "+wrapped[index], collector.Width),
+		))
+		added++
+	}
+	if added < len(wrapped) {
+		collector.Hidden = true
+	}
+}
+
+func reverseStyledLines(lines []styledLine) {
+	for left, right := 0, len(lines)-1; left < right; left, right = left+1, right-1 {
+		lines[left], lines[right] = lines[right], lines[left]
+	}
+}
+
 func (app *App) hiddenToolLinesText(hiddenLines int) string {
 	unit := "lines"
 	if hiddenLines == 1 {


### PR DESCRIPTION
## Summary
- lazily render only the visible tail of expanded tool output at the bottom of the transcript
- avoid warming full message history while tool output is expanded
- add regression coverage for expanded tool rendering cache behavior

## Validation
- mise exec -- go test ./internal/terminal
- mise exec -- task ci