### PR TITLE
feat(terminal): show auto-compaction indicator

### DIFF
--- a/internal/assistant/client_adapter.go
+++ b/internal/assistant/client_adapter.go
@@ -392,6 +392,9 @@ func llmPartFromStreamEvent(event StreamEvent) *llm.Part {
 		StreamEventUsage,
 		StreamEventUsageSnapshot,
 		StreamEventContextCompaction,
+		StreamEventContextCompactionStart,
+		StreamEventContextCompactionDone,
+		StreamEventContextCompactionError,
 		StreamEventUnknown:
 		part := llm.TextPart(event.Text)
 		return &part

--- a/internal/assistant/context_auto_compaction.go
+++ b/internal/assistant/context_auto_compaction.go
@@ -13,7 +13,10 @@ import (
 	"github.com/omarluq/librecode/internal/model"
 )
 
-const postResponseAutoCompactThresholdPercent = 80
+const (
+	contextAutoCompactionBeforeRequestFailed = "context auto-compaction before request failed"
+	postResponseAutoCompactThresholdPercent  = 80
+)
 
 type contextRequestBuild struct {
 	Context *contextwindow.BuildResult
@@ -102,12 +105,13 @@ func (runtime *Runtime) prepareCompletionRequestWithAutoCompaction(
 	if !runtime.cfg.Context.PreflightEnabled {
 		return build, nil, nil
 	}
-	validationErr := build.Budget.Validate()
+	originalBudget := build.Budget
+	validationErr := originalBudget.Validate()
 	if validationErr == nil {
 		return build, nil, nil
 	}
 
-	compactionEntry, err := runtime.compactBeforeRequest(ctx, input, build.Budget, validationErr)
+	compactionEntry, err := runtime.compactBeforeRequest(ctx, input, originalBudget, validationErr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -122,7 +126,7 @@ func (runtime *Runtime) prepareCompletionRequestWithAutoCompaction(
 		input.onEvent,
 	)
 	if err != nil {
-		runtime.emitContextCompactionError(ctx, input.onEvent, "context auto-compaction before request failed", err)
+		runtime.emitContextCompactionError(ctx, input.onEvent, contextAutoCompactionBeforeRequestFailed, err)
 
 		return nil, nil, oops.In("assistant").
 			Code("context_request_rebuild").
@@ -130,12 +134,18 @@ func (runtime *Runtime) prepareCompletionRequestWithAutoCompaction(
 	}
 	runtime.emitUsageSnapshot(ctx, input.onEvent, build.Context.Usage)
 	if err := build.Budget.Validate(); err != nil {
-		runtime.emitContextCompactionError(ctx, input.onEvent, "context auto-compaction before request failed", err)
+		runtime.emitContextCompactionError(ctx, input.onEvent, contextAutoCompactionBeforeRequestFailed, err)
 
 		return nil, nil, oops.In("assistant").
 			Code("context_budget_after_compact").
 			Wrapf(err, "context: validate rebuilt budget")
 	}
+	runtime.emitContextCompactionEvent(
+		ctx,
+		input.onEvent,
+		StreamEventContextCompactionDone,
+		autoCompactionMessage(originalBudget, compactionEntry),
+	)
 
 	return build, compactionEntry, nil
 }
@@ -163,18 +173,12 @@ func (runtime *Runtime) compactBeforeRequest(
 		return nil, validationErr
 	}
 	if err != nil {
-		runtime.emitContextCompactionError(ctx, input.onEvent, "context auto-compaction before request failed", err)
+		runtime.emitContextCompactionError(ctx, input.onEvent, contextAutoCompactionBeforeRequestFailed, err)
 
 		return nil, oops.In("assistant").
 			Code("auto_compact").
 			Wrapf(err, "auto-compact context before provider request")
 	}
-	runtime.emitContextCompactionEvent(
-		ctx,
-		input.onEvent,
-		StreamEventContextCompactionDone,
-		autoCompactionMessage(budget, entry),
-	)
 
 	return entry, nil
 }

--- a/internal/assistant/context_auto_compaction.go
+++ b/internal/assistant/context_auto_compaction.go
@@ -107,27 +107,10 @@ func (runtime *Runtime) prepareCompletionRequestWithAutoCompaction(
 		return build, nil, nil
 	}
 
-	runtime.emitContextCompactionEvent(
-		ctx,
-		input.onEvent,
-		StreamEventContextCompactionStart,
-		preRequestAutoCompactionStartMessage(build.Budget),
-	)
-	compactionEntry, err := runtime.CompactSessionFrom(ctx, input.sessionID, input.cwd, &input.userEntryID)
-	if isCompactNothingToDoError(err) {
-		return nil, nil, validationErr
-	}
+	compactionEntry, err := runtime.compactBeforeRequest(ctx, input, build.Budget, validationErr)
 	if err != nil {
-		return nil, nil, oops.In("assistant").
-			Code("auto_compact").
-			Wrapf(err, "auto-compact context before provider request")
+		return nil, nil, err
 	}
-	runtime.emitContextCompactionEvent(
-		ctx,
-		input.onEvent,
-		StreamEventContextCompactionDone,
-		autoCompactionMessage(build.Budget, compactionEntry),
-	)
 
 	build, err = runtime.buildCompletionRequest(
 		ctx,
@@ -139,18 +122,61 @@ func (runtime *Runtime) prepareCompletionRequestWithAutoCompaction(
 		input.onEvent,
 	)
 	if err != nil {
+		runtime.emitContextCompactionError(ctx, input.onEvent, "context auto-compaction before request failed", err)
+
 		return nil, nil, oops.In("assistant").
 			Code("context_request_rebuild").
 			Wrapf(err, "context: rebuild completion request after compaction")
 	}
 	runtime.emitUsageSnapshot(ctx, input.onEvent, build.Context.Usage)
 	if err := build.Budget.Validate(); err != nil {
+		runtime.emitContextCompactionError(ctx, input.onEvent, "context auto-compaction before request failed", err)
+
 		return nil, nil, oops.In("assistant").
 			Code("context_budget_after_compact").
 			Wrapf(err, "context: validate rebuilt budget")
 	}
 
 	return build, compactionEntry, nil
+}
+
+func (runtime *Runtime) compactBeforeRequest(
+	ctx context.Context,
+	input *completionRequestPreparationInput,
+	budget contextwindow.Budget,
+	validationErr error,
+) (*database.EntryEntity, error) {
+	runtime.emitContextCompactionEvent(
+		ctx,
+		input.onEvent,
+		StreamEventContextCompactionStart,
+		preRequestAutoCompactionStartMessage(budget),
+	)
+	entry, err := runtime.CompactSessionFrom(ctx, input.sessionID, input.cwd, &input.userEntryID)
+	if isCompactNothingToDoError(err) {
+		runtime.emitContextCompactionErrorMessage(
+			ctx,
+			input.onEvent,
+			"context auto-compaction before request skipped: nothing to compact",
+		)
+
+		return nil, validationErr
+	}
+	if err != nil {
+		runtime.emitContextCompactionError(ctx, input.onEvent, "context auto-compaction before request failed", err)
+
+		return nil, oops.In("assistant").
+			Code("auto_compact").
+			Wrapf(err, "auto-compact context before provider request")
+	}
+	runtime.emitContextCompactionEvent(
+		ctx,
+		input.onEvent,
+		StreamEventContextCompactionDone,
+		autoCompactionMessage(budget, entry),
+	)
+
+	return entry, nil
 }
 
 func isCompactNothingToDoError(err error) bool {
@@ -167,6 +193,26 @@ func (runtime *Runtime) emitContextCompactionEvent(
 ) {
 	emitStreamEvent(onEvent, StreamEvent{ToolEvent: nil, Usage: nil, Kind: kind, Text: message})
 	runtime.emit(ctx, string(kind), map[string]any{"message": message})
+}
+
+func (runtime *Runtime) emitContextCompactionError(
+	ctx context.Context,
+	onEvent func(StreamEvent),
+	prefix string,
+	err error,
+) {
+	if err == nil {
+		return
+	}
+	runtime.emitContextCompactionErrorMessage(ctx, onEvent, prefix+": "+err.Error())
+}
+
+func (runtime *Runtime) emitContextCompactionErrorMessage(
+	ctx context.Context,
+	onEvent func(StreamEvent),
+	message string,
+) {
+	runtime.emitContextCompactionEvent(ctx, onEvent, StreamEventContextCompactionError, message)
 }
 
 type postResponseAutoCompactionInput struct {
@@ -201,6 +247,12 @@ func (runtime *Runtime) autoCompactAfterResponse(
 	)
 	entry, err := runtime.CompactSessionFrom(ctx, input.sessionID, input.cwd, &input.parentEntryID)
 	if isCompactNothingToDoError(err) {
+		runtime.emitContextCompactionErrorMessage(
+			ctx,
+			input.onEvent,
+			"context auto-compaction after response skipped: nothing to compact",
+		)
+
 		return model.EmptyTokenUsage(), false
 	}
 	if err != nil {
@@ -243,12 +295,7 @@ func (runtime *Runtime) emitPostResponseAutoCompactionError(
 	if err == nil {
 		return
 	}
-	runtime.emitContextCompactionEvent(
-		ctx,
-		onEvent,
-		StreamEventContextCompactionError,
-		"context auto-compaction after response failed: "+err.Error(),
-	)
+	runtime.emitContextCompactionError(ctx, onEvent, "context auto-compaction after response failed", err)
 }
 
 func preRequestAutoCompactionStartMessage(budget contextwindow.Budget) string {

--- a/internal/assistant/context_auto_compaction.go
+++ b/internal/assistant/context_auto_compaction.go
@@ -107,6 +107,12 @@ func (runtime *Runtime) prepareCompletionRequestWithAutoCompaction(
 		return build, nil, nil
 	}
 
+	runtime.emitContextCompactionEvent(
+		ctx,
+		input.onEvent,
+		StreamEventContextCompactionStart,
+		preRequestAutoCompactionStartMessage(build.Budget),
+	)
 	compactionEntry, err := runtime.CompactSessionFrom(ctx, input.sessionID, input.cwd, &input.userEntryID)
 	if isCompactNothingToDoError(err) {
 		return nil, nil, validationErr
@@ -116,7 +122,12 @@ func (runtime *Runtime) prepareCompletionRequestWithAutoCompaction(
 			Code("auto_compact").
 			Wrapf(err, "auto-compact context before provider request")
 	}
-	runtime.emitContextCompaction(ctx, input.onEvent, autoCompactionMessage(build.Budget, compactionEntry))
+	runtime.emitContextCompactionEvent(
+		ctx,
+		input.onEvent,
+		StreamEventContextCompactionDone,
+		autoCompactionMessage(build.Budget, compactionEntry),
+	)
 
 	build, err = runtime.buildCompletionRequest(
 		ctx,
@@ -148,14 +159,14 @@ func isCompactNothingToDoError(err error) bool {
 	return ok && code == "compact_nothing_to_do"
 }
 
-func (runtime *Runtime) emitContextCompaction(ctx context.Context, onEvent func(StreamEvent), message string) {
-	emitStreamEvent(onEvent, StreamEvent{
-		ToolEvent: nil,
-		Usage:     nil,
-		Kind:      StreamEventContextCompaction,
-		Text:      message,
-	})
-	runtime.emit(ctx, string(StreamEventContextCompaction), map[string]any{"message": message})
+func (runtime *Runtime) emitContextCompactionEvent(
+	ctx context.Context,
+	onEvent func(StreamEvent),
+	kind StreamEventKind,
+	message string,
+) {
+	emitStreamEvent(onEvent, StreamEvent{ToolEvent: nil, Usage: nil, Kind: kind, Text: message})
+	runtime.emit(ctx, string(kind), map[string]any{"message": message})
 }
 
 type postResponseAutoCompactionInput struct {
@@ -182,7 +193,12 @@ func (runtime *Runtime) autoCompactAfterResponse(
 		return model.EmptyTokenUsage(), false
 	}
 
-	runtime.emitContextCompaction(ctx, input.onEvent, postResponseAutoCompactionStartMessage(budget))
+	runtime.emitContextCompactionEvent(
+		ctx,
+		input.onEvent,
+		StreamEventContextCompactionStart,
+		postResponseAutoCompactionStartMessage(budget),
+	)
 	entry, err := runtime.CompactSessionFrom(ctx, input.sessionID, input.cwd, &input.parentEntryID)
 	if isCompactNothingToDoError(err) {
 		return model.EmptyTokenUsage(), false
@@ -197,7 +213,7 @@ func (runtime *Runtime) autoCompactAfterResponse(
 		return model.EmptyTokenUsage(), false
 	}
 	runtime.emitUsageSnapshot(ctx, input.onEvent, compactedUsage)
-	runtime.emitContextCompaction(ctx, input.onEvent, compactionMessage(
+	runtime.emitContextCompactionEvent(ctx, input.onEvent, StreamEventContextCompactionDone, compactionMessage(
 		"context auto-compacted after response",
 		budget,
 		entry,
@@ -227,7 +243,18 @@ func (runtime *Runtime) emitPostResponseAutoCompactionError(
 	if err == nil {
 		return
 	}
-	runtime.emitContextCompaction(ctx, onEvent, "context auto-compaction after response failed: "+err.Error())
+	runtime.emitContextCompactionEvent(
+		ctx,
+		onEvent,
+		StreamEventContextCompactionError,
+		"context auto-compaction after response failed: "+err.Error(),
+	)
+}
+
+func preRequestAutoCompactionStartMessage(budget contextwindow.Budget) string {
+	message := "context auto-compacting before request: estimated input is %d tokens; usable input budget is %d"
+
+	return fmt.Sprintf(message, budget.InputTokens, budget.UsableInput)
 }
 
 func postResponseAutoCompactionStartMessage(budget contextwindow.Budget) string {

--- a/internal/assistant/context_auto_compaction_internal_extra_test.go
+++ b/internal/assistant/context_auto_compaction_internal_extra_test.go
@@ -92,7 +92,7 @@ func assertContainsCompactionErrorEvent(t *testing.T, events []assistant.StreamE
 	t.Helper()
 
 	for _, event := range events {
-		if event.Kind == assistant.StreamEventContextCompaction &&
+		if event.Kind == assistant.StreamEventContextCompactionError &&
 			strings.Contains(event.Text, "context auto-compaction after response failed:") {
 			return
 		}

--- a/internal/assistant/context_auto_compaction_test.go
+++ b/internal/assistant/context_auto_compaction_test.go
@@ -117,6 +117,6 @@ func newAutoCompactionTestRuntime(
 }
 
 func isContextAutoCompactionEvent(event *assistant.StreamEvent) bool {
-	return event.Kind == assistant.StreamEventContextCompaction &&
+	return event.Kind == assistant.StreamEventContextCompactionDone &&
 		strings.Contains(event.Text, "context auto-compacted")
 }

--- a/internal/assistant/context_overflow_compaction.go
+++ b/internal/assistant/context_overflow_compaction.go
@@ -59,9 +59,10 @@ func (runtime *Runtime) recoverProviderContextOverflow(
 		currentParentID = input.compactionEntry.ID
 	}
 
-	runtime.emitContextCompaction(
+	runtime.emitContextCompactionEvent(
 		ctx,
 		input.preparation.onEvent,
+		StreamEventContextCompactionStart,
 		"provider reported context overflow; attempting compaction before retry...",
 	)
 	recoveredEntry, err := runtime.CompactSessionFrom(
@@ -102,9 +103,10 @@ func (runtime *Runtime) recoverProviderContextOverflow(
 				Wrapf(validationErr, "context: validate budget after provider overflow compaction")
 		}
 	}
-	runtime.emitContextCompaction(
+	runtime.emitContextCompactionEvent(
 		ctx,
 		input.preparation.onEvent,
+		StreamEventContextCompactionDone,
 		compactionMessage("context auto-compacted after provider overflow", recoveredBuild.Budget, recoveredEntry),
 	)
 

--- a/internal/assistant/context_overflow_compaction.go
+++ b/internal/assistant/context_overflow_compaction.go
@@ -10,6 +10,8 @@ import (
 	"github.com/omarluq/librecode/internal/database"
 )
 
+const providerContextOverflowCompactionFailed = "provider context overflow compaction failed"
+
 type providerOverflowRecoveryInput struct {
 	preparation     *completionRequestPreparationInput
 	build           *contextRequestBuild
@@ -77,7 +79,7 @@ func (runtime *Runtime) recoverProviderContextOverflow(
 		runtime.emitContextCompactionError(
 			ctx,
 			input.preparation.onEvent,
-			"provider context overflow compaction failed",
+			providerContextOverflowCompactionFailed,
 			err,
 		)
 
@@ -92,7 +94,7 @@ func (runtime *Runtime) recoverProviderContextOverflow(
 			runtime.emitContextCompactionError(
 				ctx,
 				input.preparation.onEvent,
-				"provider context overflow compaction failed",
+				providerContextOverflowCompactionFailed,
 				validationErr,
 			)
 
@@ -105,7 +107,7 @@ func (runtime *Runtime) recoverProviderContextOverflow(
 		ctx,
 		input.preparation.onEvent,
 		StreamEventContextCompactionDone,
-		compactionMessage("context auto-compacted after provider overflow", recoveredBuild.Budget, recoveredEntry),
+		compactionMessage("context auto-compacted after provider overflow", input.build.Budget, recoveredEntry),
 	)
 
 	result, err := runtime.completeWithRetry(ctx, recoveredBuild.Request, input.onRetry)
@@ -147,7 +149,7 @@ func (runtime *Runtime) compactAfterProviderOverflow(
 		runtime.emitContextCompactionError(
 			ctx,
 			input.preparation.onEvent,
-			"provider context overflow compaction failed",
+			providerContextOverflowCompactionFailed,
 			err,
 		)
 

--- a/internal/assistant/context_overflow_compaction.go
+++ b/internal/assistant/context_overflow_compaction.go
@@ -59,25 +59,9 @@ func (runtime *Runtime) recoverProviderContextOverflow(
 		currentParentID = input.compactionEntry.ID
 	}
 
-	runtime.emitContextCompactionEvent(
-		ctx,
-		input.preparation.onEvent,
-		StreamEventContextCompactionStart,
-		"provider reported context overflow; attempting compaction before retry...",
-	)
-	recoveredEntry, err := runtime.CompactSessionFrom(
-		ctx,
-		input.preparation.sessionID,
-		input.preparation.cwd,
-		&currentParentID,
-	)
-	if isCompactNothingToDoError(err) {
-		return nil, nil, nil, providerErr
-	}
+	recoveredEntry, err := runtime.compactAfterProviderOverflow(ctx, input, currentParentID, providerErr)
 	if err != nil {
-		return nil, nil, nil, oops.In("assistant").
-			Code("context_overflow_compact").
-			Wrapf(err, "compact context after provider overflow")
+		return nil, nil, nil, err
 	}
 
 	recoveredBuild, err := runtime.buildCompletionRequest(
@@ -90,6 +74,13 @@ func (runtime *Runtime) recoverProviderContextOverflow(
 		input.preparation.onEvent,
 	)
 	if err != nil {
+		runtime.emitContextCompactionError(
+			ctx,
+			input.preparation.onEvent,
+			"provider context overflow compaction failed",
+			err,
+		)
+
 		return nil, recoveredEntry, nil, oops.In("assistant").
 			Code("context_overflow_rebuild").
 			Wrapf(err, "context: rebuild completion request after provider overflow compaction")
@@ -98,6 +89,13 @@ func (runtime *Runtime) recoverProviderContextOverflow(
 	if runtime.cfg.Context.PreflightEnabled {
 		validationErr := recoveredBuild.Budget.Validate()
 		if validationErr != nil {
+			runtime.emitContextCompactionError(
+				ctx,
+				input.preparation.onEvent,
+				"provider context overflow compaction failed",
+				validationErr,
+			)
+
 			return nil, recoveredEntry, nil, oops.In("assistant").
 				Code("context_budget_after_provider_overflow_compact").
 				Wrapf(validationErr, "context: validate budget after provider overflow compaction")
@@ -116,4 +114,47 @@ func (runtime *Runtime) recoverProviderContextOverflow(
 	}
 
 	return recoveredBuild, recoveredEntry, result, nil
+}
+
+func (runtime *Runtime) compactAfterProviderOverflow(
+	ctx context.Context,
+	input *providerOverflowRecoveryInput,
+	parentID string,
+	providerErr error,
+) (*database.EntryEntity, error) {
+	runtime.emitContextCompactionEvent(
+		ctx,
+		input.preparation.onEvent,
+		StreamEventContextCompactionStart,
+		"provider reported context overflow; attempting compaction before retry...",
+	)
+	entry, err := runtime.CompactSessionFrom(
+		ctx,
+		input.preparation.sessionID,
+		input.preparation.cwd,
+		&parentID,
+	)
+	if isCompactNothingToDoError(err) {
+		runtime.emitContextCompactionErrorMessage(
+			ctx,
+			input.preparation.onEvent,
+			"provider context overflow compaction skipped: nothing to compact",
+		)
+
+		return nil, providerErr
+	}
+	if err != nil {
+		runtime.emitContextCompactionError(
+			ctx,
+			input.preparation.onEvent,
+			"provider context overflow compaction failed",
+			err,
+		)
+
+		return nil, oops.In("assistant").
+			Code("context_overflow_compact").
+			Wrapf(err, "compact context after provider overflow")
+	}
+
+	return entry, nil
 }

--- a/internal/assistant/context_overflow_compaction_test.go
+++ b/internal/assistant/context_overflow_compaction_test.go
@@ -274,12 +274,33 @@ func assertContainsContextCompactionEvent(t *testing.T, events []assistant.Strea
 	t.Helper()
 
 	for index := range events {
-		if events[index].Kind == assistant.StreamEventContextCompaction && strings.Contains(events[index].Text, text) {
+		if isContextCompactionLifecycleEvent(events[index].Kind) && strings.Contains(events[index].Text, text) {
 			return
 		}
 	}
 
 	t.Fatalf("expected context compaction event containing %q", text)
+}
+
+func isContextCompactionLifecycleEvent(kind assistant.StreamEventKind) bool {
+	switch kind {
+	case assistant.StreamEventContextCompaction,
+		assistant.StreamEventContextCompactionStart,
+		assistant.StreamEventContextCompactionDone,
+		assistant.StreamEventContextCompactionError:
+		return true
+	case assistant.StreamEventTextDelta,
+		assistant.StreamEventThinkingDelta,
+		assistant.StreamEventToolStart,
+		assistant.StreamEventToolResult,
+		assistant.StreamEventSkillLoaded,
+		assistant.StreamEventUsage,
+		assistant.StreamEventUsageSnapshot,
+		assistant.StreamEventUnknown:
+		return false
+	}
+
+	return false
 }
 
 func assertBranchContainsCompaction(

--- a/internal/assistant/context_post_response_auto_compaction_test.go
+++ b/internal/assistant/context_post_response_auto_compaction_test.go
@@ -97,11 +97,23 @@ func assertPostResponseCompactionEvent(t *testing.T, events []assistant.StreamEv
 	foundStart := false
 	foundDone := false
 	for _, event := range events {
-		if event.Kind != assistant.StreamEventContextCompaction {
+		switch event.Kind {
+		case assistant.StreamEventContextCompactionStart:
+			foundStart = foundStart || strings.Contains(event.Text, "context auto-compacting after response")
+		case assistant.StreamEventContextCompactionDone:
+			foundDone = foundDone || strings.Contains(event.Text, "context auto-compacted after response")
+		case assistant.StreamEventContextCompaction,
+			assistant.StreamEventContextCompactionError,
+			assistant.StreamEventTextDelta,
+			assistant.StreamEventThinkingDelta,
+			assistant.StreamEventToolStart,
+			assistant.StreamEventToolResult,
+			assistant.StreamEventSkillLoaded,
+			assistant.StreamEventUsage,
+			assistant.StreamEventUsageSnapshot,
+			assistant.StreamEventUnknown:
 			continue
 		}
-		foundStart = foundStart || strings.Contains(event.Text, "context auto-compacting after response")
-		foundDone = foundDone || strings.Contains(event.Text, "context auto-compacted after response")
 	}
 	assert.True(t, foundStart, "expected post-response auto-compaction start event")
 	assert.True(t, foundDone, "expected post-response auto-compaction completion event")

--- a/internal/assistant/runtime.go
+++ b/internal/assistant/runtime.go
@@ -78,6 +78,12 @@ const (
 	StreamEventUsageSnapshot StreamEventKind = "usage_snapshot"
 	// StreamEventContextCompaction carries UI-only context compaction notices.
 	StreamEventContextCompaction StreamEventKind = "context_compaction"
+	// StreamEventContextCompactionStart reports that context compaction has started.
+	StreamEventContextCompactionStart StreamEventKind = "context_compaction_start"
+	// StreamEventContextCompactionDone reports that context compaction completed.
+	StreamEventContextCompactionDone StreamEventKind = "context_compaction_done"
+	// StreamEventContextCompactionError reports that context compaction failed.
+	StreamEventContextCompactionError StreamEventKind = "context_compaction_error"
 	// StreamEventUnknown carries unexpected provider events without persistence side effects.
 	StreamEventUnknown StreamEventKind = "unknown"
 )

--- a/internal/assistant/runtime_persist.go
+++ b/internal/assistant/runtime_persist.go
@@ -126,6 +126,9 @@ func (progress *partialPromptProgress) record(streamEvent StreamEvent) {
 		StreamEventUsage,
 		StreamEventUsageSnapshot,
 		StreamEventContextCompaction,
+		StreamEventContextCompactionStart,
+		StreamEventContextCompactionDone,
+		StreamEventContextCompactionError,
 		StreamEventUnknown:
 		return
 	}

--- a/internal/terminal/app.go
+++ b/internal/terminal/app.go
@@ -508,6 +508,7 @@ func isHighVolumePromptStreamEvent(kind asyncEventKind) bool {
 	case asyncEventAuthURL,
 		asyncEventAuthDone,
 		asyncEventAuthError,
+		asyncEventCompactStart,
 		asyncEventCompactDone,
 		asyncEventCompactError,
 		asyncEventPromptDone,

--- a/internal/terminal/async_events.go
+++ b/internal/terminal/async_events.go
@@ -29,6 +29,7 @@ const (
 	asyncEventPromptUsageSnapshot asyncEventKind = "prompt_usage_snapshot"
 	asyncEventPromptError         asyncEventKind = "prompt_error"
 	asyncEventPromptContext       asyncEventKind = "prompt_context"
+	asyncEventCompactStart        asyncEventKind = "compact_start"
 	asyncEventCompactDone         asyncEventKind = "compact_done"
 	asyncEventCompactError        asyncEventKind = "compact_error"
 )
@@ -138,12 +139,15 @@ func (app *App) promptStreamHandler(ctx context.Context, promptID uint64) func(a
 				Text:      "",
 				PromptID:  promptID,
 			})
-		case assistant.StreamEventContextCompaction:
+		case assistant.StreamEventContextCompaction,
+			assistant.StreamEventContextCompactionStart,
+			assistant.StreamEventContextCompactionDone,
+			assistant.StreamEventContextCompactionError:
 			app.postAsyncEvent(ctx, &asyncEvent{
 				Response:  nil,
 				ToolEvent: nil,
 				Usage:     nil,
-				Kind:      asyncEventPromptContext,
+				Kind:      asyncContextEventKind(event.Kind),
 				Provider:  "",
 				Text:      event.Text,
 				PromptID:  promptID,
@@ -210,6 +214,7 @@ func (app *App) handleAuthAsyncEvent(payload *asyncEvent) bool {
 		asyncEventPromptUsageSnapshot,
 		asyncEventPromptError,
 		asyncEventPromptContext,
+		asyncEventCompactStart,
 		asyncEventCompactDone,
 		asyncEventCompactError:
 		return false
@@ -252,13 +257,14 @@ func isPromptAsyncEvent(kind asyncEventKind) bool {
 		asyncEventPromptUsage,
 		asyncEventPromptUsageSnapshot,
 		asyncEventPromptError,
-		asyncEventPromptContext:
+		asyncEventPromptContext,
+		asyncEventCompactStart,
+		asyncEventCompactDone,
+		asyncEventCompactError:
 		return true
 	case asyncEventAuthURL,
 		asyncEventAuthDone,
-		asyncEventAuthError,
-		asyncEventCompactDone,
-		asyncEventCompactError:
+		asyncEventAuthError:
 		return false
 	}
 
@@ -287,14 +293,15 @@ func (app *App) handlePromptLifecycleEvent(ctx context.Context, payload *asyncEv
 	case asyncEventPromptError:
 		app.applyPromptError(payload.Text, payload.PromptID)
 		return true
-	case asyncEventPromptContext:
-		app.addSystemMessage(payload.Text)
+	case asyncEventPromptContext,
+		asyncEventCompactStart,
+		asyncEventCompactDone,
+		asyncEventCompactError:
+		app.applyPromptContextEvent(payload)
 		return true
 	case asyncEventAuthURL,
 		asyncEventAuthDone,
-		asyncEventAuthError,
-		asyncEventCompactDone,
-		asyncEventCompactError:
+		asyncEventAuthError:
 		return true
 	case asyncEventPromptDelta,
 		asyncEventPromptThinkingDelta,
@@ -306,6 +313,63 @@ func (app *App) handlePromptLifecycleEvent(ctx context.Context, payload *asyncEv
 	}
 
 	return false
+}
+
+func asyncContextEventKind(kind assistant.StreamEventKind) asyncEventKind {
+	switch kind {
+	case assistant.StreamEventContextCompactionStart:
+		return asyncEventCompactStart
+	case assistant.StreamEventContextCompactionDone:
+		return asyncEventCompactDone
+	case assistant.StreamEventContextCompactionError:
+		return asyncEventCompactError
+	case assistant.StreamEventContextCompaction,
+		assistant.StreamEventTextDelta,
+		assistant.StreamEventThinkingDelta,
+		assistant.StreamEventToolStart,
+		assistant.StreamEventToolResult,
+		assistant.StreamEventSkillLoaded,
+		assistant.StreamEventUsage,
+		assistant.StreamEventUsageSnapshot,
+		assistant.StreamEventUnknown:
+		return asyncEventPromptContext
+	}
+
+	return asyncEventPromptContext
+}
+
+func (app *App) applyPromptContextEvent(payload *asyncEvent) {
+	app.addSystemMessage(payload.Text)
+	switch payload.Kind {
+	case asyncEventCompactStart:
+		app.compacting = true
+		app.workStartedAt = time.Now()
+		app.workFrame = 0
+		app.setStatus("compacting context")
+	case asyncEventCompactDone:
+		app.compacting = false
+		if payload.Text != "" {
+			app.setStatus(compactedStatusMessage)
+		}
+	case asyncEventCompactError:
+		app.compacting = false
+	case asyncEventPromptContext:
+		return
+	case asyncEventAuthURL,
+		asyncEventAuthDone,
+		asyncEventAuthError,
+		asyncEventPromptDone,
+		asyncEventPromptUserEntry,
+		asyncEventPromptDelta,
+		asyncEventPromptThinkingDelta,
+		asyncEventPromptToolStart,
+		asyncEventPromptToolResult,
+		asyncEventPromptRetry,
+		asyncEventPromptUsage,
+		asyncEventPromptUsageSnapshot,
+		asyncEventPromptError:
+		return
+	}
 }
 
 func (app *App) handlePromptStreamEvent(ctx context.Context, payload *asyncEvent) {
@@ -351,6 +415,7 @@ func (app *App) handlePromptStreamEvent(ctx context.Context, payload *asyncEvent
 		asyncEventAuthURL,
 		asyncEventAuthDone,
 		asyncEventAuthError,
+		asyncEventCompactStart,
 		asyncEventCompactDone,
 		asyncEventCompactError:
 		return

--- a/internal/terminal/async_events.go
+++ b/internal/terminal/async_events.go
@@ -339,20 +339,19 @@ func asyncContextEventKind(kind assistant.StreamEventKind) asyncEventKind {
 }
 
 func (app *App) applyPromptContextEvent(payload *asyncEvent) {
-	app.addSystemMessage(payload.Text)
+	if payload.Text != "" {
+		app.addSystemMessage(payload.Text)
+	}
 	switch payload.Kind {
 	case asyncEventCompactStart:
-		app.compacting = true
-		app.workStartedAt = time.Now()
-		app.workFrame = 0
-		app.setStatus("compacting context")
+		app.startCompactionIndicator()
 	case asyncEventCompactDone:
-		app.compacting = false
+		app.stopCompactionIndicator()
 		if payload.Text != "" {
 			app.setStatus(compactedStatusMessage)
 		}
 	case asyncEventCompactError:
-		app.compacting = false
+		app.stopCompactionIndicator()
 	case asyncEventPromptContext:
 		return
 	case asyncEventAuthURL,
@@ -370,6 +369,17 @@ func (app *App) applyPromptContextEvent(payload *asyncEvent) {
 		asyncEventPromptError:
 		return
 	}
+}
+
+func (app *App) startCompactionIndicator() {
+	app.compacting = true
+	app.workStartedAt = time.Now()
+	app.workFrame = 0
+	app.setStatus("compacting context")
+}
+
+func (app *App) stopCompactionIndicator() {
+	app.compacting = false
 }
 
 func (app *App) handlePromptStreamEvent(ctx context.Context, payload *asyncEvent) {

--- a/internal/terminal/async_events_test.go
+++ b/internal/terminal/async_events_test.go
@@ -416,7 +416,7 @@ func TestPromptLifecycleEvents(t *testing.T) {
 	}
 }
 
-func promptLifecycleEventCases() []promptLifecycleCase {
+func promptCompactionLifecycleEventCases() []promptLifecycleCase {
 	return []promptLifecycleCase{
 		{
 			name:    "prompt context start",
@@ -444,6 +444,38 @@ func promptLifecycleEventCases() []promptLifecycleCase {
 			},
 			wantHandled: true,
 		},
+		{
+			name:    "prompt context done with empty text",
+			payload: asyncTestEvent(asyncEventCompactDone, "", "", 1),
+			setup: func(app *App) {
+				app.compacting = true
+				app.statusMessage = "previous status"
+			},
+			assert: func(t *testing.T, app *App) {
+				t.Helper()
+				assert.False(t, app.compacting)
+				assert.Equal(t, "previous status", app.statusMessage)
+			},
+			wantHandled: true,
+		},
+		{
+			name:    "prompt context error",
+			payload: asyncTestEvent(asyncEventCompactError, "", asyncTestCompact, 1),
+			setup: func(app *App) {
+				app.compacting = true
+			},
+			assert: func(t *testing.T, app *App) {
+				t.Helper()
+				assert.False(t, app.compacting)
+				assert.Equal(t, asyncTestCompact, app.transcript.History[len(app.transcript.History)-1].Content)
+			},
+			wantHandled: true,
+		},
+	}
+}
+
+func promptLifecycleEventCases() []promptLifecycleCase {
+	return append(promptCompactionLifecycleEventCases(), []promptLifecycleCase{
 		{
 			name:    "prompt retry",
 			payload: asyncTestEvent(asyncEventPromptRetry, string(assistant.RetryEventStart), "retrying", 1),
@@ -492,7 +524,7 @@ func promptLifecycleEventCases() []promptLifecycleCase {
 			assert:      func(*testing.T, *App) {},
 			wantHandled: false,
 		},
-	}
+	}...)
 }
 
 func TestHandlePromptAsyncEventIgnoresStalePromptEvents(t *testing.T) {

--- a/internal/terminal/async_events_test.go
+++ b/internal/terminal/async_events_test.go
@@ -471,6 +471,17 @@ func promptCompactionLifecycleEventCases() []promptLifecycleCase {
 			},
 			wantHandled: true,
 		},
+		{
+			name:    "plain context notice",
+			payload: asyncTestEvent(asyncEventPromptContext, "", asyncTestCompact, 1),
+			setup:   func(*App) {},
+			assert: func(t *testing.T, app *App) {
+				t.Helper()
+				assert.False(t, app.compacting)
+				assert.Equal(t, asyncTestCompact, app.transcript.History[len(app.transcript.History)-1].Content)
+			},
+			wantHandled: true,
+		},
 	}
 }
 

--- a/internal/terminal/async_events_test.go
+++ b/internal/terminal/async_events_test.go
@@ -142,6 +142,10 @@ func TestPromptStreamHandlerPostsEvents(t *testing.T) {
 }
 
 func promptStreamHandlerPostCases() []streamHandlerPostCase {
+	return append(promptStreamContentEventCases(), promptStreamContextEventCases()...)
+}
+
+func promptStreamContentEventCases() []streamHandlerPostCase {
 	usage := asyncTestUsage()
 	toolEvent := asyncTestToolEvent()
 
@@ -202,14 +206,46 @@ func promptStreamHandlerPostCases() []streamHandlerPostCase {
 			wantTool:    false,
 			wantUsage:   true,
 		},
-		{
-			name:        "context compaction",
-			streamEvent: asyncTestStreamEvent(assistant.StreamEventContextCompaction, asyncTestCompact, nil, nil),
-			wantKind:    asyncEventPromptContext,
-			wantText:    asyncTestCompact,
-			wantTool:    false,
-			wantUsage:   false,
-		},
+	}
+}
+
+func promptStreamContextEventCases() []streamHandlerPostCase {
+	return []streamHandlerPostCase{
+		promptStreamContextEventCase(
+			"context compaction info",
+			assistant.StreamEventContextCompaction,
+			asyncEventPromptContext,
+		),
+		promptStreamContextEventCase(
+			"context compaction start",
+			assistant.StreamEventContextCompactionStart,
+			asyncEventCompactStart,
+		),
+		promptStreamContextEventCase(
+			"context compaction done",
+			assistant.StreamEventContextCompactionDone,
+			asyncEventCompactDone,
+		),
+		promptStreamContextEventCase(
+			"context compaction error",
+			assistant.StreamEventContextCompactionError,
+			asyncEventCompactError,
+		),
+	}
+}
+
+func promptStreamContextEventCase(
+	name string,
+	streamKind assistant.StreamEventKind,
+	wantKind asyncEventKind,
+) streamHandlerPostCase {
+	return streamHandlerPostCase{
+		name:        name,
+		streamEvent: asyncTestStreamEvent(streamKind, asyncTestCompact, nil, nil),
+		wantKind:    wantKind,
+		wantText:    asyncTestCompact,
+		wantTool:    false,
+		wantUsage:   false,
 	}
 }
 
@@ -338,6 +374,9 @@ func TestPromptAsyncEventHelpers(t *testing.T) {
 		asyncEventPromptUsageSnapshot,
 		asyncEventPromptError,
 		asyncEventPromptContext,
+		asyncEventCompactStart,
+		asyncEventCompactDone,
+		asyncEventCompactError,
 	} {
 		assert.True(t, isPromptAsyncEvent(kind), "kind %q", kind)
 	}
@@ -345,8 +384,6 @@ func TestPromptAsyncEventHelpers(t *testing.T) {
 		asyncEventAuthURL,
 		asyncEventAuthDone,
 		asyncEventAuthError,
-		asyncEventCompactDone,
-		asyncEventCompactError,
 		asyncEventKind("unknown"),
 	} {
 		assert.False(t, isPromptAsyncEvent(kind), "kind %q", kind)
@@ -382,13 +419,28 @@ func TestPromptLifecycleEvents(t *testing.T) {
 func promptLifecycleEventCases() []promptLifecycleCase {
 	return []promptLifecycleCase{
 		{
-			name:    "prompt context",
-			payload: asyncTestEvent(asyncEventPromptContext, "", asyncTestCompact, 1),
+			name:    "prompt context start",
+			payload: asyncTestEvent(asyncEventCompactStart, "", asyncTestCompact, 1),
 			setup:   func(*App) {},
 			assert: func(t *testing.T, app *App) {
 				t.Helper()
 				last := app.transcript.History[len(app.transcript.History)-1].Content
 				assert.Equal(t, asyncTestCompact, last)
+				assert.True(t, app.compacting)
+				assert.Equal(t, "compacting context", app.statusMessage)
+			},
+			wantHandled: true,
+		},
+		{
+			name:    "prompt context done",
+			payload: asyncTestEvent(asyncEventCompactDone, "", asyncTestCompact, 1),
+			setup: func(app *App) {
+				app.compacting = true
+			},
+			assert: func(t *testing.T, app *App) {
+				t.Helper()
+				assert.False(t, app.compacting)
+				assert.Equal(t, compactedStatusMessage, app.statusMessage)
 			},
 			wantHandled: true,
 		},

--- a/internal/terminal/compact_commands.go
+++ b/internal/terminal/compact_commands.go
@@ -94,9 +94,15 @@ func (app *App) postCompactError(ctx context.Context, compactID uint64, err erro
 func (app *App) handleCompactAsyncEvent(ctx context.Context, payload *asyncEvent) bool {
 	switch payload.Kind {
 	case asyncEventCompactDone:
+		if app.activeCompaction == nil {
+			return false
+		}
 		app.applyCompactDone(ctx, payload)
 		return true
 	case asyncEventCompactError:
+		if app.activeCompaction == nil {
+			return false
+		}
 		app.applyCompactError(payload)
 		return true
 	case asyncEventAuthURL,

--- a/internal/terminal/compact_commands.go
+++ b/internal/terminal/compact_commands.go
@@ -102,6 +102,7 @@ func (app *App) handleCompactAsyncEvent(ctx context.Context, payload *asyncEvent
 	case asyncEventAuthURL,
 		asyncEventAuthDone,
 		asyncEventAuthError,
+		asyncEventCompactStart,
 		asyncEventPromptDone,
 		asyncEventPromptUserEntry,
 		asyncEventPromptDelta,

--- a/internal/terminal/compact_commands_test.go
+++ b/internal/terminal/compact_commands_test.go
@@ -526,7 +526,7 @@ func TestHandleCompactAsyncEventPassesThroughAutoCompactionEvents(t *testing.T) 
 		kind asyncEventKind
 	}{
 		{name: "start", kind: asyncEventCompactStart},
-		{name: "done", kind: asyncEventCompactDone},
+		{name: statusDone, kind: asyncEventCompactDone},
 		{name: "error", kind: asyncEventCompactError},
 	}
 

--- a/internal/terminal/compact_commands_test.go
+++ b/internal/terminal/compact_commands_test.go
@@ -518,6 +518,40 @@ func TestHandleCompactAsyncEventIgnoresStaleAndNonCompactEvents(t *testing.T) {
 	}
 }
 
+func TestHandleCompactAsyncEventPassesThroughAutoCompactionEvents(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		kind asyncEventKind
+	}{
+		{name: "start", kind: asyncEventCompactStart},
+		{name: "completion event", kind: asyncEventCompactDone},
+		{name: "error", kind: asyncEventCompactError},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := newRenderTestApp(t)
+
+			handled := app.handleCompactAsyncEvent(context.Background(), &asyncEvent{
+				Response: nil, ToolEvent: nil, Usage: nil,
+				Kind: testCase.kind, Provider: "", Text: "auto compact", PromptID: 9,
+			})
+
+			if handled {
+				t.Fatal("auto-compaction event should pass through prompt lifecycle " +
+					"when no manual compaction is active")
+			}
+			if app.compacting {
+				t.Fatal("pass-through should not update compaction state")
+			}
+		})
+	}
+}
+
 func TestApplyCompactErrorDefaultMessage(t *testing.T) {
 	t.Parallel()
 

--- a/internal/terminal/compact_commands_test.go
+++ b/internal/terminal/compact_commands_test.go
@@ -526,7 +526,7 @@ func TestHandleCompactAsyncEventPassesThroughAutoCompactionEvents(t *testing.T) 
 		kind asyncEventKind
 	}{
 		{name: "start", kind: asyncEventCompactStart},
-		{name: "completion event", kind: asyncEventCompactDone},
+		{name: "done", kind: asyncEventCompactDone},
 		{name: "error", kind: asyncEventCompactError},
 	}
 

--- a/internal/terminal/panel_settings.go
+++ b/internal/terminal/panel_settings.go
@@ -5,6 +5,7 @@ import "github.com/omarluq/librecode/internal/terminal/panel"
 const (
 	settingTheme    = "theme"
 	settingThinking = "thinking"
+	statusDone      = "done"
 	themeNameDark   = "dark"
 )
 
@@ -44,7 +45,7 @@ func (app *App) openChangelogPanel() {
 			Value:       "db",
 			Title:       "Database sessions",
 			Description: "Session entries and normalized messages are SQLite-backed",
-			Meta:        "done",
+			Meta:        statusDone,
 		},
 	}
 	app.openPanel(panel.New(panelChangelog, "Changelog", "recent runtime work", items, false))

--- a/internal/terminal/prompt_send_test.go
+++ b/internal/terminal/prompt_send_test.go
@@ -268,8 +268,8 @@ func TestRunPromptPostsDoneAndError(t *testing.T) {
 		wantText string
 	}{
 		{
-			name:     "done",
-			client:   newTerminalPromptClient(newTerminalCompletionResult("done"), nil),
+			name:     statusDone,
+			client:   newTerminalPromptClient(newTerminalCompletionResult(statusDone), nil),
 			wantKind: asyncEventPromptDone,
 			wantText: "",
 		},


### PR DESCRIPTION
## Summary
- emit explicit context compaction start/done/error stream events for auto compaction paths
- map auto compaction lifecycle events to the existing terminal compaction indicator state
- keep existing transcript notices while showing the same status/shimmer behavior as manual compaction

## Validation
- go test ./internal/assistant ./internal/terminal
- golangci-lint run ./internal/assistant ./internal/terminal
- task ci