### PR TITLE
feat(context): compact after large responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
+          use_pypi: true
+          version: 11.2.8
           files: ./coverage.out
           flags: unittests
           slug: omarluq/librecode

--- a/internal/assistant/context_auto_compaction.go
+++ b/internal/assistant/context_auto_compaction.go
@@ -4,12 +4,15 @@ package assistant
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/samber/oops"
 
 	"github.com/omarluq/librecode/internal/database"
 	"github.com/omarluq/librecode/internal/model"
 )
+
+const postResponseAutoCompactThresholdPercent = 80
 
 type contextRequestBuild struct {
 	Context *contextBuildResult
@@ -149,9 +152,96 @@ func (runtime *Runtime) emitContextCompaction(ctx context.Context, onEvent func(
 	runtime.emit(ctx, string(StreamEventContextCompaction), map[string]any{"message": message})
 }
 
+type postResponseAutoCompactionInput struct {
+	onEvent       func(StreamEvent)
+	sessionID     string
+	cwd           string
+	parentEntryID string
+}
+
+func (runtime *Runtime) autoCompactAfterResponse(ctx context.Context, input *postResponseAutoCompactionInput) {
+	if !runtime.shouldTryPostResponseAutoCompaction(input) {
+		return
+	}
+	usage, err := runtime.ContextUsage(ctx, input.sessionID, input.cwd)
+	if err != nil {
+		runtime.emitPostResponseAutoCompactionError(ctx, input.onEvent, err)
+		return
+	}
+	budget := contextBudgetFromUsage(usage)
+	if !shouldAutoCompactAfterResponse(budget) {
+		return
+	}
+
+	runtime.emitContextCompaction(ctx, input.onEvent, postResponseAutoCompactionStartMessage(budget))
+	entry, err := runtime.CompactSessionFrom(ctx, input.sessionID, input.cwd, &input.parentEntryID)
+	if isCompactNothingToDoError(err) {
+		return
+	}
+	if err != nil {
+		runtime.emitPostResponseAutoCompactionError(ctx, input.onEvent, err)
+		return
+	}
+	runtime.emitContextCompaction(ctx, input.onEvent, compactionMessage(
+		"context auto-compacted after response",
+		budget,
+		entry,
+	))
+}
+
+func (runtime *Runtime) shouldTryPostResponseAutoCompaction(input *postResponseAutoCompactionInput) bool {
+	return runtime.cfg.Context.PreflightEnabled && input != nil && strings.TrimSpace(input.sessionID) != "" &&
+		strings.TrimSpace(input.parentEntryID) != ""
+}
+
+func contextBudgetFromUsage(usage model.TokenUsage) contextBudget {
+	budget := contextBudget{
+		InputTokens:       usage.ContextTokens,
+		ContextWindow:     usage.ContextWindow,
+		UsableInput:       usage.Breakdown["usable_input"],
+		OutputReserve:     usage.Breakdown["reserve_output"],
+		ToolSchemaReserve: usage.Breakdown["reserve_tools"],
+		ProviderReserve:   usage.Breakdown["reserve_provider"],
+		SafetyMargin:      usage.Breakdown["reserve_safety"],
+	}
+
+	return budget
+}
+
+func shouldAutoCompactAfterResponse(budget contextBudget) bool {
+	if budget.ContextWindow <= 0 || budget.UsableInput <= 0 || budget.InputTokens <= 0 {
+		return false
+	}
+
+	return budget.InputTokens >= budget.UsableInput*postResponseAutoCompactThresholdPercent/100
+}
+
+func (runtime *Runtime) emitPostResponseAutoCompactionError(
+	ctx context.Context,
+	onEvent func(StreamEvent),
+	err error,
+) {
+	if err == nil {
+		return
+	}
+	runtime.emitContextCompaction(ctx, onEvent, "context auto-compaction after response failed: "+err.Error())
+}
+
+func postResponseAutoCompactionStartMessage(budget contextBudget) string {
+	message := "context auto-compacting after response: estimated input is %d tokens; " +
+		"threshold is %d%% of usable input budget %d"
+
+	return fmt.Sprintf(message, budget.InputTokens, postResponseAutoCompactThresholdPercent, budget.UsableInput)
+}
+
 func autoCompactionMessage(budget contextBudget, entry *database.EntryEntity) string {
+	return compactionMessage("context auto-compacted before request", budget, entry)
+}
+
+func compactionMessage(prefix string, budget contextBudget, entry *database.EntryEntity) string {
 	message := fmt.Sprintf(
-		"context auto-compacted before request: estimated input was %d tokens; usable input budget is %d tokens",
+		"%s: estimated input was %d tokens; usable input budget is %d tokens",
+		prefix,
 		budget.InputTokens,
 		budget.UsableInput,
 	)

--- a/internal/assistant/context_auto_compaction_internal_extra_test.go
+++ b/internal/assistant/context_auto_compaction_internal_extra_test.go
@@ -1,0 +1,248 @@
+package assistant_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samber/oops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/assistant"
+	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/model"
+)
+
+const (
+	autoCompactionTestFinalAnswer = "final answer"
+	autoCompactionTestUnused      = "unused"
+)
+
+func TestRuntime_AutoCompactionBeforeRequestErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		client   assistant.CompletionClient
+		seed     func(t *testing.T, repository *database.SessionRepository, sessionID string)
+		name     string
+		wantCode string
+	}{
+		{
+			name:     "preserves validation error when nothing can be compacted",
+			client:   autoCompactionValidationOnlyClient{},
+			seed:     nil,
+			wantCode: "context_window_exceeded",
+		},
+		{
+			name:   "wraps summarization failure",
+			client: autoCompactionFailingSummaryClient{},
+			seed: func(t *testing.T, repository *database.SessionRepository, sessionID string) {
+				t.Helper()
+				appendAutoCompactionOldTurn(t, repository, sessionID)
+			},
+			wantCode: "compact_summarize",
+		},
+		{
+			name:   "wraps rebuilt budget failure",
+			client: autoCompactionLargeSummaryClient{},
+			seed: func(t *testing.T, repository *database.SessionRepository, sessionID string) {
+				t.Helper()
+				appendAutoCompactionOldTurn(t, repository, sessionID)
+			},
+			wantCode: "context_window_exceeded",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			runtime := newAutoCompactionErrorRuntime(t, testCase.client)
+			repository := runtime.SessionRepository()
+			session, err := repository.CreateSession(context.Background(), testRuntimeCWD, testCase.name, "")
+			require.NoError(t, err)
+			if testCase.seed != nil {
+				testCase.seed(t, repository, session.ID)
+			}
+			request := newRuntimePromptRequest(testRuntimeCWD, strings.Repeat("prompt ", 200), "")
+			request.SessionID = session.ID
+
+			response, err := runtime.Prompt(context.Background(), request)
+
+			require.Nil(t, response)
+			requireOopsCode(t, err, testCase.wantCode)
+		})
+	}
+}
+
+func TestRuntime_AutoCompactionAfterResponseErrorEvent(t *testing.T) {
+	t.Parallel()
+
+	runtime := newAutoCompactionErrorRuntimeWithWindow(t, autoCompactionFailingSummaryClient{}, 30_000)
+	repository := runtime.SessionRepository()
+	session, err := repository.CreateSession(context.Background(), testRuntimeCWD, "post error", "")
+	require.NoError(t, err)
+	old := appendRuntimeTestMessage(t, repository, session.ID, nil, database.RoleUser, strings.Repeat("old ", 20_000))
+	oldAssistant := appendRuntimeTestMessage(t, repository, session.ID, &old.ID, database.RoleAssistant, "recent tail")
+	events := []assistant.StreamEvent{}
+
+	runtime.AutoCompactAfterResponseForTest(context.Background(), func(event assistant.StreamEvent) {
+		events = append(events, event)
+	}, session.ID, testRuntimeCWD, oldAssistant.ID)
+
+	assert.Condition(t, func() bool {
+		for _, event := range events {
+			if event.Kind == assistant.StreamEventContextCompaction &&
+				strings.Contains(event.Text, "context auto-compaction after response failed:") {
+				return true
+			}
+		}
+
+		return false
+	})
+}
+
+func TestRuntime_EmitPostResponseAutoCompactionErrorSkipsNil(t *testing.T) {
+	t.Parallel()
+
+	runtime := newAutoCompactionErrorRuntime(t, autoCompactionStaticSummaryClient{})
+	events := []assistant.StreamEvent{}
+
+	runtime.EmitPostResponseAutoCompactionErrorForTest(context.Background(), func(event assistant.StreamEvent) {
+		events = append(events, event)
+	}, nil)
+
+	assert.Empty(t, events)
+}
+
+func TestRuntime_ContextCompactionEventWithoutEntryDetails(t *testing.T) {
+	t.Parallel()
+
+	message := assistant.AutoCompactionMessageForTest(nil)
+
+	assert.Contains(t, message, "context auto-compacted")
+	assert.NotContains(t, message, "summarized")
+	assert.NotContains(t, message, "kept recent context")
+}
+
+func newAutoCompactionErrorRuntime(t *testing.T, client assistant.CompletionClient) *assistant.Runtime {
+	t.Helper()
+
+	return newAutoCompactionErrorRuntimeWithWindow(t, client, 64)
+}
+
+func newAutoCompactionErrorRuntimeWithWindow(
+	t *testing.T,
+	client assistant.CompletionClient,
+	contextWindow int,
+) *assistant.Runtime {
+	t.Helper()
+
+	runtime := newTestRuntimeWithContextWindow(t, client, contextWindow)
+	runtimeConfig := testConfig()
+	runtimeConfig.Context.KeepRecentTokens = 1
+	runtimeConfig.Context.ProviderReserveTokens = 0
+	runtimeConfig.Context.SafetyMarginTokens = 0
+	runtimeConfig.Context.OutputReserveTokens = 1
+
+	return assistant.NewRuntime(
+		runtimeConfig,
+		runtime.SessionRepository(),
+		nil,
+		assistant.NewResponseCache(false, 1, time.Minute),
+		runtime.EventBus(),
+		runtime.ModelRegistry(),
+		client,
+		nil,
+	)
+}
+
+func appendAutoCompactionOldTurn(t *testing.T, repository *database.SessionRepository, sessionID string) {
+	t.Helper()
+
+	first := appendRuntimeTestMessage(
+		t,
+		repository,
+		sessionID,
+		nil,
+		database.RoleUser,
+		strings.Repeat("old ", 120),
+	)
+	appendRuntimeTestMessage(
+		t,
+		repository,
+		sessionID,
+		&first.ID,
+		database.RoleAssistant,
+		strings.Repeat("older ", 120),
+	)
+}
+
+func requireOopsCode(t *testing.T, err error, wantCode string) {
+	t.Helper()
+
+	require.Error(t, err)
+	oopsErr, ok := oops.AsOops(err)
+	require.True(t, ok)
+	require.Equal(t, wantCode, oopsErr.Code())
+}
+
+type autoCompactionValidationOnlyClient struct{}
+
+func (autoCompactionValidationOnlyClient) Complete(
+	context.Context,
+	*assistant.CompletionRequest,
+) (*assistant.CompletionResult, error) {
+	return autoCompactionResult(autoCompactionTestUnused), nil
+}
+
+type autoCompactionFailingSummaryClient struct{}
+
+func (autoCompactionFailingSummaryClient) Complete(
+	_ context.Context,
+	request *assistant.CompletionRequest,
+) (*assistant.CompletionResult, error) {
+	if request.DisableTools {
+		return nil, errors.New("summary failed")
+	}
+
+	return autoCompactionResult(autoCompactionTestFinalAnswer), nil
+}
+
+type autoCompactionLargeSummaryClient struct{}
+
+func (autoCompactionLargeSummaryClient) Complete(
+	_ context.Context,
+	request *assistant.CompletionRequest,
+) (*assistant.CompletionResult, error) {
+	if request.DisableTools {
+		return autoCompactionResult(strings.Repeat("summary ", 200)), nil
+	}
+
+	return autoCompactionResult(autoCompactionTestFinalAnswer), nil
+}
+
+type autoCompactionStaticSummaryClient struct{}
+
+func (autoCompactionStaticSummaryClient) Complete(
+	_ context.Context,
+	request *assistant.CompletionRequest,
+) (*assistant.CompletionResult, error) {
+	if request.DisableTools {
+		return autoCompactionResult("summary"), nil
+	}
+
+	return autoCompactionResult(autoCompactionTestFinalAnswer), nil
+}
+
+func autoCompactionResult(text string) *assistant.CompletionResult {
+	return &assistant.CompletionResult{
+		Thinking:   nil,
+		ToolEvents: nil,
+		Text:       text,
+		Usage:      model.EmptyTokenUsage(),
+	}
+}

--- a/internal/assistant/context_auto_compaction_internal_extra_test.go
+++ b/internal/assistant/context_auto_compaction_internal_extra_test.go
@@ -79,13 +79,13 @@ func TestRuntime_AutoCompactionBeforeRequestErrorPaths(t *testing.T) {
 }
 
 func TestRuntime_AutoCompactionAfterResponseErrorEvent(t *testing.T) {
-	t.Parallel()
+	t.Setenv("HOME", t.TempDir())
 
-	runtime := newAutoCompactionErrorRuntimeWithWindow(t, autoCompactionFailingSummaryClient{}, 30_000)
+	runtime := newAutoCompactionErrorRuntimeWithWindow(t, autoCompactionFailingSummaryClient{}, 160_000)
 	repository := runtime.SessionRepository()
 	session, err := repository.CreateSession(context.Background(), testRuntimeCWD, "post error", "")
 	require.NoError(t, err)
-	old := appendRuntimeTestMessage(t, repository, session.ID, nil, database.RoleUser, strings.Repeat("old ", 20_000))
+	old := appendRuntimeTestMessage(t, repository, session.ID, nil, database.RoleUser, strings.Repeat("old ", 150_000))
 	oldAssistant := appendRuntimeTestMessage(t, repository, session.ID, &old.ID, database.RoleAssistant, "recent tail")
 	events := []assistant.StreamEvent{}
 
@@ -93,16 +93,20 @@ func TestRuntime_AutoCompactionAfterResponseErrorEvent(t *testing.T) {
 		events = append(events, event)
 	}, session.ID, testRuntimeCWD, oldAssistant.ID)
 
-	assert.Condition(t, func() bool {
-		for _, event := range events {
-			if event.Kind == assistant.StreamEventContextCompaction &&
-				strings.Contains(event.Text, "context auto-compaction after response failed:") {
-				return true
-			}
-		}
+	assertContainsCompactionErrorEvent(t, events)
+}
 
-		return false
-	})
+func assertContainsCompactionErrorEvent(t *testing.T, events []assistant.StreamEvent) {
+	t.Helper()
+
+	for _, event := range events {
+		if event.Kind == assistant.StreamEventContextCompaction &&
+			strings.Contains(event.Text, "context auto-compaction after response failed:") {
+			return
+		}
+	}
+
+	t.Error("expected context compaction error event not found")
 }
 
 func TestRuntime_EmitPostResponseAutoCompactionErrorSkipsNil(t *testing.T) {

--- a/internal/assistant/context_auto_compaction_test.go
+++ b/internal/assistant/context_auto_compaction_test.go
@@ -17,16 +17,79 @@ import (
 func TestRuntime_AutoCompactsOversizedRequestBeforeProviderCall(t *testing.T) {
 	t.Parallel()
 
-	client := &sequencedCompletionClient{
-		responses: []string{"summary of old context", "final answer"},
-		requests:  nil,
+	harness := newAutoCompactionRuntimeHarness(t, []string{"summary of old context", "final answer"}, 16_000)
+	ctx := context.Background()
+	session, err := harness.runtime.SessionRepository().CreateSession(ctx, testRuntimeCWD, "auto compact", "")
+	require.NoError(t, err)
+	old := appendRuntimeTestMessage(
+		t,
+		harness.runtime.SessionRepository(),
+		session.ID,
+		nil,
+		database.RoleUser,
+		strings.Repeat("old ", 15_000),
+	)
+	appendRuntimeTestMessage(
+		t,
+		harness.runtime.SessionRepository(),
+		session.ID,
+		&old.ID,
+		database.RoleAssistant,
+		"tail",
+	)
+	request := newRuntimePromptRequest(testRuntimeCWD, "continue", "")
+	request.SessionID = session.ID
+	events := []assistant.StreamEvent{}
+	request.OnEvent = func(event assistant.StreamEvent) {
+		events = append(events, event)
 	}
-	runtime := newTestRuntimeWithContextWindow(t, client, 16_000)
+
+	response, err := harness.runtime.Prompt(ctx, request)
+
+	require.NoError(t, err)
+	assert.Equal(t, "final answer", response.Text)
+	require.Len(t, harness.client.requests, 2)
+	assert.True(t, harness.client.requests[0].DisableTools)
+	assert.False(t, harness.client.requests[1].DisableTools)
+	assert.Contains(t, harness.client.requests[1].Messages[0].Content, "summary of old context")
+	assert.Equal(t, "continue", harness.client.requests[1].Messages[len(harness.client.requests[1].Messages)-1].Content)
+	assert.Condition(t, func() bool {
+		for _, event := range events {
+			if isContextAutoCompactionEvent(&event) {
+				return true
+			}
+		}
+		return false
+	})
+
+	branch, err := harness.runtime.SessionRepository().Branch(ctx, session.ID, response.AssistantEntryID)
+	require.NoError(t, err)
+	roles := make([]database.EntryType, 0, len(branch))
+	for index := range branch {
+		roles = append(roles, branch[index].Type)
+	}
+	assert.Contains(t, roles, database.EntryTypeCompaction)
+}
+
+type autoCompactionRuntimeHarness struct {
+	runtime *assistant.Runtime
+	client  *sequencedCompletionClient
+}
+
+func newAutoCompactionRuntimeHarness(
+	t *testing.T,
+	responses []string,
+	contextWindow int,
+) autoCompactionRuntimeHarness {
+	t.Helper()
+
+	client := &sequencedCompletionClient{responses: responses, requests: nil}
+	runtime := newTestRuntimeWithContextWindow(t, client, contextWindow)
 	runtimeConfig := testConfig()
 	runtimeConfig.Context.KeepRecentTokens = 1
 	runtimeConfig.Context.ProviderReserveTokens = 0
 	runtimeConfig.Context.SafetyMarginTokens = 0
-	runtimeConfig.Context.OutputReserveTokens = 0
+	runtimeConfig.Context.OutputReserveTokens = 1
 	runtime = assistant.NewRuntime(
 		runtimeConfig,
 		runtime.SessionRepository(),
@@ -38,50 +101,7 @@ func TestRuntime_AutoCompactsOversizedRequestBeforeProviderCall(t *testing.T) {
 		nil,
 	)
 
-	ctx := context.Background()
-	session, err := runtime.SessionRepository().CreateSession(ctx, testRuntimeCWD, "auto compact", "")
-	require.NoError(t, err)
-	old := appendRuntimeTestMessage(
-		t,
-		runtime.SessionRepository(),
-		session.ID,
-		nil,
-		database.RoleUser,
-		strings.Repeat("old ", 15_000),
-	)
-	appendRuntimeTestMessage(t, runtime.SessionRepository(), session.ID, &old.ID, database.RoleAssistant, "tail")
-	request := newRuntimePromptRequest(testRuntimeCWD, "continue", "")
-	request.SessionID = session.ID
-	events := []assistant.StreamEvent{}
-	request.OnEvent = func(event assistant.StreamEvent) {
-		events = append(events, event)
-	}
-
-	response, err := runtime.Prompt(ctx, request)
-
-	require.NoError(t, err)
-	assert.Equal(t, "final answer", response.Text)
-	require.Len(t, client.requests, 2)
-	assert.True(t, client.requests[0].DisableTools)
-	assert.False(t, client.requests[1].DisableTools)
-	assert.Contains(t, client.requests[1].Messages[0].Content, "summary of old context")
-	assert.Equal(t, "continue", client.requests[1].Messages[len(client.requests[1].Messages)-1].Content)
-	assert.Condition(t, func() bool {
-		for _, event := range events {
-			if isContextAutoCompactionEvent(&event) {
-				return true
-			}
-		}
-		return false
-	})
-
-	branch, err := runtime.SessionRepository().Branch(ctx, session.ID, response.AssistantEntryID)
-	require.NoError(t, err)
-	roles := make([]database.EntryType, 0, len(branch))
-	for index := range branch {
-		roles = append(roles, branch[index].Type)
-	}
-	assert.Contains(t, roles, database.EntryTypeCompaction)
+	return autoCompactionRuntimeHarness{runtime: runtime, client: client}
 }
 
 func isContextAutoCompactionEvent(event *assistant.StreamEvent) bool {

--- a/internal/assistant/context_auto_compaction_test.go
+++ b/internal/assistant/context_auto_compaction_test.go
@@ -89,6 +89,8 @@ func newAutoCompactionRuntimeHarness(
 	runtimeConfig.Context.KeepRecentTokens = 1
 	runtimeConfig.Context.ProviderReserveTokens = 0
 	runtimeConfig.Context.SafetyMarginTokens = 0
+	// Reserve one token so post-response compaction tests keep a stable output headroom
+	// and do not depend on off-by-one budget boundaries.
 	runtimeConfig.Context.OutputReserveTokens = 1
 	runtime = assistant.NewRuntime(
 		runtimeConfig,

--- a/internal/assistant/context_post_response_auto_compaction_test.go
+++ b/internal/assistant/context_post_response_auto_compaction_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,37 +15,17 @@ import (
 func TestRuntime_AutoCompactsAfterResponseNearThreshold(t *testing.T) {
 	t.Parallel()
 
-	client := &sequencedCompletionClient{
-		responses: []string{"final answer", "summary of completed work"},
-		requests:  nil,
-	}
-	runtime := newTestRuntimeWithContextWindow(t, client, 16_000)
-	runtimeConfig := testConfig()
-	runtimeConfig.Context.KeepRecentTokens = 1
-	runtimeConfig.Context.ProviderReserveTokens = 0
-	runtimeConfig.Context.SafetyMarginTokens = 0
-	runtimeConfig.Context.OutputReserveTokens = 0
-	runtime = assistant.NewRuntime(
-		runtimeConfig,
-		runtime.SessionRepository(),
-		nil,
-		assistant.NewResponseCache(false, 1, time.Minute),
-		runtime.EventBus(),
-		runtime.ModelRegistry(),
-		client,
-		nil,
-	)
-
+	harness := newAutoCompactionRuntimeHarness(t, []string{"final answer", "summary of completed work"}, 16_000)
 	ctx := context.Background()
-	session, err := runtime.SessionRepository().CreateSession(ctx, testRuntimeCWD, "post compact", "")
+	session, err := harness.runtime.SessionRepository().CreateSession(ctx, testRuntimeCWD, "post compact", "")
 	require.NoError(t, err)
 	old := appendRuntimeTestMessage(
 		t,
-		runtime.SessionRepository(),
+		harness.runtime.SessionRepository(),
 		session.ID,
 		nil,
 		database.RoleUser,
-		strings.Repeat("old ", 1_000),
+		strings.Repeat("old ", 2_600),
 	)
 	request := newRuntimePromptRequest(testRuntimeCWD, "continue", "")
 	request.SessionID = session.ID
@@ -56,23 +35,23 @@ func TestRuntime_AutoCompactsAfterResponseNearThreshold(t *testing.T) {
 		events = append(events, event)
 	}
 
-	response, err := runtime.Prompt(ctx, request)
+	response, err := harness.runtime.Prompt(ctx, request)
 
 	require.NoError(t, err)
 	assert.Equal(t, "final answer", response.Text)
-	require.Len(t, client.requests, 2)
-	assert.False(t, client.requests[0].DisableTools)
-	assert.True(t, client.requests[1].DisableTools)
-	assert.Contains(t, client.requests[1].Messages[0].Content, "old")
+	require.Len(t, harness.client.requests, 2)
+	assert.False(t, harness.client.requests[0].DisableTools)
+	assert.True(t, harness.client.requests[1].DisableTools)
+	assert.Contains(t, harness.client.requests[1].Messages[0].Content, "old")
 	assertPostResponseCompactionEvent(t, events)
 
-	leaf, found, err := runtime.SessionRepository().LeafEntry(ctx, session.ID)
+	leaf, found, err := harness.runtime.SessionRepository().LeafEntry(ctx, session.ID)
 	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, database.EntryTypeCompaction, leaf.Type)
 	assert.Equal(t, response.AssistantEntryID, *leaf.ParentID)
 
-	branch, err := runtime.SessionRepository().Branch(ctx, session.ID, leaf.ID)
+	branch, err := harness.runtime.SessionRepository().Branch(ctx, session.ID, leaf.ID)
 	require.NoError(t, err)
 	assert.Equal(t, database.EntryTypeCompaction, branch[len(branch)-1].Type)
 }

--- a/internal/assistant/context_post_response_auto_compaction_test.go
+++ b/internal/assistant/context_post_response_auto_compaction_test.go
@@ -1,0 +1,127 @@
+package assistant_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/assistant"
+	"github.com/omarluq/librecode/internal/database"
+)
+
+func TestRuntime_AutoCompactsAfterResponseNearThreshold(t *testing.T) {
+	t.Parallel()
+
+	client := &sequencedCompletionClient{
+		responses: []string{"final answer", "summary of completed work"},
+		requests:  nil,
+	}
+	runtime := newTestRuntimeWithContextWindow(t, client, 16_000)
+	runtimeConfig := testConfig()
+	runtimeConfig.Context.KeepRecentTokens = 1
+	runtimeConfig.Context.ProviderReserveTokens = 0
+	runtimeConfig.Context.SafetyMarginTokens = 0
+	runtimeConfig.Context.OutputReserveTokens = 0
+	runtime = assistant.NewRuntime(
+		runtimeConfig,
+		runtime.SessionRepository(),
+		nil,
+		assistant.NewResponseCache(false, 1, time.Minute),
+		runtime.EventBus(),
+		runtime.ModelRegistry(),
+		client,
+		nil,
+	)
+
+	ctx := context.Background()
+	session, err := runtime.SessionRepository().CreateSession(ctx, testRuntimeCWD, "post compact", "")
+	require.NoError(t, err)
+	old := appendRuntimeTestMessage(
+		t,
+		runtime.SessionRepository(),
+		session.ID,
+		nil,
+		database.RoleUser,
+		strings.Repeat("old ", 1_000),
+	)
+	request := newRuntimePromptRequest(testRuntimeCWD, "continue", "")
+	request.SessionID = session.ID
+	request.ParentEntryID = &old.ID
+	events := []assistant.StreamEvent{}
+	request.OnEvent = func(event assistant.StreamEvent) {
+		events = append(events, event)
+	}
+
+	response, err := runtime.Prompt(ctx, request)
+
+	require.NoError(t, err)
+	assert.Equal(t, "final answer", response.Text)
+	require.Len(t, client.requests, 2)
+	assert.False(t, client.requests[0].DisableTools)
+	assert.True(t, client.requests[1].DisableTools)
+	assert.Contains(t, client.requests[1].Messages[0].Content, "old")
+	assertPostResponseCompactionEvent(t, events)
+
+	leaf, found, err := runtime.SessionRepository().LeafEntry(ctx, session.ID)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, database.EntryTypeCompaction, leaf.Type)
+	assert.Equal(t, response.AssistantEntryID, *leaf.ParentID)
+
+	branch, err := runtime.SessionRepository().Branch(ctx, session.ID, leaf.ID)
+	require.NoError(t, err)
+	assert.Equal(t, database.EntryTypeCompaction, branch[len(branch)-1].Type)
+}
+
+func TestShouldAutoCompactAfterResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		inputTokens   int
+		usableInput   int
+		contextWindow int
+		want          bool
+	}{
+		{name: "below threshold", inputTokens: 79, usableInput: 100, contextWindow: 200, want: false},
+		{name: "at threshold", inputTokens: 80, usableInput: 100, contextWindow: 200, want: true},
+		{name: "above threshold", inputTokens: 99, usableInput: 100, contextWindow: 200, want: true},
+		{name: "unknown context window", inputTokens: 80, usableInput: 100, contextWindow: 0, want: false},
+		{name: "unknown usable input", inputTokens: 80, usableInput: 0, contextWindow: 200, want: false},
+		{name: "empty context", inputTokens: 0, usableInput: 100, contextWindow: 200, want: false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := assistant.ShouldAutoCompactAfterResponseForTest(
+				testCase.inputTokens,
+				testCase.usableInput,
+				testCase.contextWindow,
+			)
+
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}
+
+func assertPostResponseCompactionEvent(t *testing.T, events []assistant.StreamEvent) {
+	t.Helper()
+
+	foundStart := false
+	foundDone := false
+	for _, event := range events {
+		if event.Kind != assistant.StreamEventContextCompaction {
+			continue
+		}
+		foundStart = foundStart || strings.Contains(event.Text, "context auto-compacting after response")
+		foundDone = foundDone || strings.Contains(event.Text, "context auto-compacted after response")
+	}
+	assert.True(t, foundStart, "expected post-response auto-compaction start event")
+	assert.True(t, foundDone, "expected post-response auto-compaction completion event")
+}

--- a/internal/assistant/context_post_response_auto_compaction_test.go
+++ b/internal/assistant/context_post_response_auto_compaction_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestRuntime_AutoCompactsAfterResponseNearThreshold(t *testing.T) {
-	t.Parallel()
+	t.Setenv("HOME", t.TempDir())
 
 	harness := newAutoCompactionRuntimeHarness(t, []string{"final answer", "summary of completed work"}, 16_000)
 	ctx := context.Background()
@@ -25,7 +25,7 @@ func TestRuntime_AutoCompactsAfterResponseNearThreshold(t *testing.T) {
 		session.ID,
 		nil,
 		database.RoleUser,
-		strings.Repeat("old ", 2_600),
+		strings.Repeat("old ", 12_000),
 	)
 	request := newRuntimePromptRequest(testRuntimeCWD, "continue", "")
 	request.SessionID = session.ID

--- a/internal/assistant/export_test.go
+++ b/internal/assistant/export_test.go
@@ -13,3 +13,16 @@ func (runtime *Runtime) DispatchToolCallLifecycleForTest(ctx context.Context, ca
 func (runtime *Runtime) DispatchToolResultLifecycleForTest(ctx context.Context, event *ToolEvent) error {
 	return runtime.dispatchToolResultLifecycle(ctx, event)
 }
+
+// ShouldAutoCompactAfterResponseForTest exposes post-response threshold policy for external package tests.
+func ShouldAutoCompactAfterResponseForTest(usageInput, usableInput, contextWindow int) bool {
+	return shouldAutoCompactAfterResponse(contextBudget{
+		InputTokens:       usageInput,
+		ContextWindow:     contextWindow,
+		UsableInput:       usableInput,
+		OutputReserve:     0,
+		ToolSchemaReserve: 0,
+		ProviderReserve:   0,
+		SafetyMargin:      0,
+	})
+}

--- a/internal/assistant/export_test.go
+++ b/internal/assistant/export_test.go
@@ -55,6 +55,8 @@ func (runtime *Runtime) EmitPostResponseAutoCompactionErrorForTest(
 }
 
 // AutoCompactionMessageForTest exposes compaction notice formatting for external package tests.
+// The contextBudget field values are arbitrary; tests use them only to exercise
+// compactionMessage formatting, not to assert semantic budget calculations.
 func AutoCompactionMessageForTest(entry *database.EntryEntity) string {
 	return compactionMessage("context auto-compacted", contextBudget{
 		InputTokens:       12,

--- a/internal/assistant/export_test.go
+++ b/internal/assistant/export_test.go
@@ -2,6 +2,8 @@ package assistant
 
 import (
 	"context"
+
+	"github.com/omarluq/librecode/internal/database"
 )
 
 // DispatchToolCallLifecycleForTest exposes tool call lifecycle dispatch for external package tests.
@@ -25,4 +27,42 @@ func ShouldAutoCompactAfterResponseForTest(usageInput, usableInput, contextWindo
 		ProviderReserve:   0,
 		SafetyMargin:      0,
 	})
+}
+
+// AutoCompactAfterResponseForTest exposes post-response auto-compaction for external package tests.
+func (runtime *Runtime) AutoCompactAfterResponseForTest(
+	ctx context.Context,
+	onEvent func(StreamEvent),
+	sessionID string,
+	cwd string,
+	parentEntryID string,
+) {
+	runtime.autoCompactAfterResponse(ctx, &postResponseAutoCompactionInput{
+		onEvent:       onEvent,
+		sessionID:     sessionID,
+		cwd:           cwd,
+		parentEntryID: parentEntryID,
+	})
+}
+
+// EmitPostResponseAutoCompactionErrorForTest exposes error event formatting for external package tests.
+func (runtime *Runtime) EmitPostResponseAutoCompactionErrorForTest(
+	ctx context.Context,
+	onEvent func(StreamEvent),
+	err error,
+) {
+	runtime.emitPostResponseAutoCompactionError(ctx, onEvent, err)
+}
+
+// AutoCompactionMessageForTest exposes compaction notice formatting for external package tests.
+func AutoCompactionMessageForTest(entry *database.EntryEntity) string {
+	return compactionMessage("context auto-compacted", contextBudget{
+		InputTokens:       12,
+		ContextWindow:     0,
+		UsableInput:       10,
+		OutputReserve:     0,
+		ToolSchemaReserve: 0,
+		ProviderReserve:   0,
+		SafetyMargin:      0,
+	}, entry)
 }

--- a/internal/assistant/runtime.go
+++ b/internal/assistant/runtime.go
@@ -169,6 +169,7 @@ func (runtime *Runtime) Prompt(ctx context.Context, request *PromptRequest) (res
 		return nil, err
 	}
 
+	compactedBeforeRequest := bundle.ParentEntryID != nil
 	assistantParentID := bundle.ParentEntryID
 	if assistantParentID == nil {
 		assistantParentID = &userEntry.ID
@@ -183,6 +184,14 @@ func (runtime *Runtime) Prompt(ctx context.Context, request *PromptRequest) (res
 	}
 	runtime.dispatchMessageAppend(ctx, assistantEntry)
 	turnLifecycle.dispatchEnd(ctx, assistantEntry.ID, cached, bundle.Usage)
+	if !compactedBeforeRequest {
+		runtime.autoCompactAfterResponse(ctx, &postResponseAutoCompactionInput{
+			onEvent:       request.OnEvent,
+			sessionID:     activeSession.ID,
+			cwd:           request.CWD,
+			parentEntryID: assistantEntry.ID,
+		})
+	}
 
 	return &PromptResponse{
 		SessionID:        activeSession.ID,


### PR DESCRIPTION
Automatically compact sessions after successful assistant turns when estimated context usage reaches the proactive threshold. Emits non-fatal context compaction events and skips duplicate post-response compaction when a request already compacted before sending.

Validation:
- mise exec -- task ci