### PR TITLE
fix(provider): preserve incomplete response output

### DIFF
--- a/internal/assistant/client.go
+++ b/internal/assistant/client.go
@@ -51,10 +51,11 @@ type CompletionRequest struct {
 
 // CompletionResult is an assistant-owned provider response plus model-visible side effects.
 type CompletionResult struct {
-	Text       string           `json:"text"`
-	Thinking   []string         `json:"thinking,omitempty"`
-	ToolEvents []ToolEvent      `json:"tool_events,omitempty"`
-	Usage      model.TokenUsage `json:"usage"`
+	FinishReason llm.FinishReason `json:"finish_reason,omitempty"`
+	Text         string           `json:"text"`
+	Thinking     []string         `json:"thinking,omitempty"`
+	ToolEvents   []ToolEvent      `json:"tool_events,omitempty"`
+	Usage        model.TokenUsage `json:"usage"`
 }
 
 // ToolCallEvent captures one requested tool call before execution.

--- a/internal/assistant/client_adapter.go
+++ b/internal/assistant/client_adapter.go
@@ -132,13 +132,20 @@ func thinkingLevelMapFromLLM(values map[string]*string) map[model.ThinkingLevel]
 
 func completionResultFromLLMResponse(response *llm.Response) *CompletionResult {
 	if response == nil {
-		return &CompletionResult{Text: "", Thinking: nil, ToolEvents: nil, Usage: model.EmptyTokenUsage()}
+		return &CompletionResult{
+			FinishReason: llm.FinishReasonUnknown,
+			Text:         "",
+			Thinking:     nil,
+			ToolEvents:   nil,
+			Usage:        model.EmptyTokenUsage(),
+		}
 	}
 	return &CompletionResult{
-		Text:       textFromLLMParts(response.Content),
-		Thinking:   thinkingFromLLMParts(response.Content),
-		ToolEvents: toolEventsFromLLMParts(response.Content),
-		Usage:      llmconv.UsageToModel(response.Usage),
+		FinishReason: response.FinishReason,
+		Text:         textFromLLMParts(response.Content),
+		Thinking:     thinkingFromLLMParts(response.Content),
+		ToolEvents:   toolEventsFromLLMParts(response.Content),
+		Usage:        llmconv.UsageToModel(response.Usage),
 	}
 }
 

--- a/internal/assistant/client_adapter_internal_test.go
+++ b/internal/assistant/client_adapter_internal_test.go
@@ -128,6 +128,7 @@ func TestCompletionResultFromLLMResponseConvertsPartsAndUsage(t *testing.T) {
 
 	converted := completionResultFromLLMResponse(response)
 	require.NotNil(t, converted)
+	assert.Equal(t, llm.FinishReasonStop, converted.FinishReason)
 	assert.Equal(t, "first \nsecond", converted.Text)
 	assert.Equal(t, []string{adapterThought}, converted.Thinking)
 	require.Len(t, converted.ToolEvents, 2)
@@ -140,6 +141,7 @@ func TestCompletionResultFromLLMResponseConvertsPartsAndUsage(t *testing.T) {
 
 	empty := completionResultFromLLMResponse(nil)
 	require.NotNil(t, empty)
+	assert.Equal(t, llm.FinishReasonUnknown, empty.FinishReason)
 	assert.Empty(t, empty.Text)
 	assert.Empty(t, empty.Thinking)
 	assert.Empty(t, empty.ToolEvents)

--- a/internal/assistant/context_auto_compaction_clients_test.go
+++ b/internal/assistant/context_auto_compaction_clients_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/samber/oops"
 
 	"github.com/omarluq/librecode/internal/assistant"
+	"github.com/omarluq/librecode/internal/llm"
 	"github.com/omarluq/librecode/internal/model"
 )
 
@@ -127,10 +128,11 @@ func testContextWindowError() error {
 
 func testCompletionResult(text string) *assistant.CompletionResult {
 	return &assistant.CompletionResult{
-		Text:       text,
-		Thinking:   nil,
-		ToolEvents: nil,
-		Usage:      model.EmptyTokenUsage(),
+		FinishReason: llm.FinishReasonStop,
+		Text:         text,
+		Thinking:     nil,
+		ToolEvents:   nil,
+		Usage:        model.EmptyTokenUsage(),
 	}
 }
 

--- a/internal/assistant/context_compaction_test.go
+++ b/internal/assistant/context_compaction_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/omarluq/librecode/internal/auth"
 	"github.com/omarluq/librecode/internal/database"
 	"github.com/omarluq/librecode/internal/event"
+	"github.com/omarluq/librecode/internal/llm"
 	"github.com/omarluq/librecode/internal/model"
 )
 
@@ -546,9 +547,10 @@ func (client *compactionCompleter) Complete(
 	}
 
 	return &assistant.CompletionResult{
-		Text:       text,
-		Thinking:   nil,
-		ToolEvents: nil,
-		Usage:      model.EmptyTokenUsage(),
+		FinishReason: llm.FinishReasonStop,
+		Text:         text,
+		Thinking:     nil,
+		ToolEvents:   nil,
+		Usage:        model.EmptyTokenUsage(),
 	}, nil
 }

--- a/internal/assistant/lifecycle_diagnostics.go
+++ b/internal/assistant/lifecycle_diagnostics.go
@@ -61,6 +61,7 @@ func providerResponseDiagnostics(
 	}
 	diagnostics := providerBaseDiagnostics(request, attempt)
 	diagnostics["response_text_bytes"] = len(result.Text)
+	diagnostics["finish_reason"] = string(result.FinishReason)
 	diagnostics["thinking_count"] = len(result.Thinking)
 	diagnostics["tool_event_count"] = len(result.ToolEvents)
 	diagnostics[lifecyclepayload.ContextTokensKey] = result.Usage.ContextTokens

--- a/internal/assistant/lifecyclepayload/behavior_test.go
+++ b/internal/assistant/lifecyclepayload/behavior_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/omarluq/librecode/internal/compaction"
 	"github.com/omarluq/librecode/internal/contextwindow"
 	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/llm"
 	"github.com/omarluq/librecode/internal/model"
 )
 
@@ -109,6 +110,7 @@ func TestProviderResponseErrorAndNilPayloads(t *testing.T) {
 		OutputTokens:    5,
 	}
 	response := lifecyclepayload.ProviderResponsePayload(&lifecyclepayload.ProviderResponse{
+		FinishReason:   llm.FinishReasonLength,
 		API:            "openai-responses",
 		ModelID:        lifecycleProviderModel,
 		Provider:       "openai",
@@ -120,6 +122,7 @@ func TestProviderResponseErrorAndNilPayloads(t *testing.T) {
 		ToolEventCount: 3,
 	})
 	assert.Equal(t, lifecycleAnswer, response[lifecyclepayload.TextKey])
+	assert.Equal(t, string(llm.FinishReasonLength), response["finish_reason"])
 	assert.Equal(t, 3, response["tool_event_count"])
 
 	providerErr := lifecyclepayload.ProviderErrorPayload(&lifecyclepayload.ProviderError{

--- a/internal/assistant/lifecyclepayload/lifecyclepayload.go
+++ b/internal/assistant/lifecyclepayload/lifecyclepayload.go
@@ -9,6 +9,7 @@ import (
 	"github.com/omarluq/librecode/internal/compaction"
 	"github.com/omarluq/librecode/internal/contextwindow"
 	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/llm"
 	"github.com/omarluq/librecode/internal/mapsutil"
 	"github.com/omarluq/librecode/internal/model"
 )
@@ -85,6 +86,7 @@ type ProviderRequest struct {
 
 // ProviderResponse describes after-provider-response lifecycle payload metadata.
 type ProviderResponse struct {
+	FinishReason   llm.FinishReason
 	API            string
 	ModelID        string
 	Provider       string
@@ -304,6 +306,7 @@ func ProviderResponsePayload(response *ProviderResponse) map[string]any {
 		ProviderKey:        response.Provider,
 		SessionIDKey:       response.SessionID,
 		TextKey:            response.Text,
+		"finish_reason":    string(response.FinishReason),
 		"thinking_count":   response.ThinkingCount,
 		"tool_event_count": response.ToolEventCount,
 		UsageKey:           TokenUsage(response.Usage),

--- a/internal/assistant/llm_conversion.go
+++ b/internal/assistant/llm_conversion.go
@@ -131,11 +131,19 @@ func llmResponseFromCompletionResult(result *CompletionResult) llm.Response {
 	}
 
 	return llm.Response{
-		FinishReason: llm.FinishReasonStop,
+		FinishReason: completionResultFinishReason(result),
 		Content:      content,
 		ToolCalls:    nil,
 		Usage:        llmconv.UsageFromModel(result.Usage),
 	}
+}
+
+func completionResultFinishReason(result *CompletionResult) llm.FinishReason {
+	if result == nil || result.FinishReason == llm.FinishReasonUnknown {
+		return llm.FinishReasonStop
+	}
+
+	return result.FinishReason
 }
 
 func llmToolResultPart(event *ToolEvent) llm.Part {

--- a/internal/assistant/llm_conversion_internal_test.go
+++ b/internal/assistant/llm_conversion_internal_test.go
@@ -115,8 +115,9 @@ func TestLLMResponseFromCompletionResultConvertsContentAndUsage(t *testing.T) {
 	t.Parallel()
 
 	result := &CompletionResult{
-		Text:     "final answer",
-		Thinking: []string{" thought ", "   "},
+		FinishReason: llm.FinishReasonLength,
+		Text:         "final answer",
+		Thinking:     []string{" thought ", "   "},
 		ToolEvents: []ToolEvent{{
 			Name:          jsonReadToolName,
 			ArgumentsJSON: `{"path":"README.md"}`,
@@ -144,7 +145,7 @@ func TestLLMResponseFromCompletionResultConvertsContentAndUsage(t *testing.T) {
 
 	converted := llmResponseFromCompletionResult(result)
 
-	assert.Equal(t, llm.FinishReasonStop, converted.FinishReason)
+	assert.Equal(t, llm.FinishReasonLength, converted.FinishReason)
 	assert.Equal(t, 18, converted.Usage.InputTokens)
 	require.Len(t, converted.Content, 4)
 	assert.Equal(t, llm.PartReasoning, converted.Content[0].Type)

--- a/internal/assistant/provider_seam_hardening_test.go
+++ b/internal/assistant/provider_seam_hardening_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/omarluq/librecode/internal/assistant"
 	"github.com/omarluq/librecode/internal/extension"
+	"github.com/omarluq/librecode/internal/llm"
 	"github.com/omarluq/librecode/internal/model"
 )
 
@@ -19,8 +20,9 @@ func TestRuntime_ProviderLifecycleEmitsDiagnostics(t *testing.T) {
 
 	runtime, _, _ := newTestRuntimeWithManager(t, staticCompleter{
 		result: &assistant.CompletionResult{
-			Text:     "provider response",
-			Thinking: []string{"thinking"},
+			FinishReason: llm.FinishReasonStop,
+			Text:         "provider response",
+			Thinking:     []string{"thinking"},
 			ToolEvents: []assistant.ToolEvent{{
 				Name:          "read",
 				ArgumentsJSON: `{}`,

--- a/internal/assistant/runtime_events.go
+++ b/internal/assistant/runtime_events.go
@@ -37,6 +37,7 @@ func (runtime *Runtime) emitProviderResponse(
 		return
 	}
 	payload := lifecyclepayload.ProviderResponsePayload(&lifecyclepayload.ProviderResponse{
+		FinishReason:   result.FinishReason,
 		Usage:          result.Usage,
 		API:            request.Model.API,
 		ModelID:        request.Model.ID,

--- a/internal/assistant/runtime_events_test.go
+++ b/internal/assistant/runtime_events_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/omarluq/librecode/internal/assistant"
 	"github.com/omarluq/librecode/internal/event"
+	"github.com/omarluq/librecode/internal/llm"
 	"github.com/omarluq/librecode/internal/model"
 )
 
@@ -30,9 +31,10 @@ func TestRuntime_ProviderLifecyclePublishesReactiveEvents(t *testing.T) {
 
 	runtime, _, _ := newTestRuntimeWithManager(t, staticCompleter{
 		result: &assistant.CompletionResult{
-			Text:       testCompletionText,
-			Thinking:   nil,
-			ToolEvents: nil,
+			FinishReason: llm.FinishReasonStop,
+			Text:         testCompletionText,
+			Thinking:     nil,
+			ToolEvents:   nil,
 			Usage: model.TokenUsage{
 				Breakdown:       nil,
 				TopContributors: nil,
@@ -119,9 +121,10 @@ func (toolCallbackClient) Complete(
 	}
 
 	return &assistant.CompletionResult{
-		Text:       testCompletionText,
-		Thinking:   nil,
-		ToolEvents: nil,
-		Usage:      model.EmptyTokenUsage(),
+		FinishReason: llm.FinishReasonStop,
+		Text:         testCompletionText,
+		Thinking:     nil,
+		ToolEvents:   nil,
+		Usage:        model.EmptyTokenUsage(),
 	}, nil
 }

--- a/internal/assistant/runtime_lifecycle_test.go
+++ b/internal/assistant/runtime_lifecycle_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/omarluq/librecode/internal/assistant"
 	"github.com/omarluq/librecode/internal/event"
+	"github.com/omarluq/librecode/internal/llm"
 	"github.com/omarluq/librecode/internal/model"
 )
 
@@ -190,8 +191,9 @@ func TestRuntime_PromptEmitsSideEffectMessageAppendEvents(t *testing.T) {
 
 	client := staticCompleter{
 		result: &assistant.CompletionResult{
-			Text:     "done",
-			Thinking: []string{"reasoning"},
+			FinishReason: llm.FinishReasonStop,
+			Text:         "done",
+			Thinking:     []string{"reasoning"},
 			ToolEvents: []assistant.ToolEvent{
 				{
 					Name:          testToolName,

--- a/internal/assistant/runtime_test.go
+++ b/internal/assistant/runtime_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/omarluq/librecode/internal/database"
 	"github.com/omarluq/librecode/internal/event"
 	"github.com/omarluq/librecode/internal/extension"
+	"github.com/omarluq/librecode/internal/llm"
 	"github.com/omarluq/librecode/internal/model"
 )
 
@@ -591,10 +592,11 @@ func (client *retryCompleter) Complete(
 	}
 
 	return &assistant.CompletionResult{
-		Text:       client.response + " for " + request.Messages[len(request.Messages)-1].Content,
-		Thinking:   nil,
-		ToolEvents: nil,
-		Usage:      model.EmptyTokenUsage(),
+		FinishReason: llm.FinishReasonStop,
+		Text:         client.response + " for " + request.Messages[len(request.Messages)-1].Content,
+		Thinking:     nil,
+		ToolEvents:   nil,
+		Usage:        model.EmptyTokenUsage(),
 	}, nil
 }
 
@@ -605,10 +607,11 @@ func (client *emptyCompleter) Complete(
 	client.attempts++
 
 	return &assistant.CompletionResult{
-		Text:       "",
-		Thinking:   nil,
-		ToolEvents: nil,
-		Usage:      model.EmptyTokenUsage(),
+		FinishReason: llm.FinishReasonStop,
+		Text:         "",
+		Thinking:     nil,
+		ToolEvents:   nil,
+		Usage:        model.EmptyTokenUsage(),
 	}, nil
 }
 
@@ -687,9 +690,10 @@ func (testCompleter) Complete(
 	}
 
 	return &assistant.CompletionResult{
-		Text:       "test assistant response for " + request.Messages[len(request.Messages)-1].Content,
-		Thinking:   nil,
-		ToolEvents: nil,
+		FinishReason: llm.FinishReasonStop,
+		Text:         "test assistant response for " + request.Messages[len(request.Messages)-1].Content,
+		Thinking:     nil,
+		ToolEvents:   nil,
 		Usage: model.TokenUsage{
 			Breakdown:       nil,
 			TopContributors: nil,

--- a/internal/assistant/tool_registry_test.go
+++ b/internal/assistant/tool_registry_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/omarluq/librecode/internal/assistant"
+	"github.com/omarluq/librecode/internal/llm"
 	"github.com/omarluq/librecode/internal/model"
 	"github.com/omarluq/librecode/internal/tool"
 )
@@ -95,10 +96,11 @@ func (client *extensionToolCompleter) Complete(
 	*client.toolDetails = result.Details
 
 	return &assistant.CompletionResult{
-		Text:       "tool registry inspected",
-		Thinking:   nil,
-		ToolEvents: nil,
-		Usage:      model.EmptyTokenUsage(),
+		FinishReason: llm.FinishReasonStop,
+		Text:         "tool registry inspected",
+		Thinking:     nil,
+		ToolEvents:   nil,
+		Usage:        model.EmptyTokenUsage(),
 	}, nil
 }
 

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -55,7 +55,7 @@ func (client *HTTPCompletionClient) advanceAnthropicLoop(
 		if fallback := TextToolCallsFromText(providerResult.Text); len(fallback) > 0 {
 			providerResult.ToolCalls = fallback
 		} else {
-			return finishTextResult(state.result, providerResult.Text)
+			return finishProviderResult(state.result, providerResult)
 		}
 	}
 	events, err := executeAnthropicToolCalls(ctx, request, providerResult.ToolCalls)
@@ -115,10 +115,10 @@ func anthropicPayload(request *CompletionRequest, messages []map[string]any) map
 	// reasoning is available. Match production agent clients by omitting
 	// temperature unless/until librecode exposes an explicit user setting.
 	payload := map[string]any{
-		jsonModelKey:    request.Request.Model.ID,
-		"max_tokens":    minPositive(request.Request.Model.MaxTokens, 4096),
-		jsonMessagesKey: messages,
-		"tools":         AnthropicTools(request),
+		jsonModelKey:          request.Request.Model.ID,
+		finishReasonMaxTokens: minPositive(request.Request.Model.MaxTokens, 4096),
+		jsonMessagesKey:       messages,
+		"tools":               AnthropicTools(request),
 	}
 	if usesAnthropicOAuth(request) {
 		payload["system"] = anthropicOAuthSystemPrompt(request.Request.SystemPrompt)
@@ -295,9 +295,10 @@ func (client *HTTPCompletionClient) requestAnthropic(
 
 func parseAnthropicResult(content []byte) (*providerResult, error) {
 	var response struct {
-		Error   providerError  `json:"error"`
-		Usage   map[string]any `json:"usage"`
-		Content []struct {
+		Error      providerError  `json:"error"`
+		Usage      map[string]any `json:"usage"`
+		StopReason string         `json:"stop_reason"`
+		Content    []struct {
 			Type  string `json:"type"`
 			Text  string `json:"text"`
 			Input any    `json:"input"`
@@ -325,12 +326,29 @@ func parseAnthropicResult(content []byte) (*providerResult, error) {
 	}
 
 	return &providerResult{
-		Text:        strings.TrimSpace(strings.Join(parts, "\n")),
-		OutputItems: nil,
-		Thinking:    nil,
-		ToolCalls:   calls,
-		Usage:       usageFromObject(response.Usage),
+		FinishReason: anthropicFinishReason(response.StopReason, len(calls) > 0),
+		Text:         strings.TrimSpace(strings.Join(parts, "\n")),
+		OutputItems:  nil,
+		Thinking:     nil,
+		ToolCalls:    calls,
+		Usage:        usageFromObject(response.Usage),
 	}, nil
+}
+
+func anthropicFinishReason(reason string, hasToolCalls bool) llm.FinishReason {
+	if hasToolCalls {
+		return llm.FinishReasonToolCalls
+	}
+	switch reason {
+	case "end_turn", "stop_sequence":
+		return llm.FinishReasonStop
+	case finishReasonMaxTokens:
+		return llm.FinishReasonLength
+	case "tool_use":
+		return llm.FinishReasonToolCalls
+	default:
+		return llm.FinishReasonUnknown
+	}
 }
 
 func anthropicToolCall(callID, name string, input any) ToolCall {

--- a/internal/provider/anthropic_mapping_internal_test.go
+++ b/internal/provider/anthropic_mapping_internal_test.go
@@ -76,6 +76,18 @@ func TestAnthropicToolArgumentsHandlesMalformedAndScalarInput(t *testing.T) {
 	assert.JSONEq(t, `"plain"`, argumentsJSON)
 }
 
+func TestParseAnthropicResultMapsMaxTokensFinishReason(t *testing.T) {
+	t.Parallel()
+
+	result, err := parseAnthropicResult([]byte(
+		`{"stop_reason":"max_tokens","content":[{"type":"text","text":"partial"}]}`,
+	))
+
+	require.NoError(t, err)
+	assert.Equal(t, "partial", result.Text)
+	assert.Equal(t, llm.FinishReasonLength, result.FinishReason)
+}
+
 func TestAnthropicAssistantToolMessageMapsProviderNames(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/anthropic_tools_test.go
+++ b/internal/provider/anthropic_tools_test.go
@@ -151,9 +151,10 @@ func TestAppendAnthropicToolConversationRejectsMismatchedNativeResults(t *testin
 
 	state := &anthropicLoopState{result: nil, endpoint: "", messages: nil}
 	result := &providerResult{
-		Text:        "",
-		OutputItems: nil,
-		Thinking:    nil,
+		FinishReason: llm.FinishReasonToolCalls,
+		Text:         "",
+		OutputItems:  nil,
+		Thinking:     nil,
 		ToolCalls: []ToolCall{{
 			Arguments:     nil,
 			Metadata:      nil,

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -82,6 +82,8 @@ const (
 	thinkingDisplaySummary  = "summarized"
 	reasoningSummaryAuto    = "auto"
 	reasoningEffortNone     = "none"
+	statusCompleted         = "completed"
+	finishReasonMaxTokens   = "max_tokens"
 	sseItemIDKey            = "item_id"
 	sseOutputItemIDKey      = "output_item_id"
 )
@@ -122,11 +124,12 @@ type ToolEvent struct {
 }
 
 type providerResult struct {
-	Text        string
-	OutputItems []any
-	Thinking    []string
-	ToolCalls   []ToolCall
-	Usage       llm.Usage
+	FinishReason llm.FinishReason
+	Text         string
+	OutputItems  []any
+	Thinking     []string
+	ToolCalls    []ToolCall
+	Usage        llm.Usage
 }
 
 // HTTPCompletionClient is a small provider client for built-in API families.

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -86,12 +86,6 @@ func TestParseSSEResultFailureCases(t *testing.T) {
 			expectedSubstring: "nope",
 		},
 		{
-			name: "incomplete event",
-			stream: "data: " + `{"type":"response.incomplete",` +
-				`"response":{"incomplete_details":{"reason":"max_output_tokens"}}}` + "\n",
-			expectedSubstring: "provider response incomplete: max_output_tokens",
-		},
-		{
 			name:              "closed before completion",
 			stream:            "data: " + `{"type":"response.created"}` + "\n",
 			expectedSubstring: "provider stream closed before completion",
@@ -110,6 +104,43 @@ func TestParseSSEResultFailureCases(t *testing.T) {
 	}
 }
 
+func TestParseSSEResultIncompleteMaxOutputTokensReturnsPartialResult(t *testing.T) {
+	t.Parallel()
+
+	stream := strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"partial "}`,
+		`data: {"type":"response.output_text.delta","delta":"answer"}`,
+		`data: {"type":"response.incomplete","response":{"status":"incomplete",` +
+			`"incomplete_details":{"reason":"max_output_tokens"},"output":[],` +
+			`"usage":{"input_tokens":10,"output_tokens":2}}}`,
+		``,
+	}, "\n")
+
+	result, err := parseSSEResult(strings.NewReader(stream), nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "partial answer", result.Text)
+	assert.Equal(t, llm.FinishReasonLength, result.FinishReason)
+	assert.Equal(t, 10, result.Usage.InputTokens)
+	assert.Equal(t, 2, result.Usage.OutputTokens)
+}
+
+func TestParseSSEResultIncompleteToolCallsWinOverLength(t *testing.T) {
+	t.Parallel()
+
+	stream := "data: " + `{"type":"response.incomplete","response":{"status":"incomplete",` +
+		`"incomplete_details":{"reason":"max_output_tokens"},"output":[{"id":"call_1",` +
+		`"type":"function_call","call_id":"call_1","name":"read",` +
+		`"arguments":"{\"path\":\"README.md\"}"}]}}` + "\n"
+
+	result, err := parseSSEResult(strings.NewReader(stream), nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, llm.FinishReasonToolCalls, result.FinishReason)
+	require.Len(t, result.ToolCalls, 1)
+	assert.Equal(t, jsonReadToolName, result.ToolCalls[0].Name)
+}
+
 func completedSSEEvent() string {
-	return "data: " + `{"type":"response.completed","response":{"output":[]}}` + "\n"
+	return "data: " + `{"type":"response.completed","response":{"status":"completed","output":[]}}` + "\n"
 }

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -104,62 +104,85 @@ func TestParseSSEResultFailureCases(t *testing.T) {
 	}
 }
 
-func TestParseSSEResultIncompleteMaxOutputTokensReturnsPartialResult(t *testing.T) {
+func TestParseSSEResultIncompleteEvents(t *testing.T) {
 	t.Parallel()
 
-	stream := strings.Join([]string{
-		`data: {"type":"response.output_text.delta","delta":"partial "}`,
-		`data: {"type":"response.output_text.delta","delta":"answer"}`,
-		`data: {"type":"response.incomplete","response":{"status":"incomplete",` +
-			`"incomplete_details":{"reason":"max_output_tokens"},"output":[],` +
-			`"usage":{"input_tokens":10,"output_tokens":2}}}`,
-		``,
-	}, "\n")
+	tests := []struct {
+		name                 string
+		stream               string
+		expectedText         string
+		expectedFinishReason llm.FinishReason
+		expectedToolName     string
+		expectedInputTokens  int
+		expectedOutputTokens int
+		expectedToolCalls    int
+	}{
+		{
+			name: "max output tokens returns accumulated deltas",
+			stream: strings.Join([]string{
+				`data: {"type":"response.output_text.delta","delta":"partial "}`,
+				`data: {"type":"response.output_text.delta","delta":"answer"}`,
+				`data: {"type":"response.incomplete","response":{"status":"incomplete",` +
+					`"incomplete_details":{"reason":"max_output_tokens"},"output":[],` +
+					`"usage":{"input_tokens":10,"output_tokens":2}}}`,
+				``,
+			}, "\n"),
+			expectedText:         "partial answer",
+			expectedFinishReason: llm.FinishReasonLength,
+			expectedToolName:     "",
+			expectedInputTokens:  10,
+			expectedOutputTokens: 2,
+			expectedToolCalls:    0,
+		},
+		{
+			name: "max output tokens preserves final finish reason with accumulated items",
+			stream: strings.Join([]string{
+				`data: {"type":"response.output_item.done","item":{"id":"msg_1","type":"message",` +
+					`"content":[{"type":"output_text","text":"partial answer"}]}}`,
+				`data: {"type":"response.incomplete","response":{"status":"incomplete",` +
+					`"incomplete_details":{"reason":"max_output_tokens"},"output":[],` +
+					`"usage":{"input_tokens":10,"output_tokens":2}}}`,
+				``,
+			}, "\n"),
+			expectedText:         "partial answer",
+			expectedFinishReason: llm.FinishReasonLength,
+			expectedToolName:     "",
+			expectedInputTokens:  10,
+			expectedOutputTokens: 2,
+			expectedToolCalls:    0,
+		},
+		{
+			name: "tool calls win over length",
+			stream: "data: " + `{"type":"response.incomplete","response":{"status":"incomplete",` +
+				`"incomplete_details":{"reason":"max_output_tokens"},"output":[{"id":"call_1",` +
+				`"type":"function_call","call_id":"call_1","name":"read",` +
+				`"arguments":"{\"path\":\"README.md\"}"}]}}` + "\n",
+			expectedText:         "",
+			expectedFinishReason: llm.FinishReasonToolCalls,
+			expectedToolName:     jsonReadToolName,
+			expectedInputTokens:  0,
+			expectedOutputTokens: 0,
+			expectedToolCalls:    1,
+		},
+	}
 
-	result, err := parseSSEResult(strings.NewReader(stream), nil)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-	require.NoError(t, err)
-	assert.Equal(t, "partial answer", result.Text)
-	assert.Equal(t, llm.FinishReasonLength, result.FinishReason)
-	assert.Equal(t, 10, result.Usage.InputTokens)
-	assert.Equal(t, 2, result.Usage.OutputTokens)
-}
+			result, err := parseSSEResult(strings.NewReader(test.stream), nil)
 
-func TestParseSSEResultPreservesFinalFinishReasonWhenUsingAccumulatedItems(t *testing.T) {
-	t.Parallel()
-
-	stream := strings.Join([]string{
-		`data: {"type":"response.output_item.done","item":{"id":"msg_1","type":"message",` +
-			`"content":[{"type":"output_text","text":"partial answer"}]}}`,
-		`data: {"type":"response.incomplete","response":{"status":"incomplete",` +
-			`"incomplete_details":{"reason":"max_output_tokens"},"output":[],` +
-			`"usage":{"input_tokens":10,"output_tokens":2}}}`,
-		``,
-	}, "\n")
-
-	result, err := parseSSEResult(strings.NewReader(stream), nil)
-
-	require.NoError(t, err)
-	assert.Equal(t, "partial answer", result.Text)
-	assert.Equal(t, llm.FinishReasonLength, result.FinishReason)
-	assert.Equal(t, 10, result.Usage.InputTokens)
-	assert.Equal(t, 2, result.Usage.OutputTokens)
-}
-
-func TestParseSSEResultIncompleteToolCallsWinOverLength(t *testing.T) {
-	t.Parallel()
-
-	stream := "data: " + `{"type":"response.incomplete","response":{"status":"incomplete",` +
-		`"incomplete_details":{"reason":"max_output_tokens"},"output":[{"id":"call_1",` +
-		`"type":"function_call","call_id":"call_1","name":"read",` +
-		`"arguments":"{\"path\":\"README.md\"}"}]}}` + "\n"
-
-	result, err := parseSSEResult(strings.NewReader(stream), nil)
-
-	require.NoError(t, err)
-	assert.Equal(t, llm.FinishReasonToolCalls, result.FinishReason)
-	require.Len(t, result.ToolCalls, 1)
-	assert.Equal(t, jsonReadToolName, result.ToolCalls[0].Name)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedText, result.Text)
+			assert.Equal(t, test.expectedFinishReason, result.FinishReason)
+			assert.Equal(t, test.expectedInputTokens, result.Usage.InputTokens)
+			assert.Equal(t, test.expectedOutputTokens, result.Usage.OutputTokens)
+			require.Len(t, result.ToolCalls, test.expectedToolCalls)
+			if test.expectedToolCalls > 0 {
+				assert.Equal(t, test.expectedToolName, result.ToolCalls[0].Name)
+			}
+		})
+	}
 }
 
 func completedSSEEvent() string {

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -125,6 +125,27 @@ func TestParseSSEResultIncompleteMaxOutputTokensReturnsPartialResult(t *testing.
 	assert.Equal(t, 2, result.Usage.OutputTokens)
 }
 
+func TestParseSSEResultPreservesFinalFinishReasonWhenUsingAccumulatedItems(t *testing.T) {
+	t.Parallel()
+
+	stream := strings.Join([]string{
+		`data: {"type":"response.output_item.done","item":{"id":"msg_1","type":"message",` +
+			`"content":[{"type":"output_text","text":"partial answer"}]}}`,
+		`data: {"type":"response.incomplete","response":{"status":"incomplete",` +
+			`"incomplete_details":{"reason":"max_output_tokens"},"output":[],` +
+			`"usage":{"input_tokens":10,"output_tokens":2}}}`,
+		``,
+	}, "\n")
+
+	result, err := parseSSEResult(strings.NewReader(stream), nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "partial answer", result.Text)
+	assert.Equal(t, llm.FinishReasonLength, result.FinishReason)
+	assert.Equal(t, 10, result.Usage.InputTokens)
+	assert.Equal(t, 2, result.Usage.OutputTokens)
+}
+
 func TestParseSSEResultIncompleteToolCallsWinOverLength(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -11,7 +11,12 @@ import (
 	"github.com/omarluq/librecode/internal/llm"
 )
 
-const answerDelta = "answer"
+const (
+	answerDelta                     = "answer"
+	incompleteTextTrailer           = `,"output":[],"usage":{"input_tokens":10,"output_tokens":2}}}`
+	incompleteFilteredTextTrailer   = `,"output":[],"usage":{"input_tokens":7,"output_tokens":1}}}`
+	incompleteMissingDetailsTrailer = `"output":[],"usage":{"input_tokens":5,"output_tokens":1}}}`
+)
 
 func TestSSEAccumulatorEmitsOutputTextDelta(t *testing.T) {
 	t.Parallel()
@@ -107,66 +112,7 @@ func TestParseSSEResultFailureCases(t *testing.T) {
 func TestParseSSEResultIncompleteEvents(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name                 string
-		stream               string
-		expectedText         string
-		expectedFinishReason llm.FinishReason
-		expectedToolName     string
-		expectedInputTokens  int
-		expectedOutputTokens int
-		expectedToolCalls    int
-	}{
-		{
-			name: "max output tokens returns accumulated deltas",
-			stream: strings.Join([]string{
-				`data: {"type":"response.output_text.delta","delta":"partial "}`,
-				`data: {"type":"response.output_text.delta","delta":"answer"}`,
-				`data: {"type":"response.incomplete","response":{"status":"incomplete",` +
-					`"incomplete_details":{"reason":"max_output_tokens"},"output":[],` +
-					`"usage":{"input_tokens":10,"output_tokens":2}}}`,
-				``,
-			}, "\n"),
-			expectedText:         "partial answer",
-			expectedFinishReason: llm.FinishReasonLength,
-			expectedToolName:     "",
-			expectedInputTokens:  10,
-			expectedOutputTokens: 2,
-			expectedToolCalls:    0,
-		},
-		{
-			name: "max output tokens preserves final finish reason with accumulated items",
-			stream: strings.Join([]string{
-				`data: {"type":"response.output_item.done","item":{"id":"msg_1","type":"message",` +
-					`"content":[{"type":"output_text","text":"partial answer"}]}}`,
-				`data: {"type":"response.incomplete","response":{"status":"incomplete",` +
-					`"incomplete_details":{"reason":"max_output_tokens"},"output":[],` +
-					`"usage":{"input_tokens":10,"output_tokens":2}}}`,
-				``,
-			}, "\n"),
-			expectedText:         "partial answer",
-			expectedFinishReason: llm.FinishReasonLength,
-			expectedToolName:     "",
-			expectedInputTokens:  10,
-			expectedOutputTokens: 2,
-			expectedToolCalls:    0,
-		},
-		{
-			name: "tool calls win over length",
-			stream: "data: " + `{"type":"response.incomplete","response":{"status":"incomplete",` +
-				`"incomplete_details":{"reason":"max_output_tokens"},"output":[{"id":"call_1",` +
-				`"type":"function_call","call_id":"call_1","name":"read",` +
-				`"arguments":"{\"path\":\"README.md\"}"}]}}` + "\n",
-			expectedText:         "",
-			expectedFinishReason: llm.FinishReasonToolCalls,
-			expectedToolName:     jsonReadToolName,
-			expectedInputTokens:  0,
-			expectedOutputTokens: 0,
-			expectedToolCalls:    1,
-		},
-	}
-
-	for _, test := range tests {
+	for _, test := range incompleteSSECases() {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -183,6 +129,103 @@ func TestParseSSEResultIncompleteEvents(t *testing.T) {
 			}
 		})
 	}
+}
+
+type incompleteSSECase struct {
+	name                 string
+	stream               string
+	expectedText         string
+	expectedFinishReason llm.FinishReason
+	expectedToolName     string
+	expectedInputTokens  int
+	expectedOutputTokens int
+	expectedToolCalls    int
+}
+
+func incompleteSSECases() []incompleteSSECase {
+	return []incompleteSSECase{
+		{
+			name:                 "max output tokens returns accumulated deltas",
+			stream:               incompleteTextSSE("partial ", "max_output_tokens", incompleteTextTrailer),
+			expectedText:         "partial answer",
+			expectedFinishReason: llm.FinishReasonLength,
+			expectedToolName:     "",
+			expectedInputTokens:  10,
+			expectedOutputTokens: 2,
+			expectedToolCalls:    0,
+		},
+		{
+			name:                 "max output tokens preserves final finish reason with accumulated items",
+			stream:               incompleteOutputItemSSE(),
+			expectedText:         "partial answer",
+			expectedFinishReason: llm.FinishReasonLength,
+			expectedToolName:     "",
+			expectedInputTokens:  10,
+			expectedOutputTokens: 2,
+			expectedToolCalls:    0,
+		},
+		{
+			name:                 "content filter maps to content filter finish reason",
+			stream:               incompleteTextSSE("safe ", "content_filter", incompleteFilteredTextTrailer),
+			expectedText:         "safe answer",
+			expectedFinishReason: llm.FinishReasonContentFilter,
+			expectedToolName:     "",
+			expectedInputTokens:  7,
+			expectedOutputTokens: 1,
+			expectedToolCalls:    0,
+		},
+		{
+			name:                 "missing incomplete details defaults to length",
+			stream:               incompleteTextSSE("truncated ", "", incompleteMissingDetailsTrailer),
+			expectedText:         "truncated answer",
+			expectedFinishReason: llm.FinishReasonLength,
+			expectedToolName:     "",
+			expectedInputTokens:  5,
+			expectedOutputTokens: 1,
+			expectedToolCalls:    0,
+		},
+		{
+			name:                 "tool calls win over length",
+			stream:               incompleteToolCallSSE(),
+			expectedText:         "",
+			expectedFinishReason: llm.FinishReasonToolCalls,
+			expectedToolName:     jsonReadToolName,
+			expectedInputTokens:  0,
+			expectedOutputTokens: 0,
+			expectedToolCalls:    1,
+		},
+	}
+}
+
+func incompleteTextSSE(prefix, reason, trailer string) string {
+	incompleteDetails := ""
+	if reason != "" {
+		incompleteDetails = `"incomplete_details":{"reason":"` + reason + `"}`
+	}
+
+	return strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"` + prefix + `"}`,
+		`data: {"type":"response.output_text.delta","delta":"` + answerDelta + `"}`,
+		`data: {"type":"response.incomplete","response":{"status":"incomplete",` + incompleteDetails + trailer,
+		``,
+	}, "\n")
+}
+
+func incompleteOutputItemSSE() string {
+	return strings.Join([]string{
+		`data: {"type":"response.output_item.done","item":{"id":"msg_1","type":"message",` +
+			`"content":[{"type":"output_text","text":"partial answer"}]}}`,
+		`data: {"type":"response.incomplete","response":{"status":"incomplete",` +
+			`"incomplete_details":{"reason":"max_output_tokens"}` + incompleteTextTrailer,
+		``,
+	}, "\n")
+}
+
+func incompleteToolCallSSE() string {
+	return "data: " + `{"type":"response.incomplete","response":{"status":"incomplete",` +
+		`"incomplete_details":{"reason":"max_output_tokens"},"output":[{"id":"call_1",` +
+		`"type":"function_call","call_id":"call_1","name":"read",` +
+		`"arguments":"{\"path\":\"README.md\"}"}]}}` + "\n"
 }
 
 func completedSSEEvent() string {

--- a/internal/provider/empty_response_internal_test.go
+++ b/internal/provider/empty_response_internal_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,7 @@ import (
 	"github.com/omarluq/librecode/internal/llm"
 )
 
-func TestFinishTextResultAllowsEmptyText(t *testing.T) {
+func TestFinishProviderResultAllowsEmptyText(t *testing.T) {
 	t.Parallel()
 
 	result := &llm.Response{
@@ -19,7 +20,14 @@ func TestFinishTextResultAllowsEmptyText(t *testing.T) {
 		ToolCalls:    nil,
 		Usage:        llm.EmptyUsage(),
 	}
-	finished, err := finishTextResult(result, "   ")
+	finished, err := finishProviderResult(result, &providerResult{
+		FinishReason: llm.FinishReasonStop,
+		Text:         strings.Repeat(" ", 3),
+		OutputItems:  nil,
+		Thinking:     nil,
+		ToolCalls:    nil,
+		Usage:        llm.EmptyUsage(),
+	})
 
 	require.NoError(t, err)
 	assert.True(t, finished)

--- a/internal/provider/empty_response_internal_test.go
+++ b/internal/provider/empty_response_internal_test.go
@@ -31,6 +31,7 @@ func TestFinishProviderResultAllowsEmptyText(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, finished)
+	assert.Empty(t, result.Content)
 	assert.Empty(t, responseText(result))
 }
 

--- a/internal/provider/openai_chat.go
+++ b/internal/provider/openai_chat.go
@@ -63,7 +63,7 @@ func (client *HTTPCompletionClient) advanceOpenAIChatLoop(
 		if fallback := TextToolCallsFromText(providerResult.Text); len(fallback) > 0 {
 			providerResult.ToolCalls = fallback
 		} else {
-			return finishTextResult(state.result, providerResult.Text)
+			return finishProviderResult(state.result, providerResult)
 		}
 	}
 	events, err := executeOpenAIChatToolCalls(ctx, request, providerResult.ToolCalls)
@@ -134,7 +134,8 @@ func parseOpenAIChatResult(content []byte) (*providerResult, error) {
 		Error   providerError  `json:"error"`
 		Usage   map[string]any `json:"usage"`
 		Choices []struct {
-			Message struct {
+			FinishReason string `json:"finish_reason"`
+			Message      struct {
 				Content   string `json:"content"`
 				ToolCalls []struct {
 					ID       string `json:"id"`
@@ -155,11 +156,12 @@ func parseOpenAIChatResult(content []byte) (*providerResult, error) {
 	}
 	if len(response.Choices) == 0 {
 		return &providerResult{
-			Text:        "",
-			OutputItems: nil,
-			Thinking:    nil,
-			ToolCalls:   nil,
-			Usage:       usageFromObject(response.Usage),
+			FinishReason: llm.FinishReasonUnknown,
+			Text:         "",
+			OutputItems:  nil,
+			Thinking:     nil,
+			ToolCalls:    nil,
+			Usage:        usageFromObject(response.Usage),
 		}, nil
 	}
 	message := response.Choices[0].Message
@@ -179,12 +181,31 @@ func parseOpenAIChatResult(content []byte) (*providerResult, error) {
 	}
 
 	return &providerResult{
-		Text:        strings.TrimSpace(message.Content),
-		OutputItems: nil,
-		Thinking:    nil,
-		ToolCalls:   calls,
-		Usage:       usageFromObject(response.Usage),
+		FinishReason: openAIChatFinishReason(response.Choices[0].FinishReason, len(calls) > 0),
+		Text:         strings.TrimSpace(message.Content),
+		OutputItems:  nil,
+		Thinking:     nil,
+		ToolCalls:    calls,
+		Usage:        usageFromObject(response.Usage),
 	}, nil
+}
+
+func openAIChatFinishReason(reason string, hasToolCalls bool) llm.FinishReason {
+	if hasToolCalls {
+		return llm.FinishReasonToolCalls
+	}
+	switch reason {
+	case "stop":
+		return llm.FinishReasonStop
+	case "length":
+		return llm.FinishReasonLength
+	case "tool_calls", "function_call":
+		return llm.FinishReasonToolCalls
+	case "content_filter":
+		return llm.FinishReasonContentFilter
+	default:
+		return llm.FinishReasonUnknown
+	}
 }
 
 func shouldIncludeReasoningEffort(request *CompletionRequest) bool {

--- a/internal/provider/openai_chat_payload_internal_test.go
+++ b/internal/provider/openai_chat_payload_internal_test.go
@@ -62,6 +62,7 @@ func TestParseOpenAIChatResultHandlesErrorsAndToolFiltering(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "answer", result.Text)
+	assert.Equal(t, llm.FinishReasonToolCalls, result.FinishReason)
 	require.Len(t, result.ToolCalls, 1)
 	assert.Equal(t, testCallID, result.ToolCalls[0].ID)
 	assert.Equal(t, testToolPath, result.ToolCalls[0].Arguments[jsonPathKey])
@@ -71,13 +72,26 @@ func TestParseOpenAIChatResultHandlesErrorsAndToolFiltering(t *testing.T) {
 	}, result.Usage)
 }
 
+func TestParseOpenAIChatResultMapsFinishReasonLength(t *testing.T) {
+	t.Parallel()
+
+	result, err := parseOpenAIChatResult([]byte(
+		`{"choices":[{"finish_reason":"length","message":{"content":"partial"}}]}`,
+	))
+
+	require.NoError(t, err)
+	assert.Equal(t, "partial", result.Text)
+	assert.Equal(t, llm.FinishReasonLength, result.FinishReason)
+}
+
 func TestOpenAIChatAssistantToolMessage(t *testing.T) {
 	t.Parallel()
 
 	message := openAIChatAssistantToolMessage(&providerResult{
-		Text:        "using tool",
-		OutputItems: nil,
-		Thinking:    nil,
+		FinishReason: llm.FinishReasonToolCalls,
+		Text:         "using tool",
+		OutputItems:  nil,
+		Thinking:     nil,
 		ToolCalls: []ToolCall{{
 			Arguments:     nil,
 			Metadata:      nil,

--- a/internal/provider/openai_responses.go
+++ b/internal/provider/openai_responses.go
@@ -58,11 +58,15 @@ func (client *HTTPCompletionClient) completeResponsesLoop(
 		}
 		appendThinking(result, providerResult.Thinking)
 		result.Usage = mergeUsage(result.Usage, providerResult.Usage)
+		result.FinishReason = providerResult.FinishReason
 		if validateErr := validateToolCalls(providerResult.ToolCalls); validateErr != nil {
 			return nil, validateErr
 		}
 		if len(providerResult.ToolCalls) == 0 {
 			setResponseText(result, providerResult.Text)
+			if result.FinishReason == llm.FinishReasonUnknown {
+				result.FinishReason = llm.FinishReasonStop
+			}
 			return result, nil
 		}
 		input = append(input, statelessResponseOutputItems(providerResult.OutputItems)...)
@@ -159,7 +163,7 @@ func statelessResponseOutputItems(items []any) []any {
 			jsonCallIDKey:    stringValue(object[jsonCallIDKey]),
 			jsonToolNameKey:  stringValue(object[jsonToolNameKey]),
 			jsonArgumentsKey: stringValue(object[jsonArgumentsKey]),
-			"status":         "completed",
+			"status":         statusCompleted,
 		})
 	}
 
@@ -183,6 +187,7 @@ func parseOpenAIResponseResult(content []byte) (*providerResult, error) {
 
 func providerResultFromResponse(response map[string]any) *providerResult {
 	outputItems := outputItemsFromResponse(response[jsonOutputKey])
+	toolCalls := toolCallsFromOutput(outputItems)
 	text := strings.TrimSpace(extractText(response[jsonOutputKey]))
 	if text == "" {
 		if outputText, ok := response["output_text"].(string); ok {
@@ -191,11 +196,12 @@ func providerResultFromResponse(response map[string]any) *providerResult {
 	}
 
 	return &providerResult{
-		Text:        text,
-		OutputItems: outputItems,
-		Thinking:    thinkingFromOutput(outputItems),
-		ToolCalls:   toolCallsFromOutput(outputItems),
-		Usage:       usageFromObject(response["usage"]),
+		FinishReason: openAIResponseFinishReason(response, len(toolCalls) > 0),
+		Text:         text,
+		OutputItems:  outputItems,
+		Thinking:     thinkingFromOutput(outputItems),
+		ToolCalls:    toolCalls,
+		Usage:        usageFromObject(response["usage"]),
 	}
 }
 
@@ -205,13 +211,57 @@ func providerResultFromOutputItems(outputItems []any, fallbackText string) *prov
 		text = fallbackText
 	}
 
+	toolCalls := toolCallsFromOutput(outputItems)
+
 	return &providerResult{
-		Text:        text,
-		OutputItems: outputItems,
-		Thinking:    thinkingFromOutput(outputItems),
-		ToolCalls:   toolCallsFromOutput(outputItems),
-		Usage:       llm.EmptyUsage(),
+		FinishReason: openAIResponseOutputItemsFinishReason(toolCalls),
+		Text:         text,
+		OutputItems:  outputItems,
+		Thinking:     thinkingFromOutput(outputItems),
+		ToolCalls:    toolCalls,
+		Usage:        llm.EmptyUsage(),
 	}
+}
+
+func openAIResponseFinishReason(response map[string]any, hasToolCalls bool) llm.FinishReason {
+	if hasToolCalls {
+		return llm.FinishReasonToolCalls
+	}
+	status := stringValue(response["status"])
+	if status == statusCompleted {
+		return llm.FinishReasonStop
+	}
+	if status == "failed" {
+		return llm.FinishReasonError
+	}
+	if status != "incomplete" {
+		return llm.FinishReasonUnknown
+	}
+
+	return openAIIncompleteFinishReason(response)
+}
+
+func openAIIncompleteFinishReason(response map[string]any) llm.FinishReason {
+	details, ok := response["incomplete_details"].(map[string]any)
+	if !ok {
+		return llm.FinishReasonLength
+	}
+	switch stringValue(details["reason"]) {
+	case "max_output_tokens", finishReasonMaxTokens:
+		return llm.FinishReasonLength
+	case "content_filter":
+		return llm.FinishReasonContentFilter
+	default:
+		return llm.FinishReasonLength
+	}
+}
+
+func openAIResponseOutputItemsFinishReason(toolCalls []ToolCall) llm.FinishReason {
+	if len(toolCalls) > 0 {
+		return llm.FinishReasonToolCalls
+	}
+
+	return llm.FinishReasonUnknown
 }
 
 func outputItemsFromResponse(output any) []any {

--- a/internal/provider/openai_responses_internal_test.go
+++ b/internal/provider/openai_responses_internal_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/llm"
 )
 
 func TestStatelessResponseOutputItemsFiltersFunctionCalls(t *testing.T) {
@@ -54,6 +56,44 @@ func TestParseOpenAIResponseResultExtractsTextThinkingAndToolCalls(t *testing.T)
 	assert.Equal(t, testToolPath, result.ToolCalls[0].Arguments[jsonPathKey])
 	assert.Equal(t, 12, result.Usage.InputTokens)
 	assert.Equal(t, 3, result.Usage.OutputTokens)
+	assert.Equal(t, llm.FinishReasonToolCalls, result.FinishReason)
+}
+
+func TestParseOpenAIResponseResultMapsIncompleteFinishReasons(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+		want llm.FinishReason
+	}{
+		{
+			name: "max output tokens",
+			body: `{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},` +
+				`"output":[{"type":"message","content":[{"type":"output_text","text":"partial"}]}]}`,
+			want: llm.FinishReasonLength,
+		},
+		{
+			name: "content filter",
+			body: `{"status":"incomplete","incomplete_details":{"reason":"content_filter"},"output_text":"partial"}`,
+			want: llm.FinishReasonContentFilter,
+		},
+		{
+			name: statusCompleted,
+			body: `{"status":"completed","output_text":"done"}`,
+			want: llm.FinishReasonStop,
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := parseOpenAIResponseResult([]byte(testCase.body))
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.want, result.FinishReason)
+		})
+	}
 }
 
 func TestParseOpenAIResponseResultUsesOutputTextFallbackAndErrors(t *testing.T) {

--- a/internal/provider/result_internal_test.go
+++ b/internal/provider/result_internal_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,9 +17,10 @@ func TestResponseResultHelpers(t *testing.T) {
 	assert.Equal(t, llm.FinishReasonUnknown, response.FinishReason)
 	assert.Equal(t, llm.EmptyUsage(), response.Usage)
 
-	appendThinking(response, []string{"  reason  ", "   "})
+	blank := strings.Repeat(" ", 3)
+	appendThinking(response, []string{"  reason  ", blank})
 	setResponseText(response, " hello ")
-	setResponseText(response, "   ")
+	setResponseText(response, blank)
 	appendToolResults(response, []ToolEvent{{
 		Name:          jsonReadToolName,
 		ArgumentsJSON: `{"path":"README.md"}`,

--- a/internal/provider/sse.go
+++ b/internal/provider/sse.go
@@ -18,6 +18,7 @@ type sseAccumulator struct {
 	parts                 []string
 	items                 []any
 	completed             bool
+	terminal              bool
 	sawTypedResponseEvent bool
 }
 
@@ -29,6 +30,7 @@ func newSSEAccumulator() *sseAccumulator {
 		parts:                 []string{},
 		items:                 []any{},
 		completed:             false,
+		terminal:              false,
 		sawTypedResponseEvent: false,
 	}
 }
@@ -74,10 +76,12 @@ func (accumulator *sseAccumulator) addResponseEventState(event map[string]any) {
 	switch eventType {
 	case "response.completed", "response.done":
 		accumulator.completed = true
+		accumulator.terminal = true
 	case "response.failed":
+		accumulator.terminal = true
 		accumulator.terminalErr = sseProviderError("responses_failed", event, "provider response failed")
 	case "response.incomplete":
-		accumulator.terminalErr = sseProviderError("responses_incomplete", event, "provider response incomplete")
+		accumulator.terminal = true
 	}
 }
 
@@ -192,7 +196,7 @@ func parseSSEResult(reader io.Reader, onEvent func(*llm.StreamChunk)) (*provider
 	if accumulator.terminalErr != nil {
 		return nil, accumulator.terminalErr
 	}
-	if accumulator.sawTypedResponseEvent && !accumulator.completed {
+	if accumulator.sawTypedResponseEvent && !accumulator.terminal {
 		return nil, oops.In("provider").
 			Code("responses_stream_incomplete").
 			Errorf("provider stream closed before completion")
@@ -216,11 +220,12 @@ func parseSSEResult(reader io.Reader, onEvent func(*llm.StreamChunk)) (*provider
 	}
 
 	return &providerResult{
-		Text:        fallbackText,
-		OutputItems: nil,
-		Thinking:    nil,
-		ToolCalls:   nil,
-		Usage:       llm.EmptyUsage(),
+		FinishReason: llm.FinishReasonUnknown,
+		Text:         fallbackText,
+		OutputItems:  nil,
+		Thinking:     nil,
+		ToolCalls:    nil,
+		Usage:        llm.EmptyUsage(),
 	}, nil
 }
 

--- a/internal/provider/sse.go
+++ b/internal/provider/sse.go
@@ -202,21 +202,16 @@ func parseSSEResult(reader io.Reader, onEvent func(*llm.StreamChunk)) (*provider
 			Errorf("provider stream closed before completion")
 	}
 	fallbackText := strings.TrimSpace(strings.Join(accumulator.parts, ""))
-	if accumulator.finalResponse != nil {
-		result := providerResultFromResponse(accumulator.finalResponse)
-		if len(result.OutputItems) == 0 && len(accumulator.items) > 0 {
-			usage := result.Usage
-			result = providerResultFromOutputItems(accumulator.items, fallbackText)
-			result.Usage = usage
-		}
-		if strings.TrimSpace(result.Text) == "" {
-			result.Text = fallbackText
-		}
 
-		return result, nil
+	return providerResultFromSSEAccumulator(accumulator, fallbackText), nil
+}
+
+func providerResultFromSSEAccumulator(accumulator *sseAccumulator, fallbackText string) *providerResult {
+	if accumulator.finalResponse != nil {
+		return providerResultFromSSEFinalResponse(accumulator, fallbackText)
 	}
 	if len(accumulator.items) > 0 {
-		return providerResultFromOutputItems(accumulator.items, fallbackText), nil
+		return providerResultFromOutputItems(accumulator.items, fallbackText)
 	}
 
 	return &providerResult{
@@ -226,7 +221,25 @@ func parseSSEResult(reader io.Reader, onEvent func(*llm.StreamChunk)) (*provider
 		Thinking:     nil,
 		ToolCalls:    nil,
 		Usage:        llm.EmptyUsage(),
-	}, nil
+	}
+}
+
+func providerResultFromSSEFinalResponse(accumulator *sseAccumulator, fallbackText string) *providerResult {
+	result := providerResultFromResponse(accumulator.finalResponse)
+	if len(result.OutputItems) == 0 && len(accumulator.items) > 0 {
+		usage := result.Usage
+		finishReason := result.FinishReason
+		result = providerResultFromOutputItems(accumulator.items, fallbackText)
+		result.Usage = usage
+		if result.FinishReason == llm.FinishReasonUnknown {
+			result.FinishReason = finishReason
+		}
+	}
+	if strings.TrimSpace(result.Text) == "" {
+		result.Text = fallbackText
+	}
+
+	return result
 }
 
 func scanSSEResponse(scanner *bufio.Scanner, onEvent func(*llm.StreamChunk)) (accumulator *sseAccumulator, err error) {

--- a/internal/provider/text_tool_calls_test.go
+++ b/internal/provider/text_tool_calls_test.go
@@ -2,6 +2,7 @@
 package provider
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -214,7 +215,7 @@ func TestTextToolResultPromptUsesErrorsAndEmptyFallback(t *testing.T) {
 			Name:          jsonBashToolName,
 			ArgumentsJSON: `{}`,
 			DetailsJSON:   "",
-			Result:        "   ",
+			Result:        strings.Repeat(" ", 3),
 			Error:         "",
 			IsError:       false,
 		},

--- a/internal/provider/tool_loop.go
+++ b/internal/provider/tool_loop.go
@@ -184,7 +184,9 @@ func finishProviderResult(result *llm.Response, providerResult *providerResult) 
 	if result.FinishReason == llm.FinishReasonUnknown {
 		result.FinishReason = llm.FinishReasonStop
 	}
-	result.Content = append(result.Content, llm.TextPart(strings.TrimSpace(providerResult.Text)))
+	if text := strings.TrimSpace(providerResult.Text); text != "" {
+		result.Content = append(result.Content, llm.TextPart(text))
+	}
 
 	return true, nil
 }

--- a/internal/provider/tool_loop.go
+++ b/internal/provider/tool_loop.go
@@ -175,8 +175,16 @@ func toolOutputForCall(callID string, event *ToolEvent) map[string]any {
 	}
 }
 
-func finishTextResult(result *llm.Response, text string) (bool, error) {
-	result.Content = append(result.Content, llm.TextPart(strings.TrimSpace(text)))
+func finishProviderResult(result *llm.Response, providerResult *providerResult) (bool, error) {
+	if providerResult == nil {
+		result.FinishReason = llm.FinishReasonStop
+		return true, nil
+	}
+	result.FinishReason = providerResult.FinishReason
+	if result.FinishReason == llm.FinishReasonUnknown {
+		result.FinishReason = llm.FinishReasonStop
+	}
+	result.Content = append(result.Content, llm.TextPart(strings.TrimSpace(providerResult.Text)))
 
 	return true, nil
 }

--- a/internal/terminal/prompt_send_test.go
+++ b/internal/terminal/prompt_send_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/omarluq/librecode/internal/database"
 	"github.com/omarluq/librecode/internal/event"
 	"github.com/omarluq/librecode/internal/extension"
+	"github.com/omarluq/librecode/internal/llm"
 	"github.com/omarluq/librecode/internal/model"
 )
 
@@ -471,10 +472,11 @@ func promptSendTestConfig() *config.Config {
 
 func newTerminalCompletionResult(text string) *assistant.CompletionResult {
 	return &assistant.CompletionResult{
-		Text:       text,
-		Thinking:   nil,
-		ToolEvents: nil,
-		Usage:      model.EmptyTokenUsage(),
+		FinishReason: llm.FinishReasonStop,
+		Text:         text,
+		Thinking:     nil,
+		ToolEvents:   nil,
+		Usage:        model.EmptyTokenUsage(),
 	}
 }
 


### PR DESCRIPTION
## Summary
- treat OpenAI Responses incomplete/max_output_tokens as a length finish instead of a hard provider error
- preserve partial output, tool calls, usage, and finish reasons across provider and assistant boundaries
- normalize finish reasons for OpenAI Responses, OpenAI Chat, and Anthropic

## Validation
- go test ./...
- golangci-lint run ./internal/provider ./internal/assistant ./internal/assistant/lifecyclepayload ./internal/llm ./internal/terminal
- task ci