### PR TITLE
feat(context): use provider usage for compaction

### DIFF
--- a/internal/assistant/context_build.go
+++ b/internal/assistant/context_build.go
@@ -36,19 +36,21 @@ type contextBuildResult struct {
 	SystemPrompt  string
 	Contributions []contextContribution
 	Messages      []database.MessageEntity
+	UsageAnchor   *database.ContextUsageAnchorEntity
 	Usage         model.TokenUsage
 }
 
 type modelContextBase struct {
+	UsageAnchor      *database.ContextUsageAnchorEntity
 	BaseSystemPrompt string
 	SkillPrompt      string
 	SystemPrompt     string
 	ActiveSkills     []core.ActivatedSkill
 	SkillDiagnostics []core.SkillActivationDiagnostic
 	Messages         []database.MessageEntity
+	HistoryTokens    int
 	SystemTokens     int
 	SkillTokens      int
-	HistoryTokens    int
 }
 
 // ContextUsage estimates the current model-facing context without executing a prompt.
@@ -83,11 +85,14 @@ func (runtime *Runtime) ContextUsage(ctx context.Context, sessionID, cwd string)
 	}
 
 	messages := []database.MessageEntity{}
+	var usageAnchor *database.ContextUsageAnchorEntity
 	if strings.TrimSpace(sessionID) != "" {
-		messages, err = runtime.modelContextMessages(ctx, sessionID)
+		contextEntity, err := runtime.modelContextEntity(ctx, sessionID)
 		if err != nil {
 			return model.EmptyTokenUsage(), err
 		}
+		messages = modelFacingMessages(contextEntity.Messages)
+		usageAnchor = remapUsageAnchor(contextEntity.UsageAnchor, contextEntity.Messages, messages)
 	}
 
 	basePrompt := baseSystemPrompt(cwd)
@@ -102,7 +107,7 @@ func (runtime *Runtime) ContextUsage(ctx context.Context, sessionID, cwd string)
 		nil,
 	)
 
-	usage := estimateContextBuildUsage(basePrompt+skillPrompt, messages, nil, &selectedModel, breakdown)
+	usage := estimateContextBuildUsage(basePrompt+skillPrompt, messages, nil, &selectedModel, breakdown, usageAnchor)
 	budget := newContextBudget(usage, &selectedModel, runtime.cfg.Context, request)
 
 	return budget.UsageWithBudget(usage), nil
@@ -116,12 +121,14 @@ func (runtime *Runtime) buildModelContext(
 	selectedModel *model.Model,
 	onEvent func(StreamEvent),
 ) (*contextBuildResult, error) {
-	messages, err := runtime.modelContextMessages(ctx, sessionID)
+	contextEntity, err := runtime.modelContextEntity(ctx, sessionID)
 	if err != nil {
 		return nil, err
 	}
+	messages := modelFacingMessages(contextEntity.Messages)
+	usageAnchor := remapUsageAnchor(contextEntity.UsageAnchor, contextEntity.Messages, messages)
 
-	base, err := runtime.modelContextBase(ctx, cwd, prompt, messages, onEvent)
+	base, err := runtime.modelContextBase(ctx, cwd, prompt, messages, usageAnchor, onEvent)
 	if err != nil {
 		return nil, err
 	}
@@ -152,6 +159,7 @@ func (runtime *Runtime) modelContextBase(
 	cwd string,
 	prompt string,
 	messages []database.MessageEntity,
+	usageAnchor *database.ContextUsageAnchorEntity,
 	onEvent func(StreamEvent),
 ) (modelContextBase, error) {
 	basePrompt := baseSystemPrompt(cwd)
@@ -199,6 +207,7 @@ func (runtime *Runtime) modelContextBase(
 		ActiveSkills:     activeSkills,
 		SkillDiagnostics: skillActivation.Matches,
 		Messages:         messages,
+		UsageAnchor:      usageAnchor,
 		SystemPrompt:     basePrompt + availableSkillsPrompt + activeSkillsPrompt,
 		BaseSystemPrompt: basePrompt,
 		SkillPrompt:      availableSkillsPrompt + activeSkillsPrompt,
@@ -216,12 +225,14 @@ func initialContextBuildResult(base *modelContextBase, selectedModel *model.Mode
 		Messages:      base.Messages,
 		Breakdown:     breakdown,
 		SystemPrompt:  base.SystemPrompt,
+		UsageAnchor:   base.UsageAnchor,
 		Usage: estimateContextBuildUsage(
 			base.SystemPrompt,
 			base.Messages,
 			nil,
 			selectedModel,
 			breakdown,
+			base.UsageAnchor,
 		),
 	}
 }
@@ -237,12 +248,14 @@ func recalculateContextBuildResult(
 		base.HistoryTokens,
 		result.Contributions,
 	)
+	result.UsageAnchor = base.UsageAnchor
 	result.Usage = estimateContextBuildUsage(
 		result.SystemPrompt,
 		base.Messages,
 		result.Contributions,
 		selectedModel,
 		result.Breakdown,
+		base.UsageAnchor,
 	)
 }
 
@@ -252,11 +265,9 @@ func estimateContextBuildUsage(
 	contributions []contextContribution,
 	selectedModel *model.Model,
 	breakdown map[string]int,
+	usageAnchor *database.ContextUsageAnchorEntity,
 ) model.TokenUsage {
-	inputTokens := estimateInputTokens(systemPrompt, messages)
-	for index := range contributions {
-		inputTokens += contributions[index].Tokens
-	}
+	inputTokens := estimateUsageLedInputTokens(systemPrompt, messages, contributions, usageAnchor)
 
 	return model.TokenUsage{
 		Breakdown:       cloneIntMapForUsage(breakdown),

--- a/internal/assistant/context_compaction.go
+++ b/internal/assistant/context_compaction.go
@@ -179,6 +179,7 @@ type compactionPlan struct {
 	FirstKeptEntryID   string
 	Messages           []database.MessageEntity
 	PreviousSummary    string
+	SplitTurnSummary   string
 	SummarizedEntryIDs []string
 	KeptEntryIDs       []string
 	TokensBefore       int
@@ -203,21 +204,8 @@ func planCompaction(branch []database.EntryEntity, keepRecentTokens int) (compac
 		)
 	}
 
-	summarizeEnd := cutPoint.firstKeptEntryIndex
-	if cutPoint.isSplitTurn {
-		summarizeEnd = cutPoint.turnStartIndex
-	}
-	messages, summarizedIDs := compactionMessagesInRange(branch, boundaryStart, summarizeEnd)
-	if cutPoint.isSplitTurn {
-		turnPrefixMessages, turnPrefixIDs := compactionMessagesInRange(
-			branch,
-			cutPoint.turnStartIndex,
-			cutPoint.firstKeptEntryIndex,
-		)
-		messages = append(messages, turnPrefixMessages...)
-		summarizedIDs = append(summarizedIDs, turnPrefixIDs...)
-	}
-	if len(messages) == 0 {
+	messages, summarizedIDs, splitTurnSummary := compactionSummaryPayload(branch, boundaryStart, cutPoint)
+	if len(messages) == 0 && strings.TrimSpace(splitTurnSummary) == "" {
 		return compactionPlan{}, compactNothingToDoError("no model-facing history was selected for compaction")
 	}
 
@@ -227,11 +215,39 @@ func planCompaction(branch []database.EntryEntity, keepRecentTokens int) (compac
 	return compactionPlan{
 		Messages:           messages,
 		PreviousSummary:    previousSummary,
+		SplitTurnSummary:   splitTurnSummary,
 		SummarizedEntryIDs: summarizedIDs,
 		KeptEntryIDs:       keptIDs,
 		FirstKeptEntryID:   firstKeptEntryID,
 		TokensBefore:       effectiveBranchTokens(branch),
 	}, nil
+}
+
+func compactionSummaryPayload(
+	branch []database.EntryEntity,
+	boundaryStart int,
+	cutPoint compactionCutPoint,
+) (messages []database.MessageEntity, summarizedIDs []string, splitTurnSummary string) {
+	summarizeEnd := cutPoint.firstKeptEntryIndex
+	if cutPoint.isSplitTurn {
+		summarizeEnd = cutPoint.turnStartIndex
+	}
+	messages, summarizedIDs = compactionMessagesInRange(branch, boundaryStart, summarizeEnd)
+	if !cutPoint.isSplitTurn {
+		return messages, summarizedIDs, ""
+	}
+
+	turnPrefixMessages, turnPrefixIDs := compactionMessagesInRange(
+		branch,
+		cutPoint.turnStartIndex,
+		cutPoint.firstKeptEntryIndex,
+	)
+	summarizedIDs = append(summarizedIDs, turnPrefixIDs...)
+	if len(messages) == 0 {
+		return append(messages, turnPrefixMessages...), summarizedIDs, ""
+	}
+
+	return messages, summarizedIDs, formatSplitTurnSummary(turnPrefixMessages)
 }
 
 func compactNothingToDoError(message string) error {
@@ -374,6 +390,29 @@ func compactionMessagesInRange(
 	return messages, entryIDs
 }
 
+func formatSplitTurnSummary(messages []database.MessageEntity) string {
+	if len(messages) == 0 {
+		return ""
+	}
+	builder := strings.Builder{}
+	builder.WriteString("The compaction boundary split an in-progress turn. ")
+	builder.WriteString("The following earlier messages from that turn were compacted:\n")
+	for index := range messages {
+		message := messages[index]
+		content := strings.TrimSpace(message.Content)
+		if content == "" {
+			continue
+		}
+		builder.WriteString("\n[")
+		builder.WriteString(string(message.Role))
+		builder.WriteString("]\n")
+		builder.WriteString(content)
+		builder.WriteString("\n")
+	}
+
+	return strings.TrimSpace(builder.String())
+}
+
 func keptCompactionEntryIDs(entries []database.EntryEntity) []string {
 	entryIDs := make([]string, 0, len(entries))
 	for index := range entries {
@@ -496,7 +535,7 @@ func (runtime *Runtime) summarizeCompaction(
 	auth model.RequestAuth,
 	plan *compactionPlan,
 ) (string, error) {
-	systemPrompt := compactionSystemPrompt(plan.PreviousSummary)
+	systemPrompt := compactionSystemPromptWithSplit(plan.PreviousSummary, plan.SplitTurnSummary)
 	request := &CompletionRequest{
 		OnEvent:           nil,
 		OnProviderObserve: runtime.emitProviderRequest,
@@ -528,11 +567,31 @@ func (runtime *Runtime) summarizeCompaction(
 }
 
 func compactionSystemPrompt(previousSummary string) string {
+	return compactionSystemPromptWithSplit(previousSummary, "")
+}
+
+func compactionSystemPromptWithSplit(previousSummary, splitTurnSummary string) string {
+	prompt := compactionBaseSystemPrompt(previousSummary)
+	if strings.TrimSpace(splitTurnSummary) == "" {
+		return prompt
+	}
+
+	return prompt + "\n\n" + splitTurnPromptSection(splitTurnSummary)
+}
+
+func compactionBaseSystemPrompt(previousSummary string) string {
 	if strings.TrimSpace(previousSummary) == "" {
 		return compactionSummaryPrompt
 	}
 
 	return fmt.Sprintf(compactionUpdatePrompt, previousSummary)
+}
+
+func splitTurnPromptSection(splitTurnSummary string) string {
+	return strings.TrimSpace(`Additional split-turn context:
+<split_turn_summary>
+` + strings.TrimSpace(splitTurnSummary) + `
+</split_turn_summary>`)
 }
 
 func compactionRequestUsage(

--- a/internal/assistant/context_compaction_internal_test.go
+++ b/internal/assistant/context_compaction_internal_test.go
@@ -44,6 +44,7 @@ func planCompactionCases() []planCompactionCase {
 	return []planCompactionCase{
 		previousKeptBoundaryCase(),
 		turnBoundaryCase(),
+		splitTurnSummaryCase(),
 		defaultKeepRecentTokensCase(),
 		latestCompactionCase(),
 	}
@@ -79,9 +80,9 @@ func assertPreviousKeptBoundaryPlan(t *testing.T, plan *compactionPlan) {
 	assert.Equal(t, []string{"old-assistant", "recent-user"}, plan.SummarizedEntryIDs)
 	assert.Equal(t, []string{"recent-assistant"}, plan.KeptEntryIDs)
 	assert.Equal(t, "recent-assistant", plan.FirstKeptEntryID)
-	require.Len(t, plan.Messages, 2)
+	require.Len(t, plan.Messages, 1)
 	assert.Equal(t, "old assistant history", plan.Messages[0].Content)
-	assert.Equal(t, "recent user tail", plan.Messages[1].Content)
+	assert.Contains(t, plan.SplitTurnSummary, "recent user tail")
 }
 
 func turnBoundaryCase() planCompactionCase {
@@ -105,6 +106,33 @@ func assertTurnBoundaryPlan(t *testing.T, plan *compactionPlan) {
 	assert.Equal(t, []string{"user-1", "assistant-1"}, plan.SummarizedEntryIDs)
 	assert.Equal(t, []string{"user-2", "assistant-2"}, plan.KeptEntryIDs)
 	assert.Equal(t, "user-2", plan.FirstKeptEntryID)
+}
+
+func splitTurnSummaryCase() planCompactionCase {
+	return planCompactionCase{
+		assertFn: assertSplitTurnSummaryPlan,
+		entries: []database.EntryEntity{
+			compactMessageEntry("user-1", database.RoleUser, strings.Repeat("old ", 10)),
+			compactMessageEntry("assistant-1", database.RoleAssistant, strings.Repeat("old ", 10)),
+			compactMessageEntry("user-2", database.RoleUser, "split user context"),
+			compactMessageEntry("assistant-2", database.RoleAssistant, strings.Repeat("large tail ", 100)),
+		},
+		name:    "records split turn summary separately",
+		wantErr: "",
+		keep:    40,
+	}
+}
+
+func assertSplitTurnSummaryPlan(t *testing.T, plan *compactionPlan) {
+	t.Helper()
+
+	assert.Equal(t, []string{"user-1", "assistant-1", "user-2"}, plan.SummarizedEntryIDs)
+	assert.Equal(t, []string{"assistant-2"}, plan.KeptEntryIDs)
+	assert.Equal(t, "assistant-2", plan.FirstKeptEntryID)
+	assert.Contains(t, plan.SplitTurnSummary, "split user context")
+	for index := range plan.Messages {
+		assert.NotContains(t, plan.Messages[index].Content, "split user context")
+	}
 }
 
 func defaultKeepRecentTokensCase() planCompactionCase {
@@ -161,6 +189,15 @@ func TestCompactionSystemPromptIncludesPreviousSummary(t *testing.T) {
 
 	assert.Contains(t, prompt, "Update the existing compaction summary")
 	assert.Contains(t, prompt, "previous compacted facts")
+}
+
+func TestCompactionSystemPromptIncludesSplitTurnSummary(t *testing.T) {
+	t.Parallel()
+
+	prompt := compactionSystemPromptWithSplit("", "split facts")
+
+	assert.Contains(t, prompt, "<split_turn_summary>")
+	assert.Contains(t, prompt, "split facts")
 }
 
 func compactMessageEntry(entryID string, role database.Role, content string) database.EntryEntity {

--- a/internal/assistant/context_compaction_internal_test.go
+++ b/internal/assistant/context_compaction_internal_test.go
@@ -11,12 +11,11 @@ import (
 	"github.com/omarluq/librecode/internal/database"
 )
 
-//nolint:govet // Test fixture readability matters more than field packing.
 type planCompactionCase struct {
-	entries  []database.EntryEntity
 	assertFn func(t *testing.T, plan *compactionPlan)
 	name     string
 	wantErr  string
+	entries  []database.EntryEntity
 	keep     int
 }
 

--- a/internal/assistant/context_usage_led.go
+++ b/internal/assistant/context_usage_led.go
@@ -1,0 +1,57 @@
+// Package assistant orchestrates conversations, extensions, cache, and prompt execution.
+package assistant
+
+import (
+	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/model"
+)
+
+func estimateUsageLedInputTokens(
+	systemPrompt string,
+	messages []database.MessageEntity,
+	contributions []contextContribution,
+	usageAnchor *database.ContextUsageAnchorEntity,
+) int {
+	if usageAnchor != nil && usageAnchor.Usage.InputTokens > 0 && usageAnchor.MessageIndex >= 0 &&
+		usageAnchor.MessageIndex < len(messages) {
+		trailingTokens := estimateTrailingInputTokens(messages, contributions, usageAnchor.MessageIndex+1)
+
+		return usageAnchor.Usage.InputTokens + trailingTokens
+	}
+
+	inputTokens := estimateInputTokens(systemPrompt, messages)
+	for index := range contributions {
+		inputTokens += contributions[index].Tokens
+	}
+
+	return inputTokens
+}
+
+func estimateTrailingInputTokens(
+	messages []database.MessageEntity,
+	contributions []contextContribution,
+	startIndex int,
+) int {
+	trailingTokens := 0
+	for index := startIndex; index < len(messages); index++ {
+		trailingTokens += estimateTokens(messages[index].Content)
+	}
+	for index := range contributions {
+		trailingTokens += contributions[index].Tokens
+	}
+
+	return trailingTokens
+}
+
+func providerUsageEntity(usage model.TokenUsage) *database.EntryTokenUsageEntity {
+	if usage.InputTokens <= 0 && usage.ContextTokens <= 0 && usage.ContextWindow <= 0 && usage.OutputTokens <= 0 {
+		return nil
+	}
+
+	return &database.EntryTokenUsageEntity{
+		ContextWindow: usage.ContextWindow,
+		ContextTokens: usage.ContextTokens,
+		InputTokens:   usage.InputTokens,
+		OutputTokens:  usage.OutputTokens,
+	}
+}

--- a/internal/assistant/context_usage_led_internal_test.go
+++ b/internal/assistant/context_usage_led_internal_test.go
@@ -1,0 +1,102 @@
+// Package assistant orchestrates conversations, extensions, cache, and prompt execution.
+package assistant
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/model"
+)
+
+func TestEstimateUsageLedInputTokensUsesProviderAnchorAndTrailingEstimate(t *testing.T) {
+	t.Parallel()
+
+	messages := []database.MessageEntity{
+		newUsageLedTestMessage(database.RoleUser, repeatedTokenText(100)),
+		newUsageLedTestMessage(database.RoleAssistant, repeatedTokenText(100)),
+		newUsageLedTestMessage(database.RoleUser, repeatedTokenText(40)),
+	}
+	anchor := &database.ContextUsageAnchorEntity{
+		EntryID:  "assistant-entry",
+		Provider: "",
+		Model:    "",
+		Usage: database.EntryTokenUsageEntity{
+			ContextWindow: 0,
+			ContextTokens: 0,
+			InputTokens:   500,
+			OutputTokens:  0,
+		},
+		MessageIndex: 1,
+	}
+
+	tokens := estimateUsageLedInputTokens(
+		"large system prompt that should be covered by provider usage",
+		messages,
+		nil,
+		anchor,
+	)
+
+	assert.Equal(t, 540, tokens)
+}
+
+func TestEstimateUsageLedInputTokensFallsBackWhenAnchorMissing(t *testing.T) {
+	t.Parallel()
+
+	messages := []database.MessageEntity{newUsageLedTestMessage(database.RoleUser, repeatedTokenText(20))}
+	contributions := []contextContribution{{
+		Metadata: nil,
+		Source:   "",
+		Name:     "",
+		Role:     "",
+		Content:  "",
+		Tokens:   7,
+	}}
+
+	tokens := estimateUsageLedInputTokens(repeatedTokenText(12), messages, contributions, nil)
+
+	assert.Equal(t, 39, tokens)
+}
+
+func TestProviderUsageEntitySkipsEmptyUsage(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, providerUsageEntity(model.EmptyTokenUsage()))
+
+	entity := providerUsageEntity(model.TokenUsage{
+		Breakdown:       nil,
+		TopContributors: nil,
+		ContextWindow:   1000,
+		ContextTokens:   50,
+		InputTokens:     42,
+		OutputTokens:    8,
+	})
+
+	require.NotNil(t, entity)
+	assert.Equal(t, 1000, entity.ContextWindow)
+	assert.Equal(t, 50, entity.ContextTokens)
+	assert.Equal(t, 42, entity.InputTokens)
+	assert.Equal(t, 8, entity.OutputTokens)
+}
+
+func newUsageLedTestMessage(role database.Role, content string) database.MessageEntity {
+	return database.MessageEntity{
+		Timestamp: time.Time{},
+		Role:      role,
+		Content:   content,
+		Provider:  "",
+		Model:     "",
+	}
+}
+
+func repeatedTokenText(tokens int) string {
+	text := make([]byte, tokens*4)
+	for index := range text {
+		text[index] = 'x'
+	}
+
+	return string(text)
+}

--- a/internal/assistant/runtime_context.go
+++ b/internal/assistant/runtime_context.go
@@ -12,7 +12,10 @@ import (
 	"github.com/omarluq/librecode/internal/database"
 )
 
-func (runtime *Runtime) modelContextMessages(ctx context.Context, sessionID string) ([]database.MessageEntity, error) {
+func (runtime *Runtime) modelContextEntity(
+	ctx context.Context,
+	sessionID string,
+) (*database.SessionContextEntity, error) {
 	leafEntry, _, err := runtime.sessions.LeafEntry(ctx, sessionID)
 	if err != nil {
 		return nil, oops.In("assistant").Code("load_context_leaf").Wrapf(err, "load session leaf")
@@ -26,7 +29,7 @@ func (runtime *Runtime) modelContextMessages(ctx context.Context, sessionID stri
 		return nil, oops.In("assistant").Code("load_context").Wrapf(err, "load session context")
 	}
 
-	return modelFacingMessages(contextEntity.Messages), nil
+	return contextEntity, nil
 }
 
 func modelFacingMessages(messages []database.MessageEntity) []database.MessageEntity {
@@ -40,6 +43,34 @@ func modelFacingMessages(messages []database.MessageEntity) []database.MessageEn
 	}
 
 	return filtered
+}
+
+func remapUsageAnchor(
+	anchor *database.ContextUsageAnchorEntity,
+	originalMessages []database.MessageEntity,
+	modelMessages []database.MessageEntity,
+) *database.ContextUsageAnchorEntity {
+	if anchor == nil || anchor.MessageIndex < 0 || anchor.MessageIndex >= len(originalMessages) {
+		return nil
+	}
+	anchorMessage := originalMessages[anchor.MessageIndex]
+	modelIndex := -1
+	for originalIndex := range originalMessages[:anchor.MessageIndex+1] {
+		message := originalMessages[originalIndex]
+		if isModelFacingRole(message.Role) && strings.TrimSpace(message.Content) != "" {
+			modelIndex++
+		}
+	}
+	if modelIndex < 0 || modelIndex >= len(modelMessages) {
+		return nil
+	}
+	if modelMessages[modelIndex].Timestamp != anchorMessage.Timestamp {
+		return nil
+	}
+	remapped := *anchor
+	remapped.MessageIndex = modelIndex
+
+	return &remapped
 }
 
 func modelFacingMessage(message *database.MessageEntity) database.MessageEntity {

--- a/internal/assistant/runtime_entries.go
+++ b/internal/assistant/runtime_entries.go
@@ -40,5 +40,12 @@ func (runtime *Runtime) appendAssistantResponseEntry(
 		Model:     runtime.cfg.Assistant.Model,
 	}
 
-	return runtime.sessions.AppendMessageWithModelFacing(ctx, sessionID, parentID, &message, &bundle.ModelFacing)
+	return runtime.sessions.AppendMessageWithMetadata(
+		ctx,
+		sessionID,
+		parentID,
+		&message,
+		&bundle.ModelFacing,
+		providerUsageEntity(bundle.Usage),
+	)
 }

--- a/internal/database/entity.go
+++ b/internal/database/entity.go
@@ -104,24 +104,25 @@ type EntryEntity struct {
 
 // EntryDataEntity stores flexible per-entry metadata encoded in session_entries.data_json.
 type EntryDataEntity struct {
-	Details                    map[string]any `json:"details,omitempty"`
-	Display                    *bool          `json:"display,omitempty"`
-	Label                      *string        `json:"label,omitempty"`
-	ModelFacing                *bool          `json:"modelFacing,omitempty"`
-	FromID                     string         `json:"fromId,omitempty"`
-	BranchFromEntryID          string         `json:"branchFromEntryId,omitempty"`
-	TargetID                   string         `json:"targetId,omitempty"`
-	ThinkingLevel              string         `json:"thinkingLevel,omitempty"`
-	ToolName                   string         `json:"toolName,omitempty"`
-	ToolStatus                 string         `json:"toolStatus,omitempty"`
-	ToolArgsJSON               string         `json:"toolArgsJson,omitempty"`
-	Name                       string         `json:"name,omitempty"`
-	FirstKeptEntryID           string         `json:"firstKeptEntryId,omitempty"`
-	CompactionFirstKeptEntryID string         `json:"compactionFirstKeptEntryId,omitempty"`
-	TokenEstimate              int            `json:"tokenEstimate,omitempty"`
-	CompactionTokensBefore     int            `json:"compactionTokensBefore,omitempty"`
-	TokensBefore               int            `json:"tokensBefore,omitempty"`
-	FromHook                   bool           `json:"fromHook,omitempty"`
+	Details                    map[string]any         `json:"details,omitempty"`
+	Display                    *bool                  `json:"display,omitempty"`
+	Label                      *string                `json:"label,omitempty"`
+	ModelFacing                *bool                  `json:"modelFacing,omitempty"`
+	Usage                      *EntryTokenUsageEntity `json:"usage,omitempty"`
+	FromID                     string                 `json:"fromId,omitempty"`
+	BranchFromEntryID          string                 `json:"branchFromEntryId,omitempty"`
+	TargetID                   string                 `json:"targetId,omitempty"`
+	ThinkingLevel              string                 `json:"thinkingLevel,omitempty"`
+	ToolName                   string                 `json:"toolName,omitempty"`
+	ToolStatus                 string                 `json:"toolStatus,omitempty"`
+	ToolArgsJSON               string                 `json:"toolArgsJson,omitempty"`
+	Name                       string                 `json:"name,omitempty"`
+	FirstKeptEntryID           string                 `json:"firstKeptEntryId,omitempty"`
+	CompactionFirstKeptEntryID string                 `json:"compactionFirstKeptEntryId,omitempty"`
+	TokenEstimate              int                    `json:"tokenEstimate,omitempty"`
+	CompactionTokensBefore     int                    `json:"compactionTokensBefore,omitempty"`
+	TokensBefore               int                    `json:"tokensBefore,omitempty"`
+	FromHook                   bool                   `json:"fromHook,omitempty"`
 }
 
 // TreeNodeEntity is an entry and its direct descendants.
@@ -130,12 +131,35 @@ type TreeNodeEntity struct {
 	Entry    EntryEntity      `json:"entry"`
 }
 
+// EntryTokenUsageEntity stores provider-reported token usage on a durable entry.
+type EntryTokenUsageEntity struct {
+	ContextWindow int `json:"contextWindow,omitempty"`
+	ContextTokens int `json:"contextTokens,omitempty"`
+	InputTokens   int `json:"inputTokens,omitempty"`
+	OutputTokens  int `json:"outputTokens,omitempty"`
+}
+
+// HasAny reports whether the usage entity has any provider-reported values.
+func (usage EntryTokenUsageEntity) HasAny() bool {
+	return usage.ContextWindow > 0 || usage.ContextTokens > 0 || usage.InputTokens > 0 || usage.OutputTokens > 0
+}
+
+// ContextUsageAnchorEntity identifies the latest model response with known provider usage.
+type ContextUsageAnchorEntity struct {
+	EntryID      string                `json:"entry_id"`
+	Provider     string                `json:"provider,omitempty"`
+	Model        string                `json:"model,omitempty"`
+	Usage        EntryTokenUsageEntity `json:"usage"`
+	MessageIndex int                   `json:"message_index"`
+}
+
 // SessionContextEntity is the reconstructed context from a session branch.
 type SessionContextEntity struct {
-	Provider      string          `json:"provider,omitempty"`
-	Model         string          `json:"model,omitempty"`
-	ThinkingLevel string          `json:"thinking_level,omitempty"`
-	Messages      []MessageEntity `json:"messages"`
+	UsageAnchor   *ContextUsageAnchorEntity `json:"usage_anchor,omitempty"`
+	Provider      string                    `json:"provider,omitempty"`
+	Model         string                    `json:"model,omitempty"`
+	ThinkingLevel string                    `json:"thinking_level,omitempty"`
+	Messages      []MessageEntity           `json:"messages"`
 }
 
 // DocumentEntity stores JSON-backed runtime documents in SQLite.

--- a/internal/database/session_store.go
+++ b/internal/database/session_store.go
@@ -573,19 +573,26 @@ var entryContextAppliers = map[EntryType]entryContextApplier{
 func appendModelFacingEntryMessage(contextEntity *SessionContextEntity, entry *EntryEntity) error {
 	if entry.ModelFacing {
 		contextEntity.Messages = append(contextEntity.Messages, entry.Message)
-		updateContextUsageAnchor(contextEntity, entry, len(contextEntity.Messages)-1)
+		if err := updateContextUsageAnchor(contextEntity, entry, len(contextEntity.Messages)-1); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func updateContextUsageAnchor(contextEntity *SessionContextEntity, entry *EntryEntity, messageIndex int) {
+func updateContextUsageAnchor(contextEntity *SessionContextEntity, entry *EntryEntity, messageIndex int) error {
 	if entry.Type != EntryTypeMessage || entry.Message.Role != RoleAssistant {
-		return
+		return nil
 	}
 	data, err := dataFromEntry(entry)
-	if err != nil || data.Usage == nil || !data.Usage.HasAny() {
-		return
+	if err != nil {
+		return oops.In("database").
+			Code("decode_entry_usage").
+			Wrapf(err, "decode assistant entry usage")
+	}
+	if data.Usage == nil || !data.Usage.HasAny() {
+		return nil
 	}
 	contextEntity.UsageAnchor = &ContextUsageAnchorEntity{
 		EntryID:      entry.ID,
@@ -594,6 +601,8 @@ func updateContextUsageAnchor(contextEntity *SessionContextEntity, entry *EntryE
 		Model:        entry.Message.Model,
 		Usage:        *data.Usage,
 	}
+
+	return nil
 }
 
 func appendBranchSummaryContext(contextEntity *SessionContextEntity, entry *EntryEntity) error {

--- a/internal/database/session_store.go
+++ b/internal/database/session_store.go
@@ -674,9 +674,9 @@ func appendRetainedCompactionTailEntry(contextEntity *SessionContextEntity, entr
 		EntryTypeLabel,
 		EntryTypeSessionInfo:
 		return nil
+	default:
+		return nil
 	}
-
-	return nil
 }
 
 func applyModelChangeContext(contextEntity *SessionContextEntity, entry *EntryEntity) error {

--- a/internal/database/session_store.go
+++ b/internal/database/session_store.go
@@ -615,7 +615,7 @@ func applyCompactionContextWithTail(
 ) error {
 	compactionEntry := &branch[compactionIndex]
 	contextEntity.Messages = compactionSummaryMessages(compactionEntry)
-	contextEntity.UsageAnchor = nil
+	clearCompactedUsageAnchor(contextEntity)
 
 	firstKeptIndex := compactionIndex
 	for index := range compactionIndex {
@@ -631,6 +631,12 @@ func applyCompactionContextWithTail(
 	}
 
 	return nil
+}
+
+func clearCompactedUsageAnchor(contextEntity *SessionContextEntity) {
+	// Provider usage anchors describe the pre-compaction prompt shape. After a
+	// compaction entry rewrites context to summary + tail, that usage is stale.
+	contextEntity.UsageAnchor = nil
 }
 
 func compactionSummaryMessages(entry *EntryEntity) []MessageEntity {

--- a/internal/database/session_store.go
+++ b/internal/database/session_store.go
@@ -142,6 +142,7 @@ func (repository *SessionRepository) BuildContext(
 	}
 
 	contextEntity := SessionContextEntity{
+		UsageAnchor:   nil,
 		Messages:      []MessageEntity{},
 		Provider:      "",
 		Model:         "",
@@ -194,6 +195,7 @@ func newEntryData() EntryDataEntity {
 type appendEntryOptions struct {
 	modelFacing *bool
 	timestamp   time.Time
+	usage       *EntryTokenUsageEntity
 	content     string
 	customType  string
 	dataJSON    string
@@ -215,6 +217,23 @@ func (repository *SessionRepository) appendBuiltEntry(
 	entryType EntryType,
 	options *appendEntryOptions,
 ) (*EntryEntity, error) {
+	entry := repository.entryFromAppendOptions(sessionID, parentID, entryType, options)
+	if err := applyAppendEntryMetadata(&entry, options); err != nil {
+		return nil, err
+	}
+	if err := repository.appendEntry(ctx, &entry); err != nil {
+		return nil, err
+	}
+
+	return &entry, nil
+}
+
+func (repository *SessionRepository) entryFromAppendOptions(
+	sessionID string,
+	parentID *string,
+	entryType EntryType,
+	options *appendEntryOptions,
+) EntryEntity {
 	timestamp := options.timestamp
 	if timestamp.IsZero() {
 		timestamp = repository.now().UTC()
@@ -228,37 +247,40 @@ func (repository *SessionRepository) appendBuiltEntry(
 		Provider:  options.provider,
 		Model:     options.model,
 	})
-	if options.customType != "" {
-		entry.CustomType = options.customType
-	}
+	entry.CustomType = options.customType
 	if options.dataJSON != "" {
 		entry.DataJSON = normalizeDataJSON(options.dataJSON)
 	}
+	entry.Summary = options.summary
+
+	return entry
+}
+
+func applyAppendEntryMetadata(entry *EntryEntity, options *appendEntryOptions) error {
+	if options.modelFacing == nil && options.usage == nil {
+		return nil
+	}
+	data, err := dataFromEntry(entry)
+	if err != nil {
+		return oops.In("database").
+			Code("decode_entry_data").
+			Wrapf(err, "decode entry data before setting metadata")
+	}
 	if options.modelFacing != nil {
-		data, err := dataFromEntry(&entry)
-		if err != nil {
-			return nil, oops.In("database").
-				Code("decode_entry_data").
-				Wrapf(err, "decode entry data before setting model-facing metadata")
-		}
 		data.ModelFacing = options.modelFacing
-		dataJSON, err := dataJSONFromEntity(&data)
-		if err != nil {
-			return nil, oops.In("database").
-				Code("encode_entry_data").
-				Wrapf(err, "encode entry data after setting model-facing metadata")
-		}
-		entry.DataJSON = normalizeDataJSON(dataJSON)
 	}
-	if options.summary != "" {
-		entry.Summary = options.summary
+	if options.usage != nil {
+		data.Usage = options.usage
 	}
+	dataJSON, err := dataJSONFromEntity(&data)
+	if err != nil {
+		return oops.In("database").
+			Code("encode_entry_data").
+			Wrapf(err, "encode entry data after setting metadata")
+	}
+	entry.DataJSON = normalizeDataJSON(dataJSON)
 
-	if err := repository.appendEntry(ctx, &entry); err != nil {
-		return nil, err
-	}
-
-	return &entry, nil
+	return nil
 }
 
 // AppendMessage appends a message as a child of the current leaf or provided parent.
@@ -279,6 +301,18 @@ func (repository *SessionRepository) AppendMessageWithModelFacing(
 	message *MessageEntity,
 	modelFacing *bool,
 ) (*EntryEntity, error) {
+	return repository.AppendMessageWithMetadata(ctx, sessionID, parentID, message, modelFacing, nil)
+}
+
+// AppendMessageWithMetadata appends a message with optional model-facing and token usage metadata.
+func (repository *SessionRepository) AppendMessageWithMetadata(
+	ctx context.Context,
+	sessionID string,
+	parentID *string,
+	message *MessageEntity,
+	modelFacing *bool,
+	usage *EntryTokenUsageEntity,
+) (*EntryEntity, error) {
 	options := newAppendEntryOptions()
 	options.content = message.Content
 	options.model = message.Model
@@ -286,6 +320,7 @@ func (repository *SessionRepository) AppendMessageWithModelFacing(
 	options.role = message.Role
 	options.timestamp = message.Timestamp
 	options.modelFacing = modelFacing
+	options.usage = usage
 
 	return repository.appendBuiltEntry(ctx, sessionID, parentID, EntryTypeMessage, options)
 }
@@ -538,9 +573,27 @@ var entryContextAppliers = map[EntryType]entryContextApplier{
 func appendModelFacingEntryMessage(contextEntity *SessionContextEntity, entry *EntryEntity) error {
 	if entry.ModelFacing {
 		contextEntity.Messages = append(contextEntity.Messages, entry.Message)
+		updateContextUsageAnchor(contextEntity, entry, len(contextEntity.Messages)-1)
 	}
 
 	return nil
+}
+
+func updateContextUsageAnchor(contextEntity *SessionContextEntity, entry *EntryEntity, messageIndex int) {
+	if entry.Type != EntryTypeMessage || entry.Message.Role != RoleAssistant {
+		return
+	}
+	data, err := dataFromEntry(entry)
+	if err != nil || data.Usage == nil || !data.Usage.HasAny() {
+		return
+	}
+	contextEntity.UsageAnchor = &ContextUsageAnchorEntity{
+		EntryID:      entry.ID,
+		MessageIndex: messageIndex,
+		Provider:     entry.Message.Provider,
+		Model:        entry.Message.Model,
+		Usage:        *data.Usage,
+	}
 }
 
 func appendBranchSummaryContext(contextEntity *SessionContextEntity, entry *EntryEntity) error {
@@ -562,6 +615,7 @@ func applyCompactionContextWithTail(
 ) error {
 	compactionEntry := &branch[compactionIndex]
 	contextEntity.Messages = compactionSummaryMessages(compactionEntry)
+	contextEntity.UsageAnchor = nil
 
 	firstKeptIndex := compactionIndex
 	for index := range compactionIndex {
@@ -591,8 +645,13 @@ func compactionSummaryMessages(entry *EntryEntity) []MessageEntity {
 
 func appendRetainedCompactionTailEntry(contextEntity *SessionContextEntity, entry *EntryEntity) error {
 	switch entry.Type {
-	case EntryTypeMessage, EntryTypeCustomMessage, EntryTypeBranchSummary:
-		return applyEntryToContext(contextEntity, entry)
+	case EntryTypeMessage, EntryTypeCustomMessage:
+		if entry.ModelFacing {
+			contextEntity.Messages = append(contextEntity.Messages, entry.Message)
+		}
+		return nil
+	case EntryTypeBranchSummary:
+		return appendBranchSummaryContext(contextEntity, entry)
 	case EntryTypeCompaction,
 		EntryTypeModelChange,
 		EntryTypeThinkingLevelChange,

--- a/internal/database/session_usage_internal_test.go
+++ b/internal/database/session_usage_internal_test.go
@@ -1,0 +1,61 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/samber/oops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite" // register SQLite driver for sql.Open in this test
+)
+
+func newTestSessionRepositoryForUsage(t *testing.T) *SessionRepository {
+	t.Helper()
+
+	connection, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, connection.Close())
+	})
+	connection.SetMaxOpenConns(1)
+
+	require.NoError(t, Migrate(context.Background(), connection))
+
+	return NewSessionRepository(connection)
+}
+
+func TestBuildContextReturnsAssistantUsageDecodeError(t *testing.T) {
+	t.Parallel()
+
+	repository := newTestSessionRepositoryForUsage(t)
+	ctx := context.Background()
+	session, err := repository.CreateSession(ctx, "/work", "usage", "")
+	require.NoError(t, err)
+
+	entry := newEntryEntity(session.ID, nil, EntryTypeMessage, &MessageEntity{
+		Timestamp: time.Now().UTC(),
+		Role:      RoleAssistant,
+		Content:   "answer",
+		Provider:  "openai",
+		Model:     "gpt",
+	})
+	entry.ModelFacing = true
+	require.NoError(t, repository.appendEntry(ctx, &entry))
+	_, err = repository.connection.ExecContext(
+		ctx,
+		`UPDATE session_entries SET data_json = ? WHERE id = ?`,
+		`{"usage":`,
+		entry.ID,
+	)
+	require.NoError(t, err)
+
+	_, err = repository.BuildContext(ctx, session.ID, entry.ID)
+	require.Error(t, err)
+	var oopsError oops.OopsError
+	require.ErrorAs(t, err, &oopsError)
+	assert.Equal(t, "decode_entry_usage", oopsError.Code())
+	assert.Contains(t, err.Error(), "decode assistant entry usage")
+}

--- a/internal/database/session_usage_test.go
+++ b/internal/database/session_usage_test.go
@@ -1,0 +1,110 @@
+package database_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/database"
+)
+
+const (
+	testUsagePrompt = "hello usage"
+	testUsageReply  = "answer"
+)
+
+func TestBuildContextTracksLatestProviderUsageAnchor(t *testing.T) {
+	t.Parallel()
+
+	repository := newTestSessionRepository(t)
+	ctx := context.Background()
+	session, err := repository.CreateSession(ctx, "/work", "usage", "")
+	require.NoError(t, err)
+
+	userEntry, err := repository.AppendMessage(ctx, session.ID, nil, newUsageTestMessage(
+		database.RoleUser,
+		testUsagePrompt,
+		"",
+		"",
+	))
+	require.NoError(t, err)
+	modelFacing := true
+	assistantUsage := &database.EntryTokenUsageEntity{
+		ContextWindow: 1000,
+		ContextTokens: 42,
+		InputTokens:   40,
+		OutputTokens:  2,
+	}
+	assistantEntry, err := repository.AppendMessageWithMetadata(ctx, session.ID, &userEntry.ID, newUsageTestMessage(
+		database.RoleAssistant,
+		testUsageReply,
+		"openai",
+		"gpt",
+	), &modelFacing, assistantUsage)
+	require.NoError(t, err)
+
+	contextEntity, err := repository.BuildContext(ctx, session.ID, assistantEntry.ID)
+	require.NoError(t, err)
+	require.NotNil(t, contextEntity.UsageAnchor)
+	assert.Equal(t, assistantEntry.ID, contextEntity.UsageAnchor.EntryID)
+	assert.Equal(t, 1, contextEntity.UsageAnchor.MessageIndex)
+	assert.Equal(t, 40, contextEntity.UsageAnchor.Usage.InputTokens)
+}
+
+func TestBuildContextClearsUsageAnchorAfterCompaction(t *testing.T) {
+	t.Parallel()
+
+	repository := newTestSessionRepository(t)
+	ctx := context.Background()
+	session, err := repository.CreateSession(ctx, "/work", "usage", "")
+	require.NoError(t, err)
+
+	userEntry, err := repository.AppendMessage(ctx, session.ID, nil, newUsageTestMessage(
+		database.RoleUser,
+		testUsagePrompt,
+		"",
+		"",
+	))
+	require.NoError(t, err)
+	modelFacing := true
+	assistantEntry, err := repository.AppendMessageWithMetadata(ctx, session.ID, &userEntry.ID, newUsageTestMessage(
+		database.RoleAssistant,
+		testUsageReply,
+		"",
+		"",
+	), &modelFacing, &database.EntryTokenUsageEntity{
+		ContextWindow: 0,
+		ContextTokens: 0,
+		InputTokens:   40,
+		OutputTokens:  0,
+	})
+	require.NoError(t, err)
+	compactionEntry, err := repository.AppendCompaction(
+		ctx,
+		session.ID,
+		&assistantEntry.ID,
+		"summary",
+		userEntry.ID,
+		100,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+
+	contextEntity, err := repository.BuildContext(ctx, session.ID, compactionEntry.ID)
+	require.NoError(t, err)
+	assert.Nil(t, contextEntity.UsageAnchor)
+}
+
+func newUsageTestMessage(role database.Role, content, provider, model string) *database.MessageEntity {
+	return &database.MessageEntity{
+		Timestamp: time.Now().UTC(),
+		Role:      role,
+		Content:   content,
+		Provider:  provider,
+		Model:     model,
+	}
+}


### PR DESCRIPTION
## Summary
- use successful provider usage to improve context estimates
- ignore stale usage after compaction boundaries
- add split-turn compaction summary handling

## Validation
- go test ./internal/assistant
- mise exec -- task ci