### PR TITLE
feat(context): keep dynamic compaction tail

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -51,8 +51,10 @@ context:
   output_reserve_tokens: 0
   provider_reserve_tokens: 2048
   safety_margin_tokens: 8192
-  # Recent history retained verbatim during /compact; reserves above still apply to provider requests.
-  keep_recent_tokens: 20000
+  # Recent history retained verbatim during /compact.
+  # 0 keeps the newest one third of the selected model context window; positive values force a fixed tail.
+  # Reserves above still apply to provider requests.
+  keep_recent_tokens: 0
 
 models:
   discovery:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -52,8 +52,9 @@ context:
   provider_reserve_tokens: 2048
   safety_margin_tokens: 8192
   # Recent history retained verbatim during /compact.
-  # 0 keeps the newest one third of the selected model context window; positive values force a fixed tail.
-  # Reserves above still apply to provider requests.
+  # 0 keeps the newest one third of the selected model context window; if the window is unknown,
+  # librecode falls back to the fixed tail from internal/contextwindow/recent_tail.go.
+  # Positive values force a fixed tail. Reserves above still apply to provider requests.
   keep_recent_tokens: 0
 
 models:

--- a/internal/assistant/context_compaction.go
+++ b/internal/assistant/context_compaction.go
@@ -49,7 +49,8 @@ func (runtime *Runtime) CompactSessionFrom(
 	if err != nil {
 		return nil, err
 	}
-	plan, err := compaction.PlanBranch(branch, runtime.cfg.Context.KeepRecentTokens, contextwindow.EstimateTokens)
+	keepRecentTokens := runtime.compactionKeepRecentTokens(selectedModel)
+	plan, err := compaction.PlanBranch(branch, keepRecentTokens, contextwindow.EstimateTokens)
 	if err != nil {
 		return nil, err
 	}
@@ -63,6 +64,18 @@ func (runtime *Runtime) CompactSessionFrom(
 type compactionProviderInput struct {
 	selectedModel *model.Model
 	auth          model.RequestAuth
+}
+
+func (runtime *Runtime) compactionKeepRecentTokens(selectedModel *model.Model) int {
+	contextWindow := 0
+	if selectedModel != nil {
+		contextWindow = selectedModel.ContextWindow
+	}
+
+	return contextwindow.RecentTailTarget(contextwindow.RecentTailInput{
+		ExplicitKeepRecentTokens: runtime.cfg.Context.KeepRecentTokens,
+		ContextWindow:            contextWindow,
+	})
 }
 
 func (runtime *Runtime) compactSessionWithPlan(

--- a/internal/assistant/context_compaction_test.go
+++ b/internal/assistant/context_compaction_test.go
@@ -71,6 +71,59 @@ func TestRuntime_CompactSessionSummarizesOldHistoryAndKeepsTail(t *testing.T) {
 	assert.Equal(t, "recent assistant tail", contextEntity.Messages[2].Content)
 }
 
+func TestRuntime_CompactSessionUsesDynamicModelContextTail(t *testing.T) {
+	t.Parallel()
+
+	client := &compactionCompleter{summary: compactedWorkSummary, requests: nil}
+	runtime, repository := newCompactionRuntimeWithKeepRecentTokens(t, client, 0)
+	ctx := context.Background()
+	session, err := repository.CreateSession(ctx, testRuntimeCWD, "compact", "")
+	require.NoError(t, err)
+	first := appendRuntimeTestMessage(
+		t,
+		repository,
+		session.ID,
+		nil,
+		database.RoleUser,
+		repeatedTokenEstimate(10_000),
+	)
+	second := appendRuntimeTestMessage(
+		t,
+		repository,
+		session.ID,
+		&first.ID,
+		database.RoleAssistant,
+		repeatedTokenEstimate(10_000),
+	)
+	third := appendRuntimeTestMessage(
+		t,
+		repository,
+		session.ID,
+		&second.ID,
+		database.RoleUser,
+		repeatedTokenEstimate(15_000),
+	)
+	fourth := appendRuntimeTestMessage(
+		t,
+		repository,
+		session.ID,
+		&third.ID,
+		database.RoleAssistant,
+		repeatedTokenEstimate(15_000),
+	)
+
+	entry, err := runtime.CompactSession(ctx, session.ID, testRuntimeCWD)
+
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.Equal(t, second.ID, entry.CompactionFirstKeptEntryID)
+	require.NotNil(t, entry.ParentID)
+	assert.Equal(t, fourth.ID, *entry.ParentID)
+	require.Len(t, client.requests, 1)
+	require.Len(t, client.requests[0].Messages, 1)
+	assert.Equal(t, first.Message.Content, client.requests[0].Messages[0].Content)
+}
+
 func TestRuntime_CompactSessionChainsNextPromptFromCompactionEntry(t *testing.T) {
 	t.Parallel()
 
@@ -324,6 +377,10 @@ func TestRuntime_CompactSessionPreservesFileOperations(t *testing.T) {
 	operations, ok := details["file_operations"].([]any)
 	require.True(t, ok)
 	assert.Len(t, operations, 3)
+}
+
+func repeatedTokenEstimate(tokens int) string {
+	return strings.Repeat("x", tokens*4)
 }
 
 func newCompactionRuntimeWithKeepRecentTokens(

--- a/internal/assistant/context_compaction_test.go
+++ b/internal/assistant/context_compaction_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/omarluq/librecode/internal/assistant"
+	"github.com/omarluq/librecode/internal/auth"
 	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/event"
 	"github.com/omarluq/librecode/internal/model"
 )
 
@@ -74,54 +76,78 @@ func TestRuntime_CompactSessionSummarizesOldHistoryAndKeepsTail(t *testing.T) {
 func TestRuntime_CompactSessionUsesDynamicModelContextTail(t *testing.T) {
 	t.Parallel()
 
-	client := &compactionCompleter{summary: compactedWorkSummary, requests: nil}
-	runtime, repository := newCompactionRuntimeWithKeepRecentTokens(t, client, 0)
-	ctx := context.Background()
-	session, err := repository.CreateSession(ctx, testRuntimeCWD, "compact", "")
-	require.NoError(t, err)
-	first := appendRuntimeTestMessage(
-		t,
-		repository,
-		session.ID,
-		nil,
-		database.RoleUser,
-		repeatedTokenEstimate(10_000),
-	)
-	second := appendRuntimeTestMessage(
-		t,
-		repository,
-		session.ID,
-		&first.ID,
-		database.RoleAssistant,
-		repeatedTokenEstimate(10_000),
-	)
-	third := appendRuntimeTestMessage(
-		t,
-		repository,
-		session.ID,
-		&second.ID,
-		database.RoleUser,
-		repeatedTokenEstimate(15_000),
-	)
-	fourth := appendRuntimeTestMessage(
-		t,
-		repository,
-		session.ID,
-		&third.ID,
-		database.RoleAssistant,
-		repeatedTokenEstimate(15_000),
-	)
+	testCases := []struct {
+		name                    string
+		messageTokens           []int
+		keepRecentTokens        int
+		contextWindow           int
+		wantFirstKeptEntryIndex int
+		wantSummaryMessageCount int
+	}{
+		{
+			name:                    "dynamic keeps newest third of model context window",
+			keepRecentTokens:        0,
+			contextWindow:           100_000,
+			messageTokens:           []int{10_000, 10_000, 15_000, 15_000},
+			wantFirstKeptEntryIndex: 1,
+			wantSummaryMessageCount: 1,
+		},
+		{
+			name:                    "explicit override wins over model context window",
+			keepRecentTokens:        10,
+			contextWindow:           100_000,
+			messageTokens:           []int{10_000, 10_000, 15_000, 15_000},
+			wantFirstKeptEntryIndex: 3,
+			wantSummaryMessageCount: 2,
+		},
+		{
+			name:                    "unknown context window uses fixed fallback tail",
+			keepRecentTokens:        0,
+			contextWindow:           0,
+			messageTokens:           []int{10_000, 10_000, 15_000, 15_000},
+			wantFirstKeptEntryIndex: 2,
+			wantSummaryMessageCount: 2,
+		},
+		{
+			name:                    "tiny context window still keeps a positive recent tail",
+			keepRecentTokens:        0,
+			contextWindow:           2,
+			messageTokens:           []int{10_000, 10_000, 15_000, 15_000},
+			wantFirstKeptEntryIndex: 3,
+			wantSummaryMessageCount: 2,
+		},
+	}
 
-	entry, err := runtime.CompactSession(ctx, session.ID, testRuntimeCWD)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-	require.NoError(t, err)
-	require.NotNil(t, entry)
-	assert.Equal(t, second.ID, entry.CompactionFirstKeptEntryID)
-	require.NotNil(t, entry.ParentID)
-	assert.Equal(t, fourth.ID, *entry.ParentID)
-	require.Len(t, client.requests, 1)
-	require.Len(t, client.requests[0].Messages, 1)
-	assert.Equal(t, first.Message.Content, client.requests[0].Messages[0].Content)
+			client := &compactionCompleter{summary: compactedWorkSummary, requests: nil}
+			runtime, repository := newCompactionRuntimeForTailPolicy(
+				t,
+				client,
+				testCase.keepRecentTokens,
+				testCase.contextWindow,
+			)
+			ctx := context.Background()
+			session, err := repository.CreateSession(ctx, testRuntimeCWD, "compact", "")
+			require.NoError(t, err)
+			entries := appendRuntimeTestTokenMessages(t, repository, session.ID, testCase.messageTokens)
+
+			entry, err := runtime.CompactSession(ctx, session.ID, testRuntimeCWD)
+
+			require.NoError(t, err)
+			require.NotNil(t, entry)
+			assert.Equal(t, entries[testCase.wantFirstKeptEntryIndex].ID, entry.CompactionFirstKeptEntryID)
+			require.NotNil(t, entry.ParentID)
+			assert.Equal(t, entries[len(entries)-1].ID, *entry.ParentID)
+			require.Len(t, client.requests, 1)
+			require.Len(t, client.requests[0].Messages, testCase.wantSummaryMessageCount)
+			for index := range client.requests[0].Messages {
+				assert.Equal(t, entries[index].Message.Content, client.requests[0].Messages[index].Content)
+			}
+		})
+	}
 }
 
 func TestRuntime_CompactSessionChainsNextPromptFromCompactionEntry(t *testing.T) {
@@ -390,7 +416,18 @@ func newCompactionRuntimeWithKeepRecentTokens(
 ) (*assistant.Runtime, *database.SessionRepository) {
 	t.Helper()
 
-	runtime, repository := newTestRuntimeWithClient(t, client)
+	return newCompactionRuntimeForTailPolicy(t, client, keepRecentTokens, 100_000)
+}
+
+func newCompactionRuntimeForTailPolicy(
+	t *testing.T,
+	client assistant.Completer,
+	keepRecentTokens int,
+	contextWindow int,
+) (*assistant.Runtime, *database.SessionRepository) {
+	t.Helper()
+
+	_, repository := newTestRuntimeWithClient(t, client)
 	runtimeConfig := testConfig()
 	runtimeConfig.Context.KeepRecentTokens = keepRecentTokens
 
@@ -399,11 +436,55 @@ func newCompactionRuntimeWithKeepRecentTokens(
 		Sessions:   repository,
 		Extensions: nil,
 		Cache:      assistant.NewResponseCache(false, 1, time.Minute),
-		Events:     runtime.EventBus(),
-		Models:     runtime.ModelRegistry(),
+		Events:     event.NewBus(nil),
+		Models:     newCompactionTestRegistry(t, contextWindow),
 		Client:     client,
 		Logger:     nil,
 	}), repository
+}
+
+func appendRuntimeTestTokenMessages(
+	t *testing.T,
+	repository *database.SessionRepository,
+	sessionID string,
+	messageTokens []int,
+) []*database.EntryEntity {
+	t.Helper()
+
+	entries := make([]*database.EntryEntity, 0, len(messageTokens))
+	roles := []database.Role{database.RoleUser, database.RoleAssistant}
+	var parentID *string
+	for index, tokens := range messageTokens {
+		entry := appendRuntimeTestMessage(
+			t,
+			repository,
+			sessionID,
+			parentID,
+			roles[index%len(roles)],
+			repeatedTokenEstimate(tokens),
+		)
+		entries = append(entries, entry)
+		parentID = &entry.ID
+	}
+
+	return entries
+}
+
+func newCompactionTestRegistry(t *testing.T, contextWindow int) *model.Registry {
+	t.Helper()
+
+	storage, err := auth.NewInMemoryStorage(context.Background(), map[string]auth.Credential{
+		testRuntimeProvider: testProviderCredential(),
+	})
+	require.NoError(t, err)
+
+	return model.NewRegistry(&model.RegistryOptions{
+		ConfigReader: nil,
+		Auth:         storage,
+		ModelsPath:   "",
+		BuiltIns:     []model.Model{testRuntimeModelWithContextWindowAndMaxTokens(contextWindow, 0)},
+		Discovery:    disabledModelDiscovery(),
+	})
 }
 
 func appendRuntimeTestMessage(

--- a/internal/compaction/plan.go
+++ b/internal/compaction/plan.go
@@ -13,8 +13,7 @@ import (
 )
 
 const (
-	defaultKeepRecentTokens = 20_000
-	summaryPrompt           = `Summarize the conversation history below for a coding agent that will continue
+	summaryPrompt = `Summarize the conversation history below for a coding agent that will continue
 this same session.
 
 Preserve:
@@ -69,7 +68,7 @@ func PlanBranch(
 		return Plan{}, NothingToDoError("no new history to compact after the latest compaction")
 	}
 	if keepRecentTokens <= 0 {
-		keepRecentTokens = defaultKeepRecentTokens
+		return Plan{}, NothingToDoError("recent tail token target must be greater than zero")
 	}
 	if countTokens == nil {
 		countTokens = countRunesAsTokens

--- a/internal/compaction/plan_internal_test.go
+++ b/internal/compaction/plan_internal_test.go
@@ -45,7 +45,7 @@ func planCompactionCases() []planCompactionCase {
 		previousKeptBoundaryCase(),
 		turnBoundaryCase(),
 		splitTurnSummaryCase(),
-		defaultKeepRecentTokensCase(),
+		invalidKeepRecentTokensCase(),
 		latestCompactionCase(),
 	}
 }
@@ -135,26 +135,25 @@ func assertSplitTurnSummaryPlan(t *testing.T, plan *Plan) {
 	}
 }
 
-func defaultKeepRecentTokensCase() planCompactionCase {
+func invalidKeepRecentTokensCase() planCompactionCase {
 	return planCompactionCase{
-		assertFn: assertDefaultKeepRecentTokensPlan,
+		assertFn: assertInvalidKeepRecentTokensPlan,
 		entries: []database.EntryEntity{
 			messageEntry("user-1", database.RoleUser, strings.Repeat("old ", 30_000)),
 			messageEntry("assistant-1", database.RoleAssistant, strings.Repeat("old ", 30_000)),
 			messageEntry("user-2", database.RoleUser, "second user"),
 			messageEntry("assistant-2", database.RoleAssistant, "second assistant"),
 		},
-		name:    "falls back to default keep recent tokens",
-		wantErr: "",
+		name:    "rejects missing keep recent token target",
+		wantErr: "recent tail token target must be greater than zero",
 		keep:    0,
 	}
 }
 
-func assertDefaultKeepRecentTokensPlan(t *testing.T, plan *Plan) {
+func assertInvalidKeepRecentTokensPlan(t *testing.T, plan *Plan) {
 	t.Helper()
 
-	assert.NotEmpty(t, plan.SummarizedEntryIDs)
-	assert.NotEmpty(t, plan.KeptEntryIDs)
+	assert.Empty(t, plan.FirstKeptEntryID)
 }
 
 func latestCompactionCase() planCompactionCase {

--- a/internal/compaction/plan_internal_test.go
+++ b/internal/compaction/plan_internal_test.go
@@ -137,7 +137,7 @@ func assertSplitTurnSummaryPlan(t *testing.T, plan *Plan) {
 
 func invalidKeepRecentTokensCase() planCompactionCase {
 	return planCompactionCase{
-		assertFn: assertInvalidKeepRecentTokensPlan,
+		assertFn: assertNoCompactionPlan,
 		entries: []database.EntryEntity{
 			messageEntry("user-1", database.RoleUser, strings.Repeat("old ", 30_000)),
 			messageEntry("assistant-1", database.RoleAssistant, strings.Repeat("old ", 30_000)),
@@ -150,7 +150,7 @@ func invalidKeepRecentTokensCase() planCompactionCase {
 	}
 }
 
-func assertInvalidKeepRecentTokensPlan(t *testing.T, plan *Plan) {
+func assertNoCompactionPlan(t *testing.T, plan *Plan) {
 	t.Helper()
 
 	assert.Empty(t, plan.FirstKeptEntryID)
@@ -167,18 +167,12 @@ func latestCompactionCase() planCompactionCase {
 	latestSummary.CompactionFirstKeptEntryID = firstUser.ID
 
 	return planCompactionCase{
-		assertFn: assertLatestCompactionPlan,
+		assertFn: assertNoCompactionPlan,
 		entries:  []database.EntryEntity{firstUser, latestSummary},
 		name:     "rejects latest compaction",
 		wantErr:  "no new history to compact",
 		keep:     1,
 	}
-}
-
-func assertLatestCompactionPlan(t *testing.T, plan *Plan) {
-	t.Helper()
-
-	assert.Empty(t, plan.FirstKeptEntryID)
 }
 
 func TestPlanBranchFromFirstKeptUsesSelectedBoundary(t *testing.T) {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -100,7 +100,7 @@ func setDefaults(viperInstance *viper.Viper) {
 	viperInstance.SetDefault("context.output_reserve_tokens", 0)
 	viperInstance.SetDefault("context.provider_reserve_tokens", 2048)
 	viperInstance.SetDefault("context.safety_margin_tokens", 8192)
-	viperInstance.SetDefault("context.keep_recent_tokens", 20000)
+	viperInstance.SetDefault("context.keep_recent_tokens", 0)
 	viperInstance.SetDefault("models.discovery.enabled", true)
 	viperInstance.SetDefault("models.discovery.source_url", "https://models.dev/api.json")
 	viperInstance.SetDefault("models.discovery.cache_ttl", 24*time.Hour)

--- a/internal/contextwindow/recent_tail.go
+++ b/internal/contextwindow/recent_tail.go
@@ -1,0 +1,24 @@
+package contextwindow
+
+const (
+	// defaultKeepRecentTokens is used when no explicit override or model context window is available.
+	defaultKeepRecentTokens = 20_000
+)
+
+// RecentTailInput describes the policy inputs for selecting the verbatim tail kept during compaction.
+type RecentTailInput struct {
+	ExplicitKeepRecentTokens int
+	ContextWindow            int
+}
+
+// RecentTailTarget returns the number of newest tokens to keep untouched during compaction.
+func RecentTailTarget(input RecentTailInput) int {
+	if input.ExplicitKeepRecentTokens > 0 {
+		return input.ExplicitKeepRecentTokens
+	}
+	if input.ContextWindow <= 0 {
+		return defaultKeepRecentTokens
+	}
+
+	return max(1, input.ContextWindow/3)
+}

--- a/internal/contextwindow/recent_tail_internal_test.go
+++ b/internal/contextwindow/recent_tail_internal_test.go
@@ -1,0 +1,66 @@
+package contextwindow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecentTailTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input RecentTailInput
+		want  int
+	}{
+		{
+			name: "explicit override wins",
+			input: RecentTailInput{
+				ExplicitKeepRecentTokens: 12_345,
+				ContextWindow:            272_000,
+			},
+			want: 12_345,
+		},
+		{
+			name: "codex sized context keeps newest third",
+			input: RecentTailInput{
+				ExplicitKeepRecentTokens: 0,
+				ContextWindow:            272_000,
+			},
+			want: 90_666,
+		},
+		{
+			name: "million token context keeps newest third",
+			input: RecentTailInput{
+				ExplicitKeepRecentTokens: 0,
+				ContextWindow:            1_000_000,
+			},
+			want: 333_333,
+		},
+		{
+			name: "unknown context falls back to fixed tail",
+			input: RecentTailInput{
+				ExplicitKeepRecentTokens: 0,
+				ContextWindow:            0,
+			},
+			want: defaultKeepRecentTokens,
+		},
+		{
+			name: "tiny positive context keeps at least one token",
+			input: RecentTailInput{
+				ExplicitKeepRecentTokens: 0,
+				ContextWindow:            2,
+			},
+			want: 1,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, testCase.want, RecentTailTarget(testCase.input))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- default compaction now keeps the newest one-third of the selected model context window
- keep `context.keep_recent_tokens > 0` as an explicit fixed-tail override
- centralize recent-tail target selection in context window policy code
- keep the compaction planner policy-free by requiring a concrete keep target
- update config defaults and example documentation for dynamic mode

## Validation
- `go test ./internal/contextwindow ./internal/compaction ./internal/assistant`
- `golangci-lint run ./internal/contextwindow ./internal/compaction ./internal/assistant`
- `mise exec -- task ci`