### PR TITLE
refactor(terminal): extract message line cache

### DIFF
--- a/internal/terminal/app.go
+++ b/internal/terminal/app.go
@@ -128,16 +128,14 @@ type App struct {
 	promptHistoryDraft           string
 	mode                         appMode
 	resources                    core.ResourceSnapshot
-	messageLineCache             []cachedRenderedMessage
+	messageLineCache             messageLineCache
 	streamingBlockLineCache      []cachedRenderedMessage
-	messageRowPrefixSums         []int
 	queuedMessages               []string
 	messages                     []chatMessage
 	streamingBlocks              []chatMessage
 	promptHistory                []string
 	scopedOrder                  []string
 	composerBuffer               extension.BufferState
-	messageLineCacheState        messageLineCacheState
 	streamingBlockLineCacheState messageLineCacheState
 	tokenUsage                   model.TokenUsage
 	selection                    mouseSelection
@@ -149,10 +147,7 @@ type App struct {
 	promptHistoryIndex           int
 	scrollOffset                 int
 	autocompleteSelection        int
-	messageCacheWarmIndex        int
 	autocompleteClosed           bool
-	messageCacheWarm             bool
-	messageCacheWarmQueued       bool
 	sessionNamedOnly             bool
 	hideThinking                 bool
 	working                      bool
@@ -220,12 +215,7 @@ func newApp(screen tcell.Screen, options *RunOptions) *App {
 		activePrompt:                 nil,
 		canceledPrompts:              map[uint64]*activePromptState{},
 		messages:                     []chatMessage{},
-		messageLineCache:             nil,
-		messageRowPrefixSums:         nil,
-		messageCacheWarmIndex:        0,
-		messageCacheWarm:             false,
-		messageCacheWarmQueued:       false,
-		messageLineCacheState:        emptyMessageLineCacheState(),
+		messageLineCache:             emptyMessageLineCache(),
 		queuedMessages:               []string{},
 		promptHistory:                []string{},
 		promptHistoryDraft:           "",
@@ -344,7 +334,7 @@ func (app *App) runLoopStep(
 		app.emitExtensionRuntimeEventOrMessage(ctx, extensionEventTick, map[string]any{})
 		return false, true
 	case <-app.messageCacheWarmTick(messageWarmTimer):
-		app.messageCacheWarmQueued = false
+		app.messageLineCache.queued = false
 		app.warmMessageLineCacheStep()
 		return false, true
 	}
@@ -429,19 +419,19 @@ func (app *App) messageCacheWarmTick(timer *time.Timer) <-chan time.Time {
 	if timer == nil {
 		return nil
 	}
-	if app.messageCacheWarm || app.working || app.authWorking || app.scrollOffset != 0 || app.toolsExpanded {
-		app.messageCacheWarmQueued = false
+	if app.messageLineCache.warm || app.working || app.authWorking || app.scrollOffset != 0 || app.toolsExpanded {
+		app.messageLineCache.queued = false
 		stopTimer(timer)
 		return nil
 	}
 	if len(app.messages) == 0 || app.lastMessageMaxRows <= 0 {
-		app.messageCacheWarmQueued = false
+		app.messageLineCache.queued = false
 		stopTimer(timer)
 		return nil
 	}
-	if !app.messageCacheWarmQueued {
+	if !app.messageLineCache.queued {
 		resetTimer(timer, 1*time.Millisecond)
-		app.messageCacheWarmQueued = true
+		app.messageLineCache.queued = true
 	}
 
 	return timer.C
@@ -554,12 +544,6 @@ func newChatMessage(role database.Role, content string) chatMessage {
 	return chatMessage{CreatedAt: time.Now().UTC(), Role: role, Content: content}
 }
 
-func emptyMessageLineCacheState() messageLineCacheState {
-	var state messageLineCacheState
-
-	return state
-}
-
 func emptyCachedRenderedMessage() cachedRenderedMessage {
 	var message cachedRenderedMessage
 
@@ -568,29 +552,19 @@ func emptyCachedRenderedMessage() cachedRenderedMessage {
 
 func (app *App) appendMessage(message chatMessage) {
 	app.messages = append(app.messages, message)
-	app.messageCacheWarmIndex = 0
-	app.messageCacheWarm = false
+	app.messageLineCache.appendInvalidation()
 }
 
 func (app *App) resetMessages() {
 	app.messages = []chatMessage{}
-	app.messageLineCache = nil
-	app.messageRowPrefixSums = nil
-	app.messageCacheWarmIndex = 0
-	app.messageCacheWarm = false
-	app.messageCacheWarmQueued = false
+	app.messageLineCache.reset()
 	app.tokenUsage = model.EmptyTokenUsage()
 	app.resetPromptHistory()
 }
 
 func (app *App) truncateMessages(length int) {
 	app.messages = app.messages[:length]
-	if len(app.messageLineCache) > length {
-		app.messageLineCache = app.messageLineCache[:length]
-	}
-	app.messageRowPrefixSums = nil
-	app.messageCacheWarmIndex = 0
-	app.messageCacheWarm = false
+	app.messageLineCache.truncate(length)
 	app.tokenUsage = model.EmptyTokenUsage()
 }
 

--- a/internal/terminal/message_line_cache.go
+++ b/internal/terminal/message_line_cache.go
@@ -97,14 +97,17 @@ func (cache *messageLineCache) rebuildPrefixesFromCache() {
 	cache.prefixes = prefixes
 }
 
-func (cache *messageLineCache) warmStep(app *App) {
+func (cache *messageLineCache) warmStep(app *App) bool {
 	if cache.warm || app.toolsExpanded || len(app.messages) == 0 || app.lastMessageMaxRows <= 0 {
-		return
+		return false
 	}
 	width := app.currentLineCacheStateWidth()
 	cache.ensure(app, width, len(app.messages))
 	start := min(max(0, cache.warmIndex), len(app.messages))
 	end := min(len(app.messages), start+messageCacheWarmBatchSize)
+	if end <= start {
+		return false
+	}
 	for index := start; index < end; index++ {
 		if !cache.items[index].Valid {
 			cache.items[index] = cachedRenderedMessage{
@@ -115,10 +118,12 @@ func (cache *messageLineCache) warmStep(app *App) {
 	}
 	cache.warmIndex = end
 	if end < len(app.messages) {
-		return
+		return true
 	}
 	cache.rebuildPrefixesFromCache()
 	cache.warm = true
+
+	return true
 }
 
 func emptyMessageLineCacheState() messageLineCacheState {

--- a/internal/terminal/message_line_cache.go
+++ b/internal/terminal/message_line_cache.go
@@ -1,0 +1,158 @@
+package terminal
+
+const messageCacheWarmBatchSize = 16
+
+type messageLineCache struct {
+	items     []cachedRenderedMessage
+	prefixes  []int
+	state     messageLineCacheState
+	warm      bool
+	queued    bool
+	warmIndex int
+}
+
+func (cache *messageLineCache) ensure(app *App, width, targetLength int) {
+	state := app.currentLineCacheState(width)
+	if cache.state != state {
+		cache.items = nil
+		cache.prefixes = nil
+		cache.state = state
+		cache.warm = false
+		cache.queued = false
+		cache.warmIndex = 0
+	}
+	if len(cache.items) > targetLength {
+		cache.items = cache.items[:targetLength]
+		cache.prefixes = nil
+		cache.warm = false
+		cache.warmIndex = min(cache.warmIndex, targetLength)
+	}
+	for len(cache.items) < targetLength {
+		cache.items = append(cache.items, emptyCachedRenderedMessage())
+	}
+	if len(cache.prefixes) != len(cache.items)+1 {
+		cache.prefixes = nil
+	}
+}
+
+func (cache *messageLineCache) reset() {
+	cache.items = nil
+	cache.prefixes = nil
+	cache.warmIndex = 0
+	cache.warm = false
+	cache.queued = false
+}
+
+func (cache *messageLineCache) appendInvalidation() {
+	cache.warmIndex = 0
+	cache.warm = false
+	cache.queued = false
+}
+
+func (cache *messageLineCache) truncate(length int) {
+	if len(cache.items) > length {
+		cache.items = cache.items[:length]
+	}
+	cache.prefixes = nil
+	cache.warmIndex = 0
+	cache.warm = false
+	cache.queued = false
+}
+
+func (cache *messageLineCache) lines(app *App, width, index int) []styledLine {
+	cache.ensure(app, width, len(app.messages))
+	if index < len(cache.items) && cache.items[index].Valid {
+		return cache.items[index].Lines
+	}
+	lines := app.renderMessage(width, app.messages[index])
+	if index >= len(cache.items) {
+		return lines
+	}
+	cache.items[index] = cachedRenderedMessage{Lines: lines, Valid: true}
+	cache.prefixes = nil
+
+	return lines
+}
+
+func (cache *messageLineCache) rebuildPrefixes(app *App, width int) {
+	cache.ensure(app, width, len(app.messages))
+	prefixes := make([]int, len(cache.items)+1)
+	for index := range cache.items {
+		if !cache.items[index].Valid {
+			cache.items[index] = cachedRenderedMessage{
+				Lines: app.renderMessage(width, app.messages[index]),
+				Valid: true,
+			}
+		}
+		prefixes[index+1] = prefixes[index] + len(cache.items[index].Lines)
+	}
+	cache.prefixes = prefixes
+}
+
+func (cache *messageLineCache) rebuildPrefixesFromCache() {
+	prefixes := make([]int, len(cache.items)+1)
+	for index := range cache.items {
+		prefixes[index+1] = prefixes[index] + len(cache.items[index].Lines)
+	}
+	cache.prefixes = prefixes
+}
+
+func (cache *messageLineCache) warmStep(app *App) {
+	if cache.warm || app.toolsExpanded || len(app.messages) == 0 || app.lastMessageMaxRows <= 0 {
+		return
+	}
+	width := app.currentLineCacheStateWidth()
+	cache.ensure(app, width, len(app.messages))
+	start := min(max(0, cache.warmIndex), len(app.messages))
+	end := min(len(app.messages), start+messageCacheWarmBatchSize)
+	for index := start; index < end; index++ {
+		if !cache.items[index].Valid {
+			cache.items[index] = cachedRenderedMessage{
+				Lines: app.renderMessage(width, app.messages[index]),
+				Valid: true,
+			}
+		}
+	}
+	cache.warmIndex = end
+	if end < len(app.messages) {
+		return
+	}
+	cache.rebuildPrefixesFromCache()
+	cache.warm = true
+}
+
+func emptyMessageLineCacheState() messageLineCacheState {
+	var state messageLineCacheState
+
+	return state
+}
+
+func (app *App) ensureLineCache(
+	width int,
+	targetLength int,
+	cache *[]cachedRenderedMessage,
+	cacheState *messageLineCacheState,
+) {
+	state := app.currentLineCacheState(width)
+	if *cacheState != state {
+		*cache = nil
+		*cacheState = state
+	}
+	if len(*cache) > targetLength {
+		*cache = (*cache)[:targetLength]
+	}
+	for len(*cache) < targetLength {
+		*cache = append(*cache, emptyCachedRenderedMessage())
+	}
+}
+
+func emptyMessageLineCache() messageLineCache {
+	return messageLineCache{
+		items:     nil,
+		prefixes:  nil,
+		state:     emptyMessageLineCacheState(),
+		warm:      false,
+		queued:    false,
+		warmIndex: 0,
+	}
+}

--- a/internal/terminal/render_messages.go
+++ b/internal/terminal/render_messages.go
@@ -82,6 +82,7 @@ func (app *App) scrolledMessageLines(width, maxRows int, dynamicGroups [][]style
 	if maxRows <= 0 {
 		return nil
 	}
+	app.messageLineCache.ensure(app, width, len(app.messages))
 	if !app.messageLineCache.warm {
 		return app.scrolledMessageLinesFromTail(width, maxRows, dynamicGroups)
 	}
@@ -237,12 +238,14 @@ func (app *App) rebuildMessageRowPrefixSums(width int) {
 
 func (app *App) warmMessageLineCache() {
 	for !app.messageLineCache.warm {
-		app.warmMessageLineCacheStep()
+		if !app.warmMessageLineCacheStep() {
+			return
+		}
 	}
 }
 
-func (app *App) warmMessageLineCacheStep() {
-	app.messageLineCache.warmStep(app)
+func (app *App) warmMessageLineCacheStep() bool {
+	return app.messageLineCache.warmStep(app)
 }
 
 func (app *App) currentLineCacheStateWidth() int {

--- a/internal/terminal/render_messages.go
+++ b/internal/terminal/render_messages.go
@@ -82,11 +82,11 @@ func (app *App) scrolledMessageLines(width, maxRows int, dynamicGroups [][]style
 	if maxRows <= 0 {
 		return nil
 	}
-	if !app.messageCacheWarm {
+	if !app.messageLineCache.warm {
 		return app.scrolledMessageLinesFromTail(width, maxRows, dynamicGroups)
 	}
 
-	staticRows := app.messageRowPrefixSums[len(app.messages)]
+	staticRows := app.messageLineCache.prefixes[len(app.messages)]
 	dynamicRows := extraGroupsVisibleRows(dynamicGroups)
 	totalRows := staticRows + dynamicRows
 	if totalRows <= maxRows {
@@ -179,17 +179,17 @@ func (app *App) staticMessageLinesForRows(width, startRow, endRow int) []styledL
 		return nil
 	}
 	app.rebuildMessageRowPrefixSums(width)
-	app.messageCacheWarm = true
-	startIndex := lowerBoundInts(app.messageRowPrefixSums, startRow+1) - 1
-	endIndex := lowerBoundInts(app.messageRowPrefixSums, endRow)
+	app.messageLineCache.warm = true
+	startIndex := lowerBoundInts(app.messageLineCache.prefixes, startRow+1) - 1
+	endIndex := lowerBoundInts(app.messageLineCache.prefixes, endRow)
 	startIndex = min(max(0, startIndex), len(app.messages))
 	endIndex = min(max(startIndex, endIndex), len(app.messages))
 	groups := make([][]styledLine, 0, endIndex-startIndex)
 	for index := startIndex; index < endIndex; index++ {
 		groups = append(groups, app.cachedMessageLines(width, index))
 	}
-	relativeStart := startRow - app.messageRowPrefixSums[startIndex]
-	relativeEnd := endRow - app.messageRowPrefixSums[startIndex]
+	relativeStart := startRow - app.messageLineCache.prefixes[startIndex]
+	relativeEnd := endRow - app.messageLineCache.prefixes[startIndex]
 
 	return sliceStyledLineGroups(groups, relativeStart, relativeEnd)
 }
@@ -219,46 +219,7 @@ func (app *App) dynamicMessageLineGroups(width int) [][]styledLine {
 }
 
 func (app *App) cachedMessageLines(width, index int) []styledLine {
-	app.ensureMessageLineCache(width)
-	if index < len(app.messageLineCache) && app.messageLineCache[index].Valid {
-		return app.messageLineCache[index].Lines
-	}
-	lines := app.renderMessage(width, app.messages[index])
-	if index >= len(app.messageLineCache) {
-		return lines
-	}
-	app.messageLineCache[index] = cachedRenderedMessage{Lines: lines, Valid: true}
-	app.messageRowPrefixSums = nil
-
-	return lines
-}
-
-func (app *App) ensureMessageLineCache(width int) {
-	app.ensureLineCache(width, len(app.messages), &app.messageLineCache, &app.messageLineCacheState)
-	if len(app.messageRowPrefixSums) != len(app.messageLineCache)+1 {
-		app.messageRowPrefixSums = nil
-	}
-}
-
-func (app *App) ensureLineCache(
-	width int,
-	targetLength int,
-	cache *[]cachedRenderedMessage,
-	cacheState *messageLineCacheState,
-) {
-	state := app.currentLineCacheState(width)
-	if *cacheState != state {
-		*cache = nil
-		*cacheState = state
-		app.messageRowPrefixSums = nil
-		app.messageCacheWarm = false
-	}
-	if len(*cache) > targetLength {
-		*cache = (*cache)[:targetLength]
-	}
-	for len(*cache) < targetLength {
-		*cache = append(*cache, emptyCachedRenderedMessage())
-	}
+	return app.messageLineCache.lines(app, width, index)
 }
 
 func (app *App) currentLineCacheState(width int) messageLineCacheState {
@@ -271,62 +232,21 @@ func (app *App) currentLineCacheState(width int) messageLineCacheState {
 }
 
 func (app *App) rebuildMessageRowPrefixSums(width int) {
-	app.ensureMessageLineCache(width)
-	prefixSums := make([]int, len(app.messageLineCache)+1)
-	for index := range app.messageLineCache {
-		if !app.messageLineCache[index].Valid {
-			app.messageLineCache[index] = cachedRenderedMessage{
-				Lines: app.renderMessage(width, app.messages[index]),
-				Valid: true,
-			}
-		}
-		prefixSums[index+1] = prefixSums[index] + len(app.messageLineCache[index].Lines)
-	}
-	app.messageRowPrefixSums = prefixSums
+	app.messageLineCache.rebuildPrefixes(app, width)
 }
 
-const messageCacheWarmBatchSize = 16
-
 func (app *App) warmMessageLineCache() {
-	for !app.messageCacheWarm {
+	for !app.messageLineCache.warm {
 		app.warmMessageLineCacheStep()
 	}
 }
 
 func (app *App) warmMessageLineCacheStep() {
-	if app.messageCacheWarm || app.toolsExpanded || len(app.messages) == 0 || app.lastMessageMaxRows <= 0 {
-		return
-	}
-	width := app.currentLineCacheStateWidth()
-	app.ensureMessageLineCache(width)
-	start := min(max(0, app.messageCacheWarmIndex), len(app.messages))
-	end := min(len(app.messages), start+messageCacheWarmBatchSize)
-	for index := start; index < end; index++ {
-		if !app.messageLineCache[index].Valid {
-			app.messageLineCache[index] = cachedRenderedMessage{
-				Lines: app.renderMessage(width, app.messages[index]),
-				Valid: true,
-			}
-		}
-	}
-	app.messageCacheWarmIndex = end
-	if end < len(app.messages) {
-		return
-	}
-	app.rebuildMessageRowPrefixSumsFromCache()
-	app.messageCacheWarm = true
-}
-
-func (app *App) rebuildMessageRowPrefixSumsFromCache() {
-	prefixSums := make([]int, len(app.messageLineCache)+1)
-	for index := range app.messageLineCache {
-		prefixSums[index+1] = prefixSums[index] + len(app.messageLineCache[index].Lines)
-	}
-	app.messageRowPrefixSums = prefixSums
+	app.messageLineCache.warmStep(app)
 }
 
 func (app *App) currentLineCacheStateWidth() int {
-	state := app.messageLineCacheState
+	state := app.messageLineCache.state
 	if state.Width > 0 {
 		return state.Width
 	}

--- a/internal/terminal/render_test.go
+++ b/internal/terminal/render_test.go
@@ -507,18 +507,18 @@ func TestWarmMessageLineCachePrebuildsFullHistoryAfterInitialRender(t *testing.T
 	}
 
 	_ = app.messageLines(80, 6)
-	if app.messageCacheWarm {
+	if app.messageLineCache.warm {
 		t.Fatal("tail render should not eagerly warm full history")
 	}
 
 	app.warmMessageLineCache()
-	if !app.messageCacheWarm {
+	if !app.messageLineCache.warm {
 		t.Fatal("expected history cache to be warm")
 	}
-	if len(app.messageRowPrefixSums) != len(app.messages)+1 {
+	if len(app.messageLineCache.prefixes) != len(app.messages)+1 {
 		t.Fatalf(
 			"row prefix length = %d, want %d",
-			len(app.messageRowPrefixSums),
+			len(app.messageLineCache.prefixes),
 			len(app.messages)+1,
 		)
 	}
@@ -534,15 +534,15 @@ func TestWarmMessageLineCacheStepPrebuildsIncrementally(t *testing.T) {
 
 	_ = app.messageLines(80, 6)
 	app.warmMessageLineCacheStep()
-	if app.messageCacheWarm {
+	if app.messageLineCache.warm {
 		t.Fatal("single warm step should not eagerly warm full history")
 	}
-	if app.messageCacheWarmIndex != messageCacheWarmBatchSize {
-		t.Fatalf("warm index = %d, want %d", app.messageCacheWarmIndex, messageCacheWarmBatchSize)
+	if app.messageLineCache.warmIndex != messageCacheWarmBatchSize {
+		t.Fatalf("warm index = %d, want %d", app.messageLineCache.warmIndex, messageCacheWarmBatchSize)
 	}
 
 	app.warmMessageLineCacheStep()
-	if !app.messageCacheWarm {
+	if !app.messageLineCache.warm {
 		t.Fatal("expected second warm step to finish cache")
 	}
 }
@@ -556,12 +556,12 @@ func TestScrolledMessageLinesBeforeWarmCacheUsesVisibleTail(t *testing.T) {
 	}
 
 	_ = app.messageLines(80, 6)
-	if app.messageCacheWarm {
+	if app.messageLineCache.warm {
 		t.Fatal("tail render should not warm full history")
 	}
 	app.scrollTranscript(3)
 	lines := app.messageLines(80, 6)
-	if app.messageCacheWarm {
+	if app.messageLineCache.warm {
 		t.Fatal("scroll before cache warm should not synchronously warm full history")
 	}
 	if lineIndexContaining(lines, "history message 98") == -1 {
@@ -598,7 +598,7 @@ func TestBottomMessageLinesExpandedToolUsesTailWithoutFullRender(t *testing.T) {
 	if lineIndexContaining(lines, "line 0") != -1 {
 		t.Fatalf("expected old tool output to stay unrendered in bottom tail, got %v", texts)
 	}
-	if len(app.messageLineCache) > 0 && app.messageLineCache[0].Valid {
+	if len(app.messageLineCache.items) > 0 && app.messageLineCache.items[0].Valid {
 		t.Fatal("bottom tail render should not populate full expanded tool cache")
 	}
 }

--- a/internal/terminal/render_test.go
+++ b/internal/terminal/render_test.go
@@ -524,6 +524,25 @@ func TestWarmMessageLineCachePrebuildsFullHistoryAfterInitialRender(t *testing.T
 	}
 }
 
+func TestWarmMessageLineCacheStopsWhenNoProgressIsPossible(t *testing.T) {
+	t.Parallel()
+
+	app := newRenderTestApp(t)
+	app.addMessage(database.RoleAssistant, "history message")
+
+	app.warmMessageLineCache()
+	if app.messageLineCache.warm {
+		t.Fatal("cache should not warm without a measured viewport")
+	}
+
+	app.lastMessageMaxRows = 6
+	app.toolsExpanded = true
+	app.warmMessageLineCache()
+	if app.messageLineCache.warm {
+		t.Fatal("cache should not warm while tools are expanded")
+	}
+}
+
 func TestWarmMessageLineCacheStepPrebuildsIncrementally(t *testing.T) {
 	t.Parallel()
 
@@ -567,6 +586,25 @@ func TestScrolledMessageLinesBeforeWarmCacheUsesVisibleTail(t *testing.T) {
 	if lineIndexContaining(lines, "history message 98") == -1 {
 		t.Fatalf("expected recent history while warm cache is pending, got %v", lineTexts(lines))
 	}
+}
+
+func TestScrolledMessageLinesRevalidatesWarmCacheAfterResize(t *testing.T) {
+	t.Parallel()
+
+	app := newRenderTestApp(t)
+	for index := range 20 {
+		app.addMessage(database.RoleAssistant, "history message "+intText(index)+" with enough text to wrap")
+	}
+	_ = app.messageLines(80, 6)
+	app.warmMessageLineCache()
+	require.True(t, app.messageLineCache.warm)
+	require.Equal(t, 80, app.messageLineCache.state.Width)
+
+	app.scrollTranscript(3)
+	_ = app.messageLines(24, 6)
+
+	require.Equal(t, 24, app.messageLineCache.state.Width)
+	require.False(t, app.messageLineCache.warm)
 }
 
 func TestBottomMessageLinesExpandedToolUsesTailWithoutFullRender(t *testing.T) {


### PR DESCRIPTION
## Summary
- extract message line cache state and warming logic into a focused type
- keep terminal render behavior unchanged
- update cache-related tests for the new state owner

## Validation
- mise exec -- task ci