### PR TITLE
fix(context): use realistic output reserve

### DIFF
--- a/internal/assistant/context_budget.go
+++ b/internal/assistant/context_budget.go
@@ -89,12 +89,9 @@ func (budget contextBudget) Validate() error {
 		Errorf(message, budget.InputTokens, budget.UsableInput, budget.TotalReserve(), budget.ContextWindow)
 }
 
-func contextOutputReserve(selectedModel *model.Model, contextWindow int, policy config.ContextConfig) int {
+func contextOutputReserve(_ *model.Model, contextWindow int, policy config.ContextConfig) int {
 	if policy.OutputReserveTokens > 0 {
 		return policy.OutputReserveTokens
-	}
-	if selectedModel != nil && selectedModel.MaxTokens > 0 {
-		return selectedModel.MaxTokens
 	}
 	reserve := defaultContextOutputReserve
 	if contextWindow > 0 {

--- a/internal/assistant/context_budget_test.go
+++ b/internal/assistant/context_budget_test.go
@@ -107,11 +107,35 @@ func TestRuntime_ContextUsageHonorsExplicitZeroReserves(t *testing.T) {
 	assert.Equal(t, 0, usage.Breakdown["reserve_safety"])
 }
 
-func TestRuntime_ContextUsageUsesModelMaxTokensAsOutputReserve(t *testing.T) {
+func TestRuntime_ContextUsageUsesDefaultOutputReserveWhenModelMaxTokensIsLarge(t *testing.T) {
 	t.Parallel()
 
 	client := &capturingCompletionClient{request: nil}
-	runtime := newTestRuntimeWithContextWindowAndMaxTokens(t, client, 100_000, 1234)
+	runtime := newTestRuntimeWithContextWindowAndMaxTokens(t, client, 272_000, 128_000)
+
+	usage, err := runtime.ContextUsage(context.Background(), "", testRuntimeCWD)
+
+	require.NoError(t, err)
+	assert.Equal(t, 16_384, usage.Breakdown["reserve_output"])
+}
+
+func TestRuntime_ContextUsageUsesExplicitOutputReserve(t *testing.T) {
+	t.Parallel()
+
+	client := &capturingCompletionClient{request: nil}
+	runtime := newTestRuntimeWithContextWindowAndMaxTokens(t, client, 100_000, 128_000)
+	runtimeConfig := testConfig()
+	runtimeConfig.Context.OutputReserveTokens = 1234
+	runtime = assistant.NewRuntime(
+		runtimeConfig,
+		runtime.SessionRepository(),
+		nil,
+		assistant.NewResponseCache(false, 1, time.Minute),
+		runtime.EventBus(),
+		runtime.ModelRegistry(),
+		client,
+		nil,
+	)
 
 	usage, err := runtime.ContextUsage(context.Background(), "", testRuntimeCWD)
 

--- a/internal/terminal/token_usage.go
+++ b/internal/terminal/token_usage.go
@@ -48,7 +48,20 @@ func formatTokenStatus(usage model.TokenUsage) string {
 }
 
 func formatContextUsage(usage model.TokenUsage) string {
+	usableInput := usableInputBudget(usage)
 	switch {
+	case usage.ContextTokens > 0 && usableInput > 0:
+		contextText := fmt.Sprintf(
+			"ctx %s/%s usable %d%%",
+			compactCount(usage.ContextTokens),
+			compactCount(usableInput),
+			percentOf(usage.ContextTokens, usableInput),
+		)
+		if usage.ContextWindow > 0 {
+			contextText += fmt.Sprintf(" (%d%% window)", usage.ContextPercent())
+		}
+
+		return contextText
 	case usage.ContextTokens > 0 && usage.ContextWindow > 0:
 		return fmt.Sprintf(
 			"ctx %s/%s %d%%",
@@ -63,6 +76,22 @@ func formatContextUsage(usage model.TokenUsage) string {
 	default:
 		return ""
 	}
+}
+
+func usableInputBudget(usage model.TokenUsage) int {
+	if len(usage.Breakdown) == 0 {
+		return 0
+	}
+
+	return usage.Breakdown["usable_input"]
+}
+
+func percentOf(tokens, budget int) int {
+	if tokens <= 0 || budget <= 0 {
+		return 0
+	}
+
+	return tokens * 100 / budget
 }
 
 func cloneTokenBreakdown(values map[string]int) map[string]int {

--- a/internal/terminal/token_usage_test.go
+++ b/internal/terminal/token_usage_test.go
@@ -228,3 +228,19 @@ func TestShowContextInfoDisplaysSummaryAndBreakdown(t *testing.T) {
 	assert.Contains(t, message, "- top contributors:")
 	assert.Contains(t, message, "message 2 7.0k assistant")
 }
+
+func TestFormatContextUsagePrefersUsableInputBudget(t *testing.T) {
+	t.Parallel()
+
+	usage := model.TokenUsage{
+		Breakdown: map[string]int{
+			"usable_input": 132_624,
+		},
+		ContextWindow: 272_000,
+		ContextTokens: 156_652,
+		InputTokens:   156_652,
+		OutputTokens:  0,
+	}
+
+	assert.Equal(t, "ctx 156k/132k usable 118% (57% window)", terminal.FormatContextUsageForTest(usage))
+}

--- a/internal/terminal/token_usage_test.go
+++ b/internal/terminal/token_usage_test.go
@@ -236,10 +236,11 @@ func TestFormatContextUsagePrefersUsableInputBudget(t *testing.T) {
 		Breakdown: map[string]int{
 			"usable_input": 132_624,
 		},
-		ContextWindow: 272_000,
-		ContextTokens: 156_652,
-		InputTokens:   156_652,
-		OutputTokens:  0,
+		TopContributors: nil,
+		ContextWindow:   272_000,
+		ContextTokens:   156_652,
+		InputTokens:     156_652,
+		OutputTokens:    0,
 	}
 
 	assert.Equal(t, "ctx 156k/132k usable 118% (57% window)", terminal.FormatContextUsageForTest(usage))


### PR DESCRIPTION
## Summary
- cap context preflight output reserve to configured/default reserve instead of model max output tokens
- show usable input budget in context token UI when available
- add coverage for reserve calculation and UI formatting

## Tests
- go test ./internal/assistant ./internal/extension ./internal/terminal