### PR TITLE
fix(context): stabilize usage status updates

### DIFF
--- a/internal/assistant/context_auto_compaction.go
+++ b/internal/assistant/context_auto_compaction.go
@@ -126,7 +126,7 @@ func (runtime *Runtime) prepareCompletionRequestWithAutoCompaction(
 			Code("context_request_rebuild").
 			Wrapf(err, "context: rebuild completion request after compaction")
 	}
-	runtime.emitUsage(ctx, input.onEvent, build.Context.Usage)
+	runtime.emitUsageSnapshot(ctx, input.onEvent, build.Context.Usage)
 	if err := build.Budget.Validate(); err != nil {
 		return nil, nil, oops.In("assistant").
 			Code("context_budget_after_compact").
@@ -159,34 +159,45 @@ type postResponseAutoCompactionInput struct {
 	parentEntryID string
 }
 
-func (runtime *Runtime) autoCompactAfterResponse(ctx context.Context, input *postResponseAutoCompactionInput) {
+func (runtime *Runtime) autoCompactAfterResponse(
+	ctx context.Context,
+	input *postResponseAutoCompactionInput,
+) (model.TokenUsage, bool) {
 	if !runtime.shouldTryPostResponseAutoCompaction(input) {
-		return
+		return model.EmptyTokenUsage(), false
 	}
 	usage, err := runtime.ContextUsage(ctx, input.sessionID, input.cwd)
 	if err != nil {
 		runtime.emitPostResponseAutoCompactionError(ctx, input.onEvent, err)
-		return
+		return model.EmptyTokenUsage(), false
 	}
 	budget := contextBudgetFromUsage(usage)
 	if !shouldAutoCompactAfterResponse(budget) {
-		return
+		return model.EmptyTokenUsage(), false
 	}
 
 	runtime.emitContextCompaction(ctx, input.onEvent, postResponseAutoCompactionStartMessage(budget))
 	entry, err := runtime.CompactSessionFrom(ctx, input.sessionID, input.cwd, &input.parentEntryID)
 	if isCompactNothingToDoError(err) {
-		return
+		return model.EmptyTokenUsage(), false
 	}
 	if err != nil {
 		runtime.emitPostResponseAutoCompactionError(ctx, input.onEvent, err)
-		return
+		return model.EmptyTokenUsage(), false
 	}
+	compactedUsage, err := runtime.ContextUsage(ctx, input.sessionID, input.cwd)
+	if err != nil {
+		runtime.emitPostResponseAutoCompactionError(ctx, input.onEvent, err)
+		return model.EmptyTokenUsage(), false
+	}
+	runtime.emitUsageSnapshot(ctx, input.onEvent, compactedUsage)
 	runtime.emitContextCompaction(ctx, input.onEvent, compactionMessage(
 		"context auto-compacted after response",
 		budget,
 		entry,
 	))
+
+	return compactedUsage, true
 }
 
 func (runtime *Runtime) shouldTryPostResponseAutoCompaction(input *postResponseAutoCompactionInput) bool {

--- a/internal/assistant/context_overflow_compaction.go
+++ b/internal/assistant/context_overflow_compaction.go
@@ -93,7 +93,7 @@ func (runtime *Runtime) recoverProviderContextOverflow(
 			Code("context_overflow_rebuild").
 			Wrapf(err, "context: rebuild completion request after provider overflow compaction")
 	}
-	runtime.emitUsage(ctx, input.preparation.onEvent, recoveredBuild.Context.Usage)
+	runtime.emitUsageSnapshot(ctx, input.preparation.onEvent, recoveredBuild.Context.Usage)
 	if runtime.cfg.Context.PreflightEnabled {
 		validationErr := recoveredBuild.Budget.Validate()
 		if validationErr != nil {

--- a/internal/assistant/context_post_response_auto_compaction_test.go
+++ b/internal/assistant/context_post_response_auto_compaction_test.go
@@ -39,11 +39,13 @@ func TestRuntime_AutoCompactsAfterResponseNearThreshold(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "final answer", response.Text)
+	assert.Greater(t, response.Usage.ContextTokens, 0)
 	require.Len(t, harness.client.requests, 2)
 	assert.False(t, harness.client.requests[0].DisableTools)
 	assert.True(t, harness.client.requests[1].DisableTools)
 	assert.Contains(t, harness.client.requests[1].Messages[0].Content, "old")
 	assertPostResponseCompactionEvent(t, events)
+	assertPostResponseUsageSnapshot(t, events)
 
 	leaf, found, err := harness.runtime.SessionRepository().LeafEntry(ctx, session.ID)
 	require.NoError(t, err)
@@ -103,4 +105,18 @@ func assertPostResponseCompactionEvent(t *testing.T, events []assistant.StreamEv
 	}
 	assert.True(t, foundStart, "expected post-response auto-compaction start event")
 	assert.True(t, foundDone, "expected post-response auto-compaction completion event")
+}
+
+func assertPostResponseUsageSnapshot(t *testing.T, events []assistant.StreamEvent) {
+	t.Helper()
+
+	for _, event := range events {
+		if event.Kind != assistant.StreamEventUsageSnapshot || event.Usage == nil {
+			continue
+		}
+		if event.Usage.ContextTokens > 0 {
+			return
+		}
+	}
+	assert.Fail(t, "expected post-response auto-compaction usage snapshot")
 }

--- a/internal/assistant/context_post_response_auto_compaction_test.go
+++ b/internal/assistant/context_post_response_auto_compaction_test.go
@@ -110,13 +110,24 @@ func assertPostResponseCompactionEvent(t *testing.T, events []assistant.StreamEv
 func assertPostResponseUsageSnapshot(t *testing.T, events []assistant.StreamEvent) {
 	t.Helper()
 
+	snapshotCount := 0
 	for _, event := range events {
 		if event.Kind != assistant.StreamEventUsageSnapshot || event.Usage == nil {
 			continue
 		}
+		snapshotCount++
 		if event.Usage.ContextTokens > 0 {
 			return
 		}
 	}
-	assert.Fail(t, "expected post-response auto-compaction usage snapshot")
+	if snapshotCount == 0 {
+		assert.Fail(t, "expected post-response auto-compaction usage snapshot, found no snapshot events")
+		return
+	}
+	assert.Failf(
+		t,
+		"expected post-response auto-compaction usage snapshot",
+		"found %d snapshot events but all had ContextTokens == 0",
+		snapshotCount,
+	)
 }

--- a/internal/assistant/export_test.go
+++ b/internal/assistant/export_test.go
@@ -37,8 +37,8 @@ func (runtime *Runtime) AutoCompactAfterResponseForTest(
 	sessionID string,
 	cwd string,
 	parentEntryID string,
-) {
-	runtime.autoCompactAfterResponse(ctx, &postResponseAutoCompactionInput{
+) (model.TokenUsage, bool) {
+	return runtime.autoCompactAfterResponse(ctx, &postResponseAutoCompactionInput{
 		onEvent:       onEvent,
 		sessionID:     sessionID,
 		cwd:           cwd,

--- a/internal/assistant/runtime.go
+++ b/internal/assistant/runtime.go
@@ -73,6 +73,8 @@ const (
 	StreamEventSkillLoaded StreamEventKind = "skill_loaded"
 	// StreamEventUsage carries estimated or provider-reported token usage.
 	StreamEventUsage StreamEventKind = "usage"
+	// StreamEventUsageSnapshot carries a fresh full-context usage snapshot that should replace prior UI usage.
+	StreamEventUsageSnapshot StreamEventKind = "usage_snapshot"
 	// StreamEventContextCompaction carries UI-only context compaction notices.
 	StreamEventContextCompaction StreamEventKind = "context_compaction"
 )
@@ -184,14 +186,14 @@ func (runtime *Runtime) Prompt(ctx context.Context, request *PromptRequest) (res
 	}
 	runtime.dispatchMessageAppend(ctx, assistantEntry)
 	turnLifecycle.dispatchEnd(ctx, assistantEntry.ID, cached, bundle.Usage)
-	if !compactedBeforeRequest {
-		runtime.autoCompactAfterResponse(ctx, &postResponseAutoCompactionInput{
-			onEvent:       request.OnEvent,
-			sessionID:     activeSession.ID,
-			cwd:           request.CWD,
-			parentEntryID: assistantEntry.ID,
-		})
-	}
+	runtime.maybeAutoCompactAfterResponse(
+		ctx,
+		activeSession.ID,
+		assistantEntry.ID,
+		request,
+		bundle,
+		compactedBeforeRequest,
+	)
 
 	return &PromptResponse{
 		SessionID:        activeSession.ID,
@@ -203,6 +205,28 @@ func (runtime *Runtime) Prompt(ctx context.Context, request *PromptRequest) (res
 		Usage:            bundle.Usage,
 		Cached:           cached,
 	}, nil
+}
+
+func (runtime *Runtime) maybeAutoCompactAfterResponse(
+	ctx context.Context,
+	sessionID string,
+	assistantEntryID string,
+	request *PromptRequest,
+	bundle *responseBundle,
+	compactedBeforeRequest bool,
+) {
+	if compactedBeforeRequest || request == nil || bundle == nil {
+		return
+	}
+	usage, compacted := runtime.autoCompactAfterResponse(ctx, &postResponseAutoCompactionInput{
+		onEvent:       request.OnEvent,
+		sessionID:     sessionID,
+		cwd:           request.CWD,
+		parentEntryID: assistantEntryID,
+	})
+	if compacted {
+		bundle.Usage = usage
+	}
 }
 
 // SessionRepository returns the underlying session repository for command and UI layers.

--- a/internal/assistant/runtime_persist.go
+++ b/internal/assistant/runtime_persist.go
@@ -124,6 +124,7 @@ func (progress *partialPromptProgress) record(streamEvent StreamEvent) {
 	case StreamEventToolStart,
 		StreamEventSkillLoaded,
 		StreamEventUsage,
+		StreamEventUsageSnapshot,
 		StreamEventContextCompaction:
 		return
 	}

--- a/internal/assistant/usage_events.go
+++ b/internal/assistant/usage_events.go
@@ -7,13 +7,26 @@ import (
 )
 
 func (runtime *Runtime) emitUsage(ctx context.Context, onEvent func(StreamEvent), usage model.TokenUsage) {
+	runtime.emitUsageEvent(ctx, onEvent, usage, StreamEventUsage)
+}
+
+func (runtime *Runtime) emitUsageSnapshot(ctx context.Context, onEvent func(StreamEvent), usage model.TokenUsage) {
+	runtime.emitUsageEvent(ctx, onEvent, usage, StreamEventUsageSnapshot)
+}
+
+func (runtime *Runtime) emitUsageEvent(
+	ctx context.Context,
+	onEvent func(StreamEvent),
+	usage model.TokenUsage,
+	kind StreamEventKind,
+) {
 	if !usage.HasAny() {
 		return
 	}
 	emitStreamEvent(onEvent, StreamEvent{
 		ToolEvent: nil,
 		Usage:     &usage,
-		Kind:      StreamEventUsage,
+		Kind:      kind,
 		Text:      "",
 	})
 	payload := map[string]any{
@@ -22,6 +35,9 @@ func (runtime *Runtime) emitUsage(ctx context.Context, onEvent func(StreamEvent)
 		jsonContextTokensKey: usage.ContextTokens,
 		jsonInputTokensKey:   usage.InputTokens,
 		jsonOutputTokensKey:  usage.OutputTokens,
+	}
+	if kind == StreamEventUsageSnapshot {
+		payload["snapshot"] = true
 	}
 	runtime.emit(ctx, jsonUsageKey, payload)
 	if runtime.extensions != nil {

--- a/internal/terminal/app.go
+++ b/internal/terminal/app.go
@@ -520,7 +520,8 @@ func isHighVolumePromptStreamEvent(kind asyncEventKind) bool {
 		asyncEventPromptThinkingDelta,
 		asyncEventPromptToolStart,
 		asyncEventPromptToolResult,
-		asyncEventPromptUsage:
+		asyncEventPromptUsage,
+		asyncEventPromptUsageSnapshot:
 		return true
 	case asyncEventAuthURL,
 		asyncEventAuthDone,

--- a/internal/terminal/async_events.go
+++ b/internal/terminal/async_events.go
@@ -26,6 +26,7 @@ const (
 	asyncEventPromptToolResult    asyncEventKind = "prompt_tool_result"
 	asyncEventPromptRetry         asyncEventKind = "prompt_retry"
 	asyncEventPromptUsage         asyncEventKind = "prompt_usage"
+	asyncEventPromptUsageSnapshot asyncEventKind = "prompt_usage_snapshot"
 	asyncEventPromptError         asyncEventKind = "prompt_error"
 	asyncEventPromptContext       asyncEventKind = "prompt_context"
 	asyncEventCompactDone         asyncEventKind = "compact_done"
@@ -127,6 +128,16 @@ func (app *App) promptStreamHandler(ctx context.Context, promptID uint64) func(a
 				Text:      "",
 				PromptID:  promptID,
 			})
+		case assistant.StreamEventUsageSnapshot:
+			app.postAsyncEvent(ctx, &asyncEvent{
+				Response:  nil,
+				ToolEvent: nil,
+				Usage:     event.Usage,
+				Kind:      asyncEventPromptUsageSnapshot,
+				Provider:  "",
+				Text:      "",
+				PromptID:  promptID,
+			})
 		case assistant.StreamEventContextCompaction:
 			app.postAsyncEvent(ctx, &asyncEvent{
 				Response:  nil,
@@ -194,6 +205,7 @@ func (app *App) handleAuthAsyncEvent(payload *asyncEvent) bool {
 		asyncEventPromptToolResult,
 		asyncEventPromptRetry,
 		asyncEventPromptUsage,
+		asyncEventPromptUsageSnapshot,
 		asyncEventPromptError,
 		asyncEventPromptContext,
 		asyncEventCompactDone,
@@ -236,6 +248,7 @@ func isPromptAsyncEvent(kind asyncEventKind) bool {
 		asyncEventPromptToolResult,
 		asyncEventPromptRetry,
 		asyncEventPromptUsage,
+		asyncEventPromptUsageSnapshot,
 		asyncEventPromptError,
 		asyncEventPromptContext:
 		return true
@@ -285,7 +298,8 @@ func (app *App) handlePromptLifecycleEvent(ctx context.Context, payload *asyncEv
 		asyncEventPromptThinkingDelta,
 		asyncEventPromptToolStart,
 		asyncEventPromptToolResult,
-		asyncEventPromptUsage:
+		asyncEventPromptUsage,
+		asyncEventPromptUsageSnapshot:
 		return false
 	}
 
@@ -323,6 +337,9 @@ func (app *App) handlePromptStreamEvent(ctx context.Context, payload *asyncEvent
 		return
 	case asyncEventPromptUsage:
 		app.applyTokenUsage(payload.Usage)
+		return
+	case asyncEventPromptUsageSnapshot:
+		app.applyTokenUsageEvent(payload.Usage, true)
 		return
 	case asyncEventPromptDone,
 		asyncEventPromptUserEntry,

--- a/internal/terminal/async_events_test.go
+++ b/internal/terminal/async_events_test.go
@@ -458,6 +458,7 @@ func TestHandlePromptAsyncEventIgnoresStalePromptEvents(t *testing.T) {
 type streamEventApplyCase struct {
 	payload        *asyncEvent
 	assert         func(*testing.T, *App)
+	prepare        func(*App)
 	name           string
 	canceledActive bool
 }
@@ -470,6 +471,9 @@ func TestHandlePromptStreamEventAppliesStreamData(t *testing.T) {
 			t.Parallel()
 
 			app := newRenderTestApp(t)
+			if testCase.prepare != nil {
+				testCase.prepare(app)
+			}
 			if testCase.canceledActive {
 				app.activePrompt = newTestActivePrompt(nil)
 				app.activePrompt.Canceled = true
@@ -496,6 +500,7 @@ func promptStreamEventApplyCases() []streamEventApplyCase {
 				assert.Equal(t, database.RoleAssistant, app.transcript.Streaming.Blocks[0].Role)
 				assert.Equal(t, asyncTestGreeting, app.transcript.Streaming.Blocks[0].Content)
 			},
+			prepare:        nil,
 			canceledActive: false,
 		},
 		{
@@ -506,6 +511,7 @@ func promptStreamEventApplyCases() []streamEventApplyCase {
 				require.Len(t, app.transcript.Streaming.Blocks, 1)
 				assert.Equal(t, database.RoleThinking, app.transcript.Streaming.Blocks[0].Role)
 			},
+			prepare:        nil,
 			canceledActive: false,
 		},
 		{
@@ -517,6 +523,7 @@ func promptStreamEventApplyCases() []streamEventApplyCase {
 				assert.Equal(t, database.RoleToolResult, app.transcript.Streaming.Blocks[0].Role)
 				assert.Equal(t, 1, app.streamedToolEvents)
 			},
+			prepare:        nil,
 			canceledActive: false,
 		},
 		{
@@ -526,11 +533,15 @@ func promptStreamEventApplyCases() []streamEventApplyCase {
 				t.Helper()
 				assert.Equal(t, 25, app.tokenUsage.ContextTokens)
 			},
+			prepare:        nil,
 			canceledActive: false,
 		},
 		{
 			name:    "usage snapshot replaces token usage",
 			payload: asyncTestEventWithUsage(asyncEventPromptUsageSnapshot, usage),
+			prepare: func(app *App) {
+				app.tokenUsage.ContextTokens = 123
+			},
 			assert: func(t *testing.T, app *App) {
 				t.Helper()
 				assert.Equal(t, 25, app.tokenUsage.ContextTokens)
@@ -544,6 +555,7 @@ func promptStreamEventApplyCases() []streamEventApplyCase {
 				t.Helper()
 				assert.Empty(t, app.transcript.Streaming.Blocks)
 			},
+			prepare:        nil,
 			canceledActive: true,
 		},
 	}

--- a/internal/terminal/async_events_test.go
+++ b/internal/terminal/async_events_test.go
@@ -195,6 +195,14 @@ func promptStreamHandlerPostCases() []streamHandlerPostCase {
 			wantUsage:   true,
 		},
 		{
+			name:        "usage snapshot",
+			streamEvent: asyncTestStreamEvent(assistant.StreamEventUsageSnapshot, "", nil, usage),
+			wantKind:    asyncEventPromptUsageSnapshot,
+			wantText:    "",
+			wantTool:    false,
+			wantUsage:   true,
+		},
+		{
 			name:        "context compaction",
 			streamEvent: asyncTestStreamEvent(assistant.StreamEventContextCompaction, asyncTestCompact, nil, nil),
 			wantKind:    asyncEventPromptContext,
@@ -327,6 +335,7 @@ func TestPromptAsyncEventHelpers(t *testing.T) {
 		asyncEventPromptToolResult,
 		asyncEventPromptRetry,
 		asyncEventPromptUsage,
+		asyncEventPromptUsageSnapshot,
 		asyncEventPromptError,
 		asyncEventPromptContext,
 	} {
@@ -513,6 +522,15 @@ func promptStreamEventApplyCases() []streamEventApplyCase {
 		{
 			name:    "usage updates token usage",
 			payload: asyncTestEventWithUsage(asyncEventPromptUsage, usage),
+			assert: func(t *testing.T, app *App) {
+				t.Helper()
+				assert.Equal(t, 25, app.tokenUsage.ContextTokens)
+			},
+			canceledActive: false,
+		},
+		{
+			name:    "usage snapshot replaces token usage",
+			payload: asyncTestEventWithUsage(asyncEventPromptUsageSnapshot, usage),
 			assert: func(t *testing.T, app *App) {
 				t.Helper()
 				assert.Equal(t, 25, app.tokenUsage.ContextTokens)

--- a/internal/terminal/compact_commands.go
+++ b/internal/terminal/compact_commands.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/model"
 )
 
 const compactedStatusMessage = "context compacted"
@@ -53,14 +54,24 @@ func (app *App) runCompactSession(
 		app.postCompactError(ctx, compactID, err)
 		return
 	}
-	app.postCompactDone(ctx, compactID, entry)
+	usage, err := app.runtime.ContextUsage(compactCtx, app.sessionID, app.cwd)
+	if err != nil {
+		app.postCompactError(ctx, compactID, err)
+		return
+	}
+	app.postCompactDone(ctx, compactID, entry, &usage)
 }
 
-func (app *App) postCompactDone(ctx context.Context, compactID uint64, entry *database.EntryEntity) {
+func (app *App) postCompactDone(
+	ctx context.Context,
+	compactID uint64,
+	entry *database.EntryEntity,
+	usage *model.TokenUsage,
+) {
 	app.postAsyncEvent(ctx, &asyncEvent{
 		Response:  nil,
 		ToolEvent: nil,
-		Usage:     nil,
+		Usage:     usage,
 		Kind:      asyncEventCompactDone,
 		Provider:  compactionEntryID(entry),
 		Text:      compactDoneText(entry),
@@ -99,6 +110,7 @@ func (app *App) handleCompactAsyncEvent(ctx context.Context, payload *asyncEvent
 		asyncEventPromptToolResult,
 		asyncEventPromptRetry,
 		asyncEventPromptUsage,
+		asyncEventPromptUsageSnapshot,
 		asyncEventPromptError,
 		asyncEventPromptContext:
 		return false
@@ -114,6 +126,7 @@ func (app *App) applyCompactDone(ctx context.Context, payload *asyncEvent) {
 	app.pendingParentID = nonEmptyStringPtr(payload.Provider)
 	app.compacting = false
 	app.activeCompaction = nil
+	app.applyTokenUsageEvent(payload.Usage, true)
 	app.addSystemMessage(payload.Text)
 	app.setStatus(compactedStatusMessage)
 	app.processQueuedPrompt(ctx)

--- a/internal/terminal/compact_commands.go
+++ b/internal/terminal/compact_commands.go
@@ -56,7 +56,7 @@ func (app *App) runCompactSession(
 	}
 	usage, err := app.runtime.ContextUsage(compactCtx, app.sessionID, app.cwd)
 	if err != nil {
-		app.postCompactError(ctx, compactID, err)
+		app.postCompactDone(ctx, compactID, entry, nil)
 		return
 	}
 	app.postCompactDone(ctx, compactID, entry, &usage)

--- a/internal/terminal/compact_commands_test.go
+++ b/internal/terminal/compact_commands_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/omarluq/librecode/internal/assistant"
 	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/model"
 )
 
 func TestCompactSessionStartsAsyncWork(t *testing.T) {
@@ -58,9 +59,17 @@ func TestCompactSessionStartsAsyncWork(t *testing.T) {
 		t.Fatal("app should still be compacting while provider is blocked")
 	}
 	client.finish("summary of compacted work", nil)
-	event := readPromptAsyncEvent(t, app)
+	assertCompactDoneEventHasUsage(t, readPromptAsyncEvent(t, app))
+}
+
+func assertCompactDoneEventHasUsage(t *testing.T, event *asyncEvent) {
+	t.Helper()
+
 	if got := event.Kind; got != asyncEventCompactDone {
 		t.Fatalf("event.Kind = %q, want %q", got, asyncEventCompactDone)
+	}
+	if event.Usage == nil || event.Usage.ContextTokens <= 0 {
+		t.Fatalf("compact done usage = %v, want refreshed usage", event.Usage)
 	}
 }
 
@@ -166,7 +175,14 @@ func TestHandleCompactDoneStartsQueuedPrompt(t *testing.T) {
 	app.queuedMessages = []string{"queued after compact"}
 
 	app.applyCompactDone(context.Background(), &asyncEvent{
-		Response: nil, ToolEvent: nil, Usage: nil,
+		Response: nil, ToolEvent: nil, Usage: &model.TokenUsage{
+			Breakdown:       nil,
+			TopContributors: nil,
+			ContextWindow:   100_000,
+			ContextTokens:   10_000,
+			InputTokens:     10_000,
+			OutputTokens:    0,
+		},
 		Kind: asyncEventCompactDone, Provider: "", Text: compactedStatusMessage, PromptID: 9,
 	})
 
@@ -176,6 +192,9 @@ func TestHandleCompactDoneStartsQueuedPrompt(t *testing.T) {
 	}
 	if len(app.queuedMessages) != 0 {
 		t.Fatalf("queuedMessages length = %d, want 0", len(app.queuedMessages))
+	}
+	if got := app.tokenUsage.ContextTokens; got != 10_000 {
+		t.Fatalf("tokenUsage.ContextTokens = %d, want 10000", got)
 	}
 }
 

--- a/internal/terminal/compact_commands_test.go
+++ b/internal/terminal/compact_commands_test.go
@@ -62,6 +62,42 @@ func TestCompactSessionStartsAsyncWork(t *testing.T) {
 	assertCompactDoneEventHasUsage(t, readPromptAsyncEvent(t, app))
 }
 
+func TestPostCompactDoneAllowsNilUsage(t *testing.T) {
+	t.Parallel()
+
+	app := newRenderTestApp(t)
+	app.compacting = true
+	app.activeCompaction = &activeCompactionState{Cancel: func() {}, ID: 9, QueuedStart: 0}
+	app.tokenUsage = model.TokenUsage{
+		Breakdown:       nil,
+		TopContributors: nil,
+		ContextWindow:   100_000,
+		ContextTokens:   42_000,
+		InputTokens:     42_000,
+		OutputTokens:    0,
+	}
+
+	app.applyCompactDone(context.Background(), &asyncEvent{
+		Response:  nil,
+		ToolEvent: nil,
+		Usage:     nil,
+		Kind:      asyncEventCompactDone,
+		Provider:  compactTestEntryID,
+		Text:      compactedStatusMessage,
+		PromptID:  9,
+	})
+
+	if app.compacting {
+		t.Fatal("app should stop compacting")
+	}
+	if got := app.tokenUsage.ContextTokens; got != 42_000 {
+		t.Fatalf("tokenUsage.ContextTokens = %d, want previous usage preserved", got)
+	}
+	if got := app.transcript.History[len(app.transcript.History)-1].Content; got != compactedStatusMessage {
+		t.Fatalf("last message = %q, want compacted message", got)
+	}
+}
+
 func assertCompactDoneEventHasUsage(t *testing.T, event *asyncEvent) {
 	t.Helper()
 
@@ -77,6 +113,7 @@ const (
 	compactTestSessionID = "compact-session"
 	compactTestIgnored   = "compact-ignored"
 	compactTestParentID  = "compact-parent"
+	compactTestEntryID   = "compaction-entry"
 	compactTestFailed    = "compaction failed"
 )
 
@@ -143,7 +180,7 @@ func TestHandleCompactDoneUpdatesState(t *testing.T) {
 		ToolEvent: nil,
 		Usage:     nil,
 		Kind:      asyncEventCompactDone,
-		Provider:  "compaction-entry",
+		Provider:  compactTestEntryID,
 		Text:      compactedStatusMessage,
 		PromptID:  9,
 	})
@@ -157,8 +194,8 @@ func TestHandleCompactDoneUpdatesState(t *testing.T) {
 	if app.activeCompaction != nil {
 		t.Fatal("activeCompaction should be cleared")
 	}
-	if app.pendingParentID == nil || *app.pendingParentID != "compaction-entry" {
-		t.Fatalf("pendingParentID = %v, want compaction-entry", app.pendingParentID)
+	if app.pendingParentID == nil || *app.pendingParentID != compactTestEntryID {
+		t.Fatalf("pendingParentID = %v, want %s", app.pendingParentID, compactTestEntryID)
 	}
 	if got := app.transcript.History[len(app.transcript.History)-1].Content; got != compactedStatusMessage {
 		t.Fatalf("last message = %q, want compacted message", got)
@@ -474,7 +511,7 @@ func TestHandleCompactAsyncEventIgnoresStaleAndNonCompactEvents(t *testing.T) {
 
 	handled = app.handleCompactAsyncEvent(context.Background(), &asyncEvent{
 		Response: nil, ToolEvent: nil, Usage: nil,
-		Kind: asyncEventPromptDelta, Provider: "", Text: "not compact", PromptID: 9,
+		Kind: asyncEventPromptUsageSnapshot, Provider: "", Text: "not compact", PromptID: 9,
 	})
 	if handled {
 		t.Fatal("non-compact event should not be handled")

--- a/internal/terminal/context_contributors_extra_test.go
+++ b/internal/terminal/context_contributors_extra_test.go
@@ -39,8 +39,8 @@ func TestApplyTokenUsageAndFormattingVariants(t *testing.T) {
 		OutputTokens:    0,
 	}
 	app.ApplyTokenUsageForTest(&usage)
-	assert.Equal(t, "ctx 0/9.0k", app.TokenStatusTextForTest())
-	assert.Equal(t, "ctx 0/9.0k", terminal.FormatTokenStatusForTest(usage))
+	assert.Empty(t, app.TokenStatusTextForTest())
+	assert.Empty(t, terminal.FormatTokenStatusForTest(usage))
 
 	assert.Equal(t, "ctx 42", terminal.FormatContextUsageForTest(model.TokenUsage{
 		Breakdown:       nil,

--- a/internal/terminal/prompt_send.go
+++ b/internal/terminal/prompt_send.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/omarluq/librecode/internal/assistant"
 	"github.com/omarluq/librecode/internal/database"
-	"github.com/omarluq/librecode/internal/model"
 )
 
 func (app *App) sendPrompt(ctx context.Context, text string) {
@@ -32,7 +31,6 @@ func (app *App) sendPrompt(ctx context.Context, text string) {
 	app.scrollOffset = 0
 	app.streamingText = ""
 	app.streamingThinkingText = ""
-	app.tokenUsage = model.EmptyTokenUsage()
 	app.resetStreamingBlocks()
 	app.streamedToolEvents = 0
 	app.activePrompt = &activePromptState{

--- a/internal/terminal/prompt_send_test.go
+++ b/internal/terminal/prompt_send_test.go
@@ -223,11 +223,22 @@ func TestSendPromptInitializesPromptState(t *testing.T) {
 	app := newPromptSendTestApp(t, client)
 	parentID := ""
 	app.pendingParentID = &parentID
+	app.tokenUsage = model.TokenUsage{
+		Breakdown:       nil,
+		TopContributors: nil,
+		ContextWindow:   100_000,
+		ContextTokens:   25_000,
+		InputTokens:     25_000,
+		OutputTokens:    0,
+	}
 
 	app.screen = newClipboardScreen()
 	app.sendPrompt(context.Background(), promptSendTestText)
 	_ = readPromptAsyncEvent(t, app)
 
+	if got := app.tokenUsage.ContextTokens; got != 25_000 {
+		t.Fatalf("tokenUsage.ContextTokens = %d, want 25000", got)
+	}
 	request := waitForPromptRequest(t, client)
 	if got := request.Messages[len(request.Messages)-1].Content; got != promptSendTestText {
 		t.Fatalf("last request message = %q, want hello", got)

--- a/internal/terminal/prompt_send_test.go
+++ b/internal/terminal/prompt_send_test.go
@@ -318,6 +318,46 @@ func TestRunPromptPostsDoneAndError(t *testing.T) {
 func newPromptSendTestApp(t *testing.T, client assistant.CompletionClient) *App {
 	t.Helper()
 
+	return newPromptSendTestAppWithConfig(t, client, promptSendTestConfig())
+}
+
+func newPromptSendTestAppWithConfig(
+	t *testing.T,
+	client assistant.CompletionClient,
+	runtimeConfig *config.Config,
+) *App {
+	t.Helper()
+
+	connection := newPromptSendTestConnection(t)
+	manager := extension.NewManager(slog.Default())
+	t.Cleanup(manager.Shutdown)
+	cache := assistant.NewResponseCache(false, 1, time.Minute)
+	t.Cleanup(cache.Shutdown)
+	registry := newPromptSendTestModelRegistry(t)
+	sessionRepository := database.NewSessionRepository(connection)
+	settingsRepository := database.NewDocumentRepository(connection)
+	runtime := assistant.NewRuntime(
+		runtimeConfig,
+		sessionRepository,
+		manager,
+		cache,
+		event.NewBus(slog.Default()),
+		registry,
+		client,
+		slog.Default(),
+	)
+	app := newRenderTestApp(t)
+	app.runtime = runtime
+	app.settings = settingsRepository
+	app.cwd = t.TempDir()
+	app.cfg = runtimeConfig
+
+	return app
+}
+
+func newPromptSendTestConnection(t *testing.T) *sql.DB {
+	t.Helper()
+
 	connection, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
@@ -333,10 +373,12 @@ func newPromptSendTestApp(t *testing.T, client assistant.CompletionClient) *App 
 		t.Fatalf("migrate sqlite: %v", migrateErr)
 	}
 
-	manager := extension.NewManager(slog.Default())
-	t.Cleanup(manager.Shutdown)
-	cache := assistant.NewResponseCache(false, 1, time.Minute)
-	t.Cleanup(cache.Shutdown)
+	return connection
+}
+
+func newPromptSendTestModelRegistry(t *testing.T) *model.Registry {
+	t.Helper()
+
 	authStorage, err := auth.NewInMemoryStorage(context.Background(), map[string]auth.Credential{
 		promptSendTestProvider: {
 			OAuth:     nil,
@@ -352,48 +394,32 @@ func newPromptSendTestApp(t *testing.T, client assistant.CompletionClient) *App 
 	if err != nil {
 		t.Fatalf("create auth storage: %v", err)
 	}
-	registry := model.NewRegistry(&model.RegistryOptions{
+
+	return model.NewRegistry(&model.RegistryOptions{
 		ConfigSource: nil,
 		Auth:         authStorage,
 		ModelsPath:   "",
-		BuiltIns: []model.Model{
-			{
-				ThinkingLevelMap: nil,
-				Headers:          nil,
-				Compat:           nil,
-				Provider:         promptSendTestProvider,
-				ID:               promptSendTestModel,
-				Name:             promptSendTestModel,
-				API:              "openai-completions",
-				BaseURL:          "https://example.invalid/v1",
-				Input:            []model.InputMode{model.InputText},
-				Cost:             model.Cost{Input: 0, Output: 0, CacheRead: 0, CacheWrite: 0},
-				ContextWindow:    1000,
-				MaxTokens:        0,
-				Reasoning:        false,
-			},
-		},
-		Discovery: disabledModelDiscovery(),
+		BuiltIns:     []model.Model{promptSendTestModelDefinition()},
+		Discovery:    disabledModelDiscovery(),
 	})
-	sessionRepository := database.NewSessionRepository(connection)
-	settingsRepository := database.NewDocumentRepository(connection)
-	runtime := assistant.NewRuntime(
-		promptSendTestConfig(),
-		sessionRepository,
-		manager,
-		cache,
-		event.NewBus(slog.Default()),
-		registry,
-		client,
-		slog.Default(),
-	)
-	app := newRenderTestApp(t)
-	app.runtime = runtime
-	app.settings = settingsRepository
-	app.cwd = t.TempDir()
-	app.cfg = promptSendTestConfig()
+}
 
-	return app
+func promptSendTestModelDefinition() model.Model {
+	return model.Model{
+		ThinkingLevelMap: nil,
+		Headers:          nil,
+		Compat:           nil,
+		Provider:         promptSendTestProvider,
+		ID:               promptSendTestModel,
+		Name:             promptSendTestModel,
+		API:              "openai-completions",
+		BaseURL:          "https://example.invalid/v1",
+		Input:            []model.InputMode{model.InputText},
+		Cost:             model.Cost{Input: 0, Output: 0, CacheRead: 0, CacheWrite: 0},
+		ContextWindow:    1000,
+		MaxTokens:        0,
+		Reasoning:        false,
+	}
 }
 
 func promptSendTestConfig() *config.Config {

--- a/internal/terminal/token_usage.go
+++ b/internal/terminal/token_usage.go
@@ -8,10 +8,25 @@ import (
 )
 
 func (app *App) applyTokenUsage(usage *model.TokenUsage) {
+	app.applyTokenUsageEvent(usage, false)
+}
+
+func (app *App) applyTokenUsageEvent(usage *model.TokenUsage, snapshot bool) {
 	if usage == nil || !usage.HasAny() {
 		return
 	}
+	if snapshot {
+		app.tokenUsage = cloneTerminalUsage(*usage)
+		return
+	}
 	app.tokenUsage = mergeTerminalUsage(app.tokenUsage, *usage)
+}
+
+func cloneTerminalUsage(usage model.TokenUsage) model.TokenUsage {
+	usage.Breakdown = cloneTokenBreakdown(usage.Breakdown)
+	usage.TopContributors = cloneTokenContributors(usage.TopContributors)
+
+	return usage
 }
 
 func mergeTerminalUsage(current, next model.TokenUsage) model.TokenUsage {
@@ -60,7 +75,7 @@ func formatContextUsage(usage model.TokenUsage) string {
 	case usage.ContextTokens > 0:
 		return "ctx " + compactCount(usage.ContextTokens)
 	case window > 0:
-		return "ctx 0/" + compactCount(window)
+		return ""
 	default:
 		return ""
 	}

--- a/internal/terminal/token_usage_export_test.go
+++ b/internal/terminal/token_usage_export_test.go
@@ -49,6 +49,10 @@ func (app *App) ApplyTokenUsageForTest(usage *model.TokenUsage) {
 	app.applyTokenUsage(usage)
 }
 
+func (app *App) ApplyTokenUsageSnapshotForTest(usage *model.TokenUsage) {
+	app.applyTokenUsageEvent(usage, true)
+}
+
 func (app *App) TokenStatusTextForTest() string {
 	return app.tokenStatusText()
 }

--- a/internal/terminal/token_usage_test.go
+++ b/internal/terminal/token_usage_test.go
@@ -77,6 +77,60 @@ func TestMergeTerminalUsagePreservesEstimatedContext(t *testing.T) {
 	}, terminal.MergeTerminalUsageForTest(current, next))
 }
 
+func TestApplyTokenUsageSnapshotAllowsContextDecrease(t *testing.T) {
+	t.Parallel()
+
+	app := terminal.NewAppForTest()
+	app.ApplyTokenUsageForTest(&model.TokenUsage{
+		Breakdown:       nil,
+		TopContributors: nil,
+		ContextWindow:   100_000,
+		ContextTokens:   80_000,
+		InputTokens:     80_000,
+		OutputTokens:    0,
+	})
+	usage := model.TokenUsage{
+		Breakdown: map[string]int{testBreakdownHistory: 5_000},
+		TopContributors: []model.TokenContributor{
+			{Label: "summary", Role: "", Preview: "", Tokens: 5_000, Chars: 20_000},
+		},
+		ContextWindow: 100_000,
+		ContextTokens: 12_000,
+		InputTokens:   12_000,
+		OutputTokens:  0,
+	}
+
+	app.ApplyTokenUsageSnapshotForTest(&usage)
+	usage.Breakdown[testBreakdownHistory] = 99
+	usage.TopContributors[0].Label = "mutated"
+
+	assert.Equal(t, model.TokenUsage{
+		Breakdown: map[string]int{testBreakdownHistory: 5_000},
+		TopContributors: []model.TokenContributor{
+			{Label: "summary", Role: "", Preview: "", Tokens: 5_000, Chars: 20_000},
+		},
+		ContextWindow: 100_000,
+		ContextTokens: 12_000,
+		InputTokens:   12_000,
+		OutputTokens:  0,
+	}, app.TokenUsageForTest())
+}
+
+func TestFormatTokenStatusHidesWindowOnlyUsage(t *testing.T) {
+	t.Parallel()
+
+	usage := model.TokenUsage{
+		Breakdown:       nil,
+		TopContributors: nil,
+		ContextWindow:   9_000,
+		ContextTokens:   0,
+		InputTokens:     0,
+		OutputTokens:    0,
+	}
+
+	assert.Empty(t, terminal.FormatTokenStatusForTest(usage))
+}
+
 func TestResetMessagesClearsTokenUsage(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Keep the previous context usage visible while prompts are in flight, hide misleading zero-token window-only usage, and emit fresh usage snapshots after manual and automatic compaction so the footer reflects real context reductions.