### PR TITLE
fix(context): accept blank provider responses

### DIFF
--- a/internal/assistant/anthropic.go
+++ b/internal/assistant/anthropic.go
@@ -56,7 +56,7 @@ func (client *HTTPCompletionClient) advanceAnthropicLoop(
 		if fallback := textToolCallsFromText(providerResult.Text); len(fallback) > 0 {
 			providerResult.ToolCalls = fallback
 		} else {
-			return finishTextResult(state.result, providerResult.Text, "anthropic_empty")
+			return finishTextResult(state.result, providerResult.Text)
 		}
 	}
 	events := executeAnthropicToolCalls(ctx, request, providerResult.ToolCalls)

--- a/internal/assistant/empty_response_internal_test.go
+++ b/internal/assistant/empty_response_internal_test.go
@@ -1,0 +1,66 @@
+package assistant
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/model"
+)
+
+func TestFinishTextResultAllowsEmptyText(t *testing.T) {
+	t.Parallel()
+
+	result := &CompletionResult{Text: "", Thinking: nil, ToolEvents: nil, Usage: model.EmptyTokenUsage()}
+	finished, err := finishTextResult(result, "   ")
+
+	require.NoError(t, err)
+	assert.True(t, finished)
+	assert.Empty(t, result.Text)
+}
+
+func TestProviderParsersAllowSuccessfulEmptyResponses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		parse func([]byte) (*providerResult, error)
+		name  string
+		body  string
+	}{
+		{
+			name:  "openai chat no choices",
+			body:  `{"usage":{"prompt_tokens":7,"completion_tokens":0,"total_tokens":7}}`,
+			parse: parseOpenAIChatResult,
+		},
+		{
+			name:  "openai chat blank content",
+			body:  `{"choices":[{"message":{"content":"   "}}]}`,
+			parse: parseOpenAIChatResult,
+		},
+		{
+			name:  "openai responses blank output",
+			body:  `{"output":[],"usage":{"input_tokens":5,"output_tokens":0,"total_tokens":5}}`,
+			parse: parseOpenAIResponseResult,
+		},
+		{
+			name:  "anthropic empty content",
+			body:  `{"content":[],"usage":{"input_tokens":3,"output_tokens":0}}`,
+			parse: parseAnthropicResult,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := testCase.parse(json.RawMessage(testCase.body))
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Empty(t, result.Text)
+			assert.Empty(t, result.ToolCalls)
+		})
+	}
+}

--- a/internal/assistant/errors_extra.go
+++ b/internal/assistant/errors_extra.go
@@ -1,7 +1,0 @@
-package assistant
-
-import "github.com/samber/oops"
-
-func emptyProviderResponseError(code string) error {
-	return oops.In("assistant").Code(code).Errorf("provider returned an empty response")
-}

--- a/internal/assistant/openai_chat.go
+++ b/internal/assistant/openai_chat.go
@@ -64,7 +64,7 @@ func (client *HTTPCompletionClient) advanceOpenAIChatLoop(
 		if fallback := textToolCallsFromText(providerResult.Text); len(fallback) > 0 {
 			providerResult.ToolCalls = fallback
 		} else {
-			return finishTextResult(state.result, providerResult.Text, "openai_chat_empty")
+			return finishTextResult(state.result, providerResult.Text)
 		}
 	}
 	events := executeOpenAIChatToolCalls(ctx, request, providerResult.ToolCalls)
@@ -157,7 +157,13 @@ func parseOpenAIChatResult(content []byte) (*providerResult, error) {
 		return nil, providerErrorToOops("openai_chat_error", &response.Error)
 	}
 	if len(response.Choices) == 0 {
-		return nil, emptyProviderResponseError("openai_chat_empty")
+		return &providerResult{
+			Text:        "",
+			OutputItems: nil,
+			Thinking:    nil,
+			ToolCalls:   nil,
+			Usage:       usageFromObject(response.Usage),
+		}, nil
 	}
 	message := response.Choices[0].Message
 	calls := make([]toolCall, 0, len(message.ToolCalls))

--- a/internal/assistant/openai_responses.go
+++ b/internal/assistant/openai_responses.go
@@ -62,9 +62,6 @@ func (client *HTTPCompletionClient) completeResponsesLoop(
 			return nil, err
 		}
 		if len(providerResult.ToolCalls) == 0 {
-			if strings.TrimSpace(providerResult.Text) == "" {
-				return nil, oops.In("assistant").Code("responses_empty").Errorf("provider returned an empty response")
-			}
 			result.Text = strings.TrimSpace(providerResult.Text)
 			return result, nil
 		}

--- a/internal/assistant/retry.go
+++ b/internal/assistant/retry.go
@@ -191,10 +191,7 @@ func providerErrorStatus(err error) (int, bool) {
 
 func retryableProviderCode(code string) bool {
 	switch code {
-	case "openai_chat_empty",
-		"anthropic_empty",
-		"responses_empty",
-		"responses_stream_incomplete",
+	case "responses_stream_incomplete",
 		"responses_http",
 		"provider_http",
 		"responses_read",
@@ -324,8 +321,6 @@ func retryableProviderMessage(message string) bool {
 		"websocket closed",
 		"websocket error",
 		"terminated",
-		"empty response",
-		"returned an empty response",
 	}
 	for _, pattern := range retryable {
 		if strings.Contains(message, pattern) {

--- a/internal/assistant/retry_test.go
+++ b/internal/assistant/retry_test.go
@@ -55,16 +55,6 @@ func TestShouldRetryModelError(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "empty provider response code",
-			err:  oops.In("assistant").Code("responses_empty").Errorf("provider returned an empty response"),
-			want: true,
-		},
-		{
-			name: "empty provider response message",
-			err:  errors.New("provider returned an empty response"),
-			want: true,
-		},
-		{
 			name: "provider decode code",
 			err:  oops.In("assistant").Code("openai_response_decode").Errorf("decode response"),
 			want: false,

--- a/internal/assistant/runtime_test.go
+++ b/internal/assistant/runtime_test.go
@@ -198,23 +198,23 @@ func TestRuntime_PromptRetriesTransientModelErrors(t *testing.T) {
 	assert.Equal(t, assistant.RetryEventEnd, retryEvents[1].Kind)
 }
 
-func TestRuntime_PromptRetriesWrappedEmptyProviderResponse(t *testing.T) {
+func TestRuntime_PromptPersistsEmptyProviderResponse(t *testing.T) {
 	t.Parallel()
 
-	client := &retryCompletionClient{
-		err:               errors.New("[system] provider returned an empty response"),
-		response:          recoveredResponseText,
-		attempts:          0,
-		failuresRemaining: 1,
-	}
-	runtime, _ := newTestRuntimeWithClient(t, client)
-	request := newRuntimePromptRequest(testRuntimeCWD, "retry empty", "")
+	client := &emptyCompletionClient{attempts: 0}
+	runtime, repository := newTestRuntimeWithClient(t, client)
+	request := newRuntimePromptRequest(testRuntimeCWD, "blank is ok", "")
 
 	response, err := runtime.Prompt(context.Background(), request)
 
 	require.NoError(t, err)
-	assert.Equal(t, recoveredResponseText+" for retry empty", response.Text)
-	assert.Equal(t, 2, client.attempts)
+	assert.Empty(t, response.Text)
+	assert.Equal(t, 1, client.attempts)
+	messages, err := repository.Messages(context.Background(), request.SessionID)
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+	assert.Equal(t, database.RoleAssistant, messages[1].Role)
+	assert.Empty(t, messages[1].Content)
 }
 
 func TestRuntime_PromptRetriesProviderStreamError(t *testing.T) {
@@ -543,6 +543,10 @@ type retryCompletionClient struct {
 
 type partialFailureCompletionClient struct{}
 
+type emptyCompletionClient struct {
+	attempts int
+}
+
 func (client *capturingCompletionClient) Complete(
 	ctx context.Context,
 	request *assistant.CompletionRequest,
@@ -568,6 +572,20 @@ func (client *retryCompletionClient) Complete(
 
 	return &assistant.CompletionResult{
 		Text:       client.response + " for " + request.Messages[len(request.Messages)-1].Content,
+		Thinking:   nil,
+		ToolEvents: nil,
+		Usage:      model.EmptyTokenUsage(),
+	}, nil
+}
+
+func (client *emptyCompletionClient) Complete(
+	_ context.Context,
+	_ *assistant.CompletionRequest,
+) (*assistant.CompletionResult, error) {
+	client.attempts++
+
+	return &assistant.CompletionResult{
+		Text:       "",
 		Thinking:   nil,
 		ToolEvents: nil,
 		Usage:      model.EmptyTokenUsage(),

--- a/internal/assistant/tool_loop.go
+++ b/internal/assistant/tool_loop.go
@@ -171,12 +171,8 @@ func toolOutputForCall(callID, resultText, detailsJSON string) map[string]any {
 	}
 }
 
-func finishTextResult(result *CompletionResult, text, emptyCode string) (bool, error) {
-	trimmed := strings.TrimSpace(text)
-	if trimmed == "" {
-		return false, emptyProviderResponseError(emptyCode)
-	}
-	result.Text = trimmed
+func finishTextResult(result *CompletionResult, text string) (bool, error) {
+	result.Text = strings.TrimSpace(text)
 
 	return true, nil
 }


### PR DESCRIPTION
## Summary
- treat successful blank provider outputs as valid assistant responses
- stop retrying generic empty-response parser results
- add coverage for blank OpenAI/Anthropic responses and runtime persistence

## Tests
- go test ./internal/assistant
- golangci-lint run ./internal/assistant
- task ci