### PR TITLE
test(auth): table drive auth availability

### DIFF
--- a/internal/auth/storage_test.go
+++ b/internal/auth/storage_test.go
@@ -17,6 +17,7 @@ const (
 	testStoredKey          = "stored-key"
 	testStoredProvider     = "stored"
 	testFallbackProvider   = "fallback"
+	testEmptyProvider      = "empty"
 	testStoredOAuthAccess  = "stored-oauth-access"
 	testStoredOAuthRefresh = "stored-oauth-refresh"
 )
@@ -120,10 +121,22 @@ func TestStoragePersistsMemoryCredentials(t *testing.T) {
 }
 
 func TestStorageReportsAuthAvailabilityBySource(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	storage, err := auth.NewInMemoryStorage(ctx, map[string]auth.Credential{
+		"env-only": {
+			OAuth:     nil,
+			Type:      auth.CredentialTypeAPIKey,
+			Key:       "env-key",
+			Access:    "",
+			Refresh:   "",
+			AccountID: "",
+			Expires:   0,
+			ExpiresAt: 0,
+		},
 		testStoredProvider: testAPIKeyCredential(),
-		"empty": {
+		testEmptyProvider: {
 			OAuth:     nil,
 			Type:      auth.CredentialTypeAPIKey,
 			Key:       "",
@@ -135,18 +148,31 @@ func TestStorageReportsAuthAvailabilityBySource(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	t.Setenv("ENV_ONLY_API_KEY", "env-key")
 	storage.SetRuntimeAPIKey("runtime", "runtime-key")
 	storage.SetFallbackResolver(func(provider string) (string, bool) {
 		return "fallback-key", provider == testFallbackProvider
 	})
 
-	assert.True(t, storage.HasAuth("runtime"))
-	assert.True(t, storage.HasAuth(testStoredProvider))
-	assert.True(t, storage.HasAuth("env-only"))
-	assert.True(t, storage.HasAuth(testFallbackProvider))
-	assert.False(t, storage.HasAuth("empty"))
-	assert.False(t, storage.HasAuth("missing"))
+	tests := []struct {
+		name     string
+		provider string
+		expected bool
+	}{
+		{name: "runtime", provider: "runtime", expected: true},
+		{name: "stored", provider: testStoredProvider, expected: true},
+		{name: "env", provider: "env-only", expected: true},
+		{name: "fallback", provider: testFallbackProvider, expected: true},
+		{name: "empty", provider: testEmptyProvider, expected: false},
+		{name: "missing", provider: "missing", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, storage.HasAuth(tt.provider))
+		})
+	}
 }
 
 func TestStorageDrainsErrors(t *testing.T) {

--- a/internal/auth/storage_test.go
+++ b/internal/auth/storage_test.go
@@ -18,6 +18,7 @@ const (
 	testStoredProvider     = "stored"
 	testFallbackProvider   = "fallback"
 	testEmptyProvider      = "empty"
+	testStoredEnvLike      = "stored-env-like"
 	testStoredOAuthAccess  = "stored-oauth-access"
 	testStoredOAuthRefresh = "stored-oauth-refresh"
 )
@@ -125,7 +126,7 @@ func TestStorageReportsAuthAvailabilityBySource(t *testing.T) {
 
 	ctx := context.Background()
 	storage, err := auth.NewInMemoryStorage(ctx, map[string]auth.Credential{
-		"env-only": {
+		testStoredEnvLike: {
 			OAuth:     nil,
 			Type:      auth.CredentialTypeAPIKey,
 			Key:       "env-key",
@@ -160,7 +161,7 @@ func TestStorageReportsAuthAvailabilityBySource(t *testing.T) {
 	}{
 		{name: "runtime", provider: "runtime", expected: true},
 		{name: "stored", provider: testStoredProvider, expected: true},
-		{name: "env", provider: "env-only", expected: true},
+		{name: testStoredEnvLike, provider: testStoredEnvLike, expected: true},
 		{name: "fallback", provider: testFallbackProvider, expected: true},
 		{name: "empty", provider: testEmptyProvider, expected: false},
 		{name: "missing", provider: "missing", expected: false},


### PR DESCRIPTION
## Summary
- convert auth availability coverage to a table-driven test
- avoid env mutation in parallel auth tests by using in-memory credentials

## Validation
- mise exec -- task ci