### PR TITLE
feat(provider): support Claude Fable and Mythos

### DIFF
--- a/internal/anthropicmodel/anthropicmodel.go
+++ b/internal/anthropicmodel/anthropicmodel.go
@@ -27,9 +27,9 @@ const (
 func RequiresAdaptiveThinking(modelID string) bool {
 	normalizedModelID := strings.ToLower(modelID)
 
-	return strings.Contains(normalizedModelID, fable5Family) ||
-		strings.Contains(normalizedModelID, mythos5Family) ||
-		strings.Contains(normalizedModelID, mythosPreview)
+	return hasFamily(normalizedModelID, fable5Family) ||
+		hasFamily(normalizedModelID, mythos5Family) ||
+		hasFamily(normalizedModelID, mythosPreview)
 }
 
 // SupportsAdaptiveThinking reports whether the model supports Anthropic's
@@ -38,14 +38,14 @@ func SupportsAdaptiveThinking(modelID string) bool {
 	normalizedModelID := strings.ToLower(modelID)
 
 	return RequiresAdaptiveThinking(normalizedModelID) ||
-		strings.Contains(normalizedModelID, opus46Hyphen) ||
-		strings.Contains(normalizedModelID, opus46Dot) ||
-		strings.Contains(normalizedModelID, opus47Hyphen) ||
-		strings.Contains(normalizedModelID, opus47Dot) ||
-		strings.Contains(normalizedModelID, opus48Hyphen) ||
-		strings.Contains(normalizedModelID, opus48Dot) ||
-		strings.Contains(normalizedModelID, sonnet46Hyphen) ||
-		strings.Contains(normalizedModelID, sonnet46Dot)
+		hasFamily(normalizedModelID, opus46Hyphen) ||
+		hasFamily(normalizedModelID, opus46Dot) ||
+		hasFamily(normalizedModelID, opus47Hyphen) ||
+		hasFamily(normalizedModelID, opus47Dot) ||
+		hasFamily(normalizedModelID, opus48Hyphen) ||
+		hasFamily(normalizedModelID, opus48Dot) ||
+		hasFamily(normalizedModelID, sonnet46Hyphen) ||
+		hasFamily(normalizedModelID, sonnet46Dot)
 }
 
 // SupportsXHigh reports whether the model supports librecode's xhigh thinking
@@ -54,8 +54,37 @@ func SupportsXHigh(modelID string) bool {
 	normalizedModelID := strings.ToLower(modelID)
 
 	return RequiresAdaptiveThinking(normalizedModelID) ||
-		strings.Contains(normalizedModelID, opus47Hyphen) ||
-		strings.Contains(normalizedModelID, opus47Dot) ||
-		strings.Contains(normalizedModelID, opus48Hyphen) ||
-		strings.Contains(normalizedModelID, opus48Dot)
+		hasFamily(normalizedModelID, opus47Hyphen) ||
+		hasFamily(normalizedModelID, opus47Dot) ||
+		hasFamily(normalizedModelID, opus48Hyphen) ||
+		hasFamily(normalizedModelID, opus48Dot)
+}
+
+func hasFamily(modelID, family string) bool {
+	for offset := 0; ; {
+		index := strings.Index(modelID[offset:], family)
+		if index == -1 {
+			return false
+		}
+
+		start := offset + index
+		end := start + len(family)
+		if isBoundary(modelID, start-1) && isBoundary(modelID, end) {
+			return true
+		}
+		offset = end
+	}
+}
+
+func isBoundary(value string, index int) bool {
+	if index < 0 || index >= len(value) {
+		return true
+	}
+
+	switch value[index] {
+	case '-', '.', '_':
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/anthropicmodel/anthropicmodel.go
+++ b/internal/anthropicmodel/anthropicmodel.go
@@ -1,0 +1,61 @@
+// Package anthropicmodel contains Anthropic model-family capability helpers.
+package anthropicmodel
+
+import "strings"
+
+const (
+	// Fable5 is Anthropic's Claude Fable 5 model ID.
+	Fable5 = "claude-fable-5"
+	// Mythos5 is Anthropic's Claude Mythos 5 model ID.
+	Mythos5 = "claude-mythos-5"
+
+	fable5Family   = "fable-5"
+	mythos5Family  = "mythos-5"
+	mythosPreview  = "mythos-preview"
+	opus46Hyphen   = "opus-4-6"
+	opus46Dot      = "opus-4.6"
+	opus47Hyphen   = "opus-4-7"
+	opus47Dot      = "opus-4.7"
+	opus48Hyphen   = "opus-4-8"
+	opus48Dot      = "opus-4.8"
+	sonnet46Hyphen = "sonnet-4-6"
+	sonnet46Dot    = "sonnet-4.6"
+)
+
+// RequiresAdaptiveThinking reports whether the model requires adaptive thinking
+// and rejects explicit disabled-thinking payloads.
+func RequiresAdaptiveThinking(modelID string) bool {
+	normalizedModelID := strings.ToLower(modelID)
+
+	return strings.Contains(normalizedModelID, fable5Family) ||
+		strings.Contains(normalizedModelID, mythos5Family) ||
+		strings.Contains(normalizedModelID, mythosPreview)
+}
+
+// SupportsAdaptiveThinking reports whether the model supports Anthropic's
+// adaptive-thinking payload shape.
+func SupportsAdaptiveThinking(modelID string) bool {
+	normalizedModelID := strings.ToLower(modelID)
+
+	return RequiresAdaptiveThinking(normalizedModelID) ||
+		strings.Contains(normalizedModelID, opus46Hyphen) ||
+		strings.Contains(normalizedModelID, opus46Dot) ||
+		strings.Contains(normalizedModelID, opus47Hyphen) ||
+		strings.Contains(normalizedModelID, opus47Dot) ||
+		strings.Contains(normalizedModelID, opus48Hyphen) ||
+		strings.Contains(normalizedModelID, opus48Dot) ||
+		strings.Contains(normalizedModelID, sonnet46Hyphen) ||
+		strings.Contains(normalizedModelID, sonnet46Dot)
+}
+
+// SupportsXHigh reports whether the model supports librecode's xhigh thinking
+// level mapping.
+func SupportsXHigh(modelID string) bool {
+	normalizedModelID := strings.ToLower(modelID)
+
+	return RequiresAdaptiveThinking(normalizedModelID) ||
+		strings.Contains(normalizedModelID, opus47Hyphen) ||
+		strings.Contains(normalizedModelID, opus47Dot) ||
+		strings.Contains(normalizedModelID, opus48Hyphen) ||
+		strings.Contains(normalizedModelID, opus48Dot)
+}

--- a/internal/anthropicmodel/anthropicmodel_test.go
+++ b/internal/anthropicmodel/anthropicmodel_test.go
@@ -60,6 +60,20 @@ func TestCapabilities(t *testing.T) {
 			wantRequired:     false,
 			wantSupportsHigh: false,
 		},
+		{
+			name:             "mythos false positive",
+			modelID:          "claude-mythos-50",
+			wantAdaptive:     false,
+			wantRequired:     false,
+			wantSupportsHigh: false,
+		},
+		{
+			name:             "opus false positive",
+			modelID:          "claude-opus-4-70",
+			wantAdaptive:     false,
+			wantRequired:     false,
+			wantSupportsHigh: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/anthropicmodel/anthropicmodel_test.go
+++ b/internal/anthropicmodel/anthropicmodel_test.go
@@ -1,0 +1,74 @@
+package anthropicmodel_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/omarluq/librecode/internal/anthropicmodel"
+)
+
+func TestCapabilities(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		modelID          string
+		wantAdaptive     bool
+		wantRequired     bool
+		wantSupportsHigh bool
+	}{
+		{
+			name:             "fable",
+			modelID:          anthropicmodel.Fable5,
+			wantAdaptive:     true,
+			wantRequired:     true,
+			wantSupportsHigh: true,
+		},
+		{
+			name:             "mythos",
+			modelID:          anthropicmodel.Mythos5,
+			wantAdaptive:     true,
+			wantRequired:     true,
+			wantSupportsHigh: true,
+		},
+		{
+			name:             "mythos preview",
+			modelID:          "claude-mythos-preview",
+			wantAdaptive:     true,
+			wantRequired:     true,
+			wantSupportsHigh: true,
+		},
+		{
+			name:             "opus 4.8",
+			modelID:          "claude-opus-4-8",
+			wantAdaptive:     true,
+			wantRequired:     false,
+			wantSupportsHigh: true,
+		},
+		{
+			name:             "sonnet 4.6",
+			modelID:          "claude-sonnet-4-6",
+			wantAdaptive:     true,
+			wantRequired:     false,
+			wantSupportsHigh: false,
+		},
+		{
+			name:             "sonnet 4.5",
+			modelID:          "claude-sonnet-4-5",
+			wantAdaptive:     false,
+			wantRequired:     false,
+			wantSupportsHigh: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.wantAdaptive, anthropicmodel.SupportsAdaptiveThinking(test.modelID))
+			assert.Equal(t, test.wantRequired, anthropicmodel.RequiresAdaptiveThinking(test.modelID))
+			assert.Equal(t, test.wantSupportsHigh, anthropicmodel.SupportsXHigh(test.modelID))
+		})
+	}
+}

--- a/internal/llm/finish_reason.go
+++ b/internal/llm/finish_reason.go
@@ -14,6 +14,8 @@ const (
 	FinishReasonToolCalls FinishReason = "tool-calls"
 	// FinishReasonContentFilter means provider policy filtered the response.
 	FinishReasonContentFilter FinishReason = "content-filter"
+	// FinishReasonRefusal means the model declined the request as a successful response.
+	FinishReasonRefusal FinishReason = "refusal"
 	// FinishReasonError means the provider reported a generation error.
 	FinishReasonError FinishReason = "error"
 	// FinishReasonAborted means generation was canceled or aborted.

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -153,6 +153,7 @@ func TestFinishReasonValues(t *testing.T) {
 	assert.Equal(t, llm.FinishReason("length"), llm.FinishReasonLength)
 	assert.Equal(t, llm.FinishReason("tool-calls"), llm.FinishReasonToolCalls)
 	assert.Equal(t, llm.FinishReason("content-filter"), llm.FinishReasonContentFilter)
+	assert.Equal(t, llm.FinishReason("refusal"), llm.FinishReasonRefusal)
 	assert.Equal(t, llm.FinishReason("error"), llm.FinishReasonError)
 	assert.Equal(t, llm.FinishReason("aborted"), llm.FinishReasonAborted)
 }

--- a/internal/model/discovery.go
+++ b/internal/model/discovery.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/samber/oops"
+
+	"github.com/omarluq/librecode/internal/anthropicmodel"
 )
 
 const (
@@ -319,6 +321,7 @@ func codexDefinition(
 
 func thinkingLevelsForDiscoveredModel(provider, modelID string) map[ThinkingLevel]*string {
 	levels := map[ThinkingLevel]*string{}
+	addAnthropicThinkingLevels(levels, provider, modelID)
 	addOpenAIThinkingOff(levels, provider, modelID)
 	addOpenAIThinkingNone(levels, provider, modelID)
 	addOpenAIXHigh(levels, modelID)
@@ -327,6 +330,18 @@ func thinkingLevelsForDiscoveredModel(provider, modelID string) map[ThinkingLeve
 	}
 
 	return levels
+}
+
+func addAnthropicThinkingLevels(levels map[ThinkingLevel]*string, provider, modelID string) {
+	if provider != providerAnthropic && provider != providerAnthropicClaude {
+		return
+	}
+	levels[ThinkingOff] = nil
+	if !anthropicmodel.SupportsXHigh(modelID) {
+		return
+	}
+	xhigh := string(ThinkingXHigh)
+	levels[ThinkingXHigh] = &xhigh
 }
 
 func addOpenAIThinkingOff(levels map[ThinkingLevel]*string, provider, modelID string) {
@@ -347,7 +362,7 @@ func addOpenAIXHigh(levels map[ThinkingLevel]*string, modelID string) {
 	if !openAISupportsXHigh(modelID) {
 		return
 	}
-	xhigh := "xhigh"
+	xhigh := string(ThinkingXHigh)
 	levels[ThinkingXHigh] = &xhigh
 }
 

--- a/internal/model/discovery_test.go
+++ b/internal/model/discovery_test.go
@@ -82,7 +82,9 @@ func TestParseDiscoveredModelsMapsSupportedProviders(t *testing.T) {
 	assert.Equal(t, "anthropic-messages", anthropicOAuthModel.API)
 	assert.Equal(t, "https://api.anthropic.com", anthropicOAuthModel.BaseURL)
 	assert.Contains(t, anthropicOAuthModel.ThinkingLevelMap, model.ThinkingOff)
-	assert.Contains(t, anthropicOAuthModel.ThinkingLevelMap, model.ThinkingXHigh)
+	xhighLevel := anthropicOAuthModel.ThinkingLevelMap[model.ThinkingXHigh]
+	require.NotNil(t, xhighLevel)
+	assert.Equal(t, string(model.ThinkingXHigh), *xhighLevel)
 
 	codexModel := findModel(t, models, "openai-codex", testDiscoveryGPT55)
 	assert.Equal(t, "openai-codex-responses", codexModel.API)

--- a/internal/model/discovery_test.go
+++ b/internal/model/discovery_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/omarluq/librecode/internal/anthropicmodel"
 	"github.com/omarluq/librecode/internal/model"
 )
 
@@ -36,8 +37,8 @@ func TestParseDiscoveredModelsMapsSupportedProviders(t *testing.T) {
 		},
 		"anthropic": {
 			"models": {
-				"claude-opus-4-7": {
-					"name": "Claude Opus 4.7",
+				"` + anthropicmodel.Fable5 + `": {
+					"name": "Claude Fable 5",
 					"tool_call": true,
 					"reasoning": true,
 					"modalities": {"input": ["text", "image"]},
@@ -77,9 +78,11 @@ func TestParseDiscoveredModelsMapsSupportedProviders(t *testing.T) {
 	assert.Equal(t, []model.InputMode{model.InputText}, openCodeModel.Input)
 	assert.NotContains(t, modelIDsForProvider(models, testDiscoveryOpenAI), "text-only")
 
-	anthropicOAuthModel := findModel(t, models, "anthropic-claude", "claude-opus-4-7")
+	anthropicOAuthModel := findModel(t, models, "anthropic-claude", anthropicmodel.Fable5)
 	assert.Equal(t, "anthropic-messages", anthropicOAuthModel.API)
 	assert.Equal(t, "https://api.anthropic.com", anthropicOAuthModel.BaseURL)
+	assert.Contains(t, anthropicOAuthModel.ThinkingLevelMap, model.ThinkingOff)
+	assert.Contains(t, anthropicOAuthModel.ThinkingLevelMap, model.ThinkingXHigh)
 
 	codexModel := findModel(t, models, "openai-codex", testDiscoveryGPT55)
 	assert.Equal(t, "openai-codex-responses", codexModel.API)

--- a/internal/model/providers.go
+++ b/internal/model/providers.go
@@ -1,6 +1,10 @@
 package model
 
-import "slices"
+import (
+	"slices"
+
+	"github.com/omarluq/librecode/internal/anthropicmodel"
+)
 
 const (
 	providerAnthropic            = "anthropic"
@@ -51,12 +55,22 @@ func BuiltInModels() []Model {
 	}
 	slices.Sort(providers)
 
-	models := make([]Model, 0, len(providers))
+	models := make([]Model, 0, len(providers)+len(additionalBuiltInModels()))
 	for _, provider := range providers {
 		models = append(models, builtInDefaultModel(provider, DefaultModelPerProvider[provider]))
 	}
+	for _, pair := range additionalBuiltInModels() {
+		models = append(models, builtInDefaultModel(pair.Provider, pair.ModelID))
+	}
 
 	return models
+}
+
+func additionalBuiltInModels() []providerModelPair {
+	return []providerModelPair{
+		{Provider: providerAnthropic, ModelID: anthropicmodel.Mythos5},
+		{Provider: providerAnthropicClaude, ModelID: anthropicmodel.Mythos5},
+	}
 }
 
 func builtInDefaultModel(provider, modelID string) Model {
@@ -151,10 +165,10 @@ func openAICodexMetadata() providerMetadata {
 }
 
 func anthropicMetadata() providerMetadata {
-	xhigh := "xhigh"
+	xhigh := string(ThinkingXHigh)
 
 	return providerMetadata{
-		ThinkingLevelMap: map[ThinkingLevel]*string{ThinkingXHigh: &xhigh},
+		ThinkingLevelMap: map[ThinkingLevel]*string{ThinkingOff: nil, ThinkingXHigh: &xhigh},
 		Headers:          nil,
 		Compat:           nil,
 		API:              "anthropic-messages",
@@ -204,8 +218,8 @@ func providerDisplayNameMap() map[string]string {
 
 func defaultModelMap() map[string]string {
 	pairs := []providerModelPair{
-		{Provider: providerAnthropic, ModelID: "claude-opus-4-7"},
-		{Provider: providerAnthropicClaude, ModelID: "claude-opus-4-7"},
+		{Provider: providerAnthropic, ModelID: anthropicmodel.Fable5},
+		{Provider: providerAnthropicClaude, ModelID: anthropicmodel.Fable5},
 		{Provider: providerAzureOpenAIResponses, ModelID: gpt54},
 		{Provider: providerCerebras, ModelID: "zai-glm-4.7"},
 		{Provider: providerDeepSeek, ModelID: "deepseek-v4-pro"},

--- a/internal/model/providers_test.go
+++ b/internal/model/providers_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/omarluq/librecode/internal/anthropicmodel"
 	"github.com/omarluq/librecode/internal/model"
 )
 
@@ -41,8 +42,57 @@ func TestAnthropicAPIAndSubscriptionProvidersAreSeparate(t *testing.T) {
 
 	assert.Equal(t, "Anthropic API", model.ProviderDisplayNames["anthropic"])
 	assert.Equal(t, "Claude Pro/Max (Anthropic OAuth)", model.ProviderDisplayNames["anthropic-claude"])
-	assert.Contains(t, model.DefaultModelPerProvider, "anthropic")
-	assert.Contains(t, model.DefaultModelPerProvider, "anthropic-claude")
+	assert.Equal(t, anthropicmodel.Fable5, model.DefaultModelPerProvider["anthropic"])
+	assert.Equal(t, anthropicmodel.Fable5, model.DefaultModelPerProvider["anthropic-claude"])
+}
+
+func TestAnthropicBuiltInDefaultsSupportFableAndMythos(t *testing.T) {
+	t.Parallel()
+
+	for _, provider := range []string{"anthropic", "anthropic-claude"} {
+		for _, modelID := range []string{anthropicmodel.Fable5, anthropicmodel.Mythos5} {
+			t.Run(provider+"/"+modelID, func(t *testing.T) {
+				t.Parallel()
+
+				builtIn := findBuiltIn(t, provider, modelID)
+				assert.Equal(t, 1_000_000, builtIn.ContextWindow)
+				assert.Equal(t, 128_000, builtIn.MaxTokens)
+				assert.True(t, builtIn.Reasoning)
+				assert.NotNil(t, builtIn.ThinkingLevelMap)
+				assert.Contains(t, builtIn.ThinkingLevelMap, model.ThinkingOff)
+				assert.Contains(t, builtIn.ThinkingLevelMap, model.ThinkingXHigh)
+			})
+		}
+	}
+}
+
+func findBuiltIn(t *testing.T, provider, modelID string) model.Model {
+	t.Helper()
+
+	builtIns := model.BuiltInModels()
+	for index := range builtIns {
+		builtIn := builtIns[index]
+		if builtIn.Provider == provider && builtIn.ID == modelID {
+			return builtIn
+		}
+	}
+	require.Failf(t, "built-in model not found", "%s/%s", provider, modelID)
+
+	return model.Model{
+		ThinkingLevelMap: nil,
+		Headers:          nil,
+		Compat:           nil,
+		Provider:         "",
+		ID:               "",
+		Name:             "",
+		API:              "",
+		BaseURL:          "",
+		Input:            nil,
+		Cost:             model.Cost{Input: 0, Output: 0, CacheRead: 0, CacheWrite: 0},
+		ContextWindow:    0,
+		MaxTokens:        0,
+		Reasoning:        false,
+	}
 }
 
 func TestBuiltInProviderCatalogIsTrimmedToImplementedProviders(t *testing.T) {

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -314,7 +314,9 @@ func parseAnthropicResult(content []byte) (*providerResult, error) {
 	finishReason := anthropicFinishReason(response.StopReason, len(calls) > 0)
 	text := strings.TrimSpace(strings.Join(parts, "\n"))
 	if finishReason == llm.FinishReasonRefusal {
-		text = anthropicRefusalText(response.StopDetails)
+		if text == "" {
+			text = anthropicRefusalText(response.StopDetails)
+		}
 		calls = nil
 	}
 
@@ -377,9 +379,6 @@ func anthropicRefusalText(details *anthropicStopDetails) string {
 }
 
 func anthropicFinishReason(reason string, hasToolCalls bool) llm.FinishReason {
-	if hasToolCalls {
-		return llm.FinishReasonToolCalls
-	}
 	switch reason {
 	case "end_turn", "stop_sequence":
 		return llm.FinishReasonStop
@@ -390,6 +389,9 @@ func anthropicFinishReason(reason string, hasToolCalls bool) llm.FinishReason {
 	case "refusal":
 		return llm.FinishReasonRefusal
 	default:
+		if hasToolCalls {
+			return llm.FinishReasonToolCalls
+		}
 		return llm.FinishReasonUnknown
 	}
 }

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/samber/oops"
 
+	"github.com/omarluq/librecode/internal/anthropicmodel"
 	"github.com/omarluq/librecode/internal/llm"
 )
 
@@ -183,20 +184,27 @@ func anthropicSystemText(text string) map[string]any {
 
 func anthropicThinkingConfig(request *CompletionRequest) map[string]any {
 	if request.Request.ThinkingLevel == "" || request.Request.ThinkingLevel == thinkingOff {
+		if anthropicmodel.RequiresAdaptiveThinking(request.Request.Model.ID) {
+			return map[string]any{}
+		}
 		return map[string]any{jsonThinkingKey: map[string]any{jsonTypeKey: "disabled"}}
 	}
-	if anthropicSupportsAdaptiveThinking(request.Request.Model.ID) {
-		config := map[string]any{
-			jsonThinkingKey: map[string]any{jsonTypeKey: "adaptive", jsonDisplayKey: thinkingDisplaySummary},
-		}
-		if effort := anthropicThinkingEffort(request); effort != "" {
-			config["output_config"] = map[string]any{"effort": effort}
-		}
-
-		return config
+	if anthropicmodel.SupportsAdaptiveThinking(request.Request.Model.ID) {
+		return anthropicAdaptiveThinkingConfig(request)
 	}
 
 	return map[string]any{jsonThinkingKey: anthropicBudgetThinking(request.Request.ThinkingLevel)}
+}
+
+func anthropicAdaptiveThinkingConfig(request *CompletionRequest) map[string]any {
+	config := map[string]any{
+		jsonThinkingKey: map[string]any{jsonTypeKey: "adaptive", jsonDisplayKey: thinkingDisplaySummary},
+	}
+	if effort := anthropicThinkingEffort(request); effort != "" {
+		config["output_config"] = map[string]any{"effort": effort}
+	}
+
+	return config
 }
 
 func anthropicBudgetThinking(level string) map[string]any {
@@ -225,20 +233,9 @@ func anthropicThinkingEffort(request *CompletionRequest) string {
 	}
 }
 
-func anthropicSupportsAdaptiveThinking(modelID string) bool {
-	normalizedModelID := strings.ToLower(modelID)
-
-	return strings.Contains(normalizedModelID, "opus-4-6") ||
-		strings.Contains(normalizedModelID, "opus-4.6") ||
-		strings.Contains(normalizedModelID, "opus-4-7") ||
-		strings.Contains(normalizedModelID, "opus-4.7") ||
-		strings.Contains(normalizedModelID, "sonnet-4-6") ||
-		strings.Contains(normalizedModelID, "sonnet-4.6")
-}
-
 func anthropicBetaFeatures(request *CompletionRequest) []string {
 	features := []string{}
-	if request.Request.Model.Reasoning && !anthropicSupportsAdaptiveThinking(request.Request.Model.ID) {
+	if request.Request.Model.Reasoning && !anthropicmodel.SupportsAdaptiveThinking(request.Request.Model.ID) {
 		features = append(features, "interleaved-thinking-2025-05-14")
 	}
 
@@ -295,10 +292,11 @@ func (client *HTTPCompletionClient) requestAnthropic(
 
 func parseAnthropicResult(content []byte) (*providerResult, error) {
 	var response struct {
-		Error      providerError  `json:"error"`
-		Usage      map[string]any `json:"usage"`
-		StopReason string         `json:"stop_reason"`
-		Content    []struct {
+		Error       providerError         `json:"error"`
+		Usage       map[string]any        `json:"usage"`
+		StopDetails *anthropicStopDetails `json:"stop_details"`
+		StopReason  string                `json:"stop_reason"`
+		Content     []struct {
 			Type  string `json:"type"`
 			Text  string `json:"text"`
 			Input any    `json:"input"`
@@ -312,9 +310,40 @@ func parseAnthropicResult(content []byte) (*providerResult, error) {
 	if response.Error.Message != "" {
 		return nil, providerErrorToOops("anthropic_error", &response.Error)
 	}
-	parts := make([]string, 0, len(response.Content))
-	calls := make([]ToolCall, 0, len(response.Content))
-	for _, block := range response.Content {
+	parts, calls := anthropicContentParts(response.Content)
+	finishReason := anthropicFinishReason(response.StopReason, len(calls) > 0)
+	text := strings.TrimSpace(strings.Join(parts, "\n"))
+	if finishReason == llm.FinishReasonRefusal {
+		text = anthropicRefusalText(response.StopDetails)
+		calls = nil
+	}
+
+	return &providerResult{
+		FinishReason: finishReason,
+		Text:         text,
+		OutputItems:  nil,
+		Thinking:     nil,
+		ToolCalls:    calls,
+		Usage:        usageFromObject(response.Usage),
+	}, nil
+}
+
+type anthropicStopDetails struct {
+	Type        string `json:"type"`
+	Category    string `json:"category"`
+	Explanation string `json:"explanation"`
+}
+
+func anthropicContentParts(content []struct {
+	Type  string `json:"type"`
+	Text  string `json:"text"`
+	Input any    `json:"input"`
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+}) ([]string, []ToolCall) {
+	parts := make([]string, 0, len(content))
+	calls := make([]ToolCall, 0, len(content))
+	for _, block := range content {
 		switch block.Type {
 		case jsonTextKey:
 			if block.Text != "" {
@@ -325,14 +354,26 @@ func parseAnthropicResult(content []byte) (*providerResult, error) {
 		}
 	}
 
-	return &providerResult{
-		FinishReason: anthropicFinishReason(response.StopReason, len(calls) > 0),
-		Text:         strings.TrimSpace(strings.Join(parts, "\n")),
-		OutputItems:  nil,
-		Thinking:     nil,
-		ToolCalls:    calls,
-		Usage:        usageFromObject(response.Usage),
-	}, nil
+	return parts, calls
+}
+
+func anthropicRefusalText(details *anthropicStopDetails) string {
+	if details == nil {
+		return "The model refused the request."
+	}
+	explanation := strings.TrimSpace(details.Explanation)
+	category := strings.TrimSpace(details.Category)
+	if explanation != "" && category != "" {
+		return "The model refused the request (" + category + "): " + explanation
+	}
+	if explanation != "" {
+		return "The model refused the request: " + explanation
+	}
+	if category != "" {
+		return "The model refused the request (" + category + ")."
+	}
+
+	return "The model refused the request."
 }
 
 func anthropicFinishReason(reason string, hasToolCalls bool) llm.FinishReason {
@@ -342,10 +383,12 @@ func anthropicFinishReason(reason string, hasToolCalls bool) llm.FinishReason {
 	switch reason {
 	case "end_turn", "stop_sequence":
 		return llm.FinishReasonStop
-	case finishReasonMaxTokens:
+	case finishReasonMaxTokens, "model_context_window_exceeded":
 		return llm.FinishReasonLength
 	case "tool_use":
 		return llm.FinishReasonToolCalls
+	case "refusal":
+		return llm.FinishReasonRefusal
 	default:
 		return llm.FinishReasonUnknown
 	}

--- a/internal/provider/anthropic_internal_test.go
+++ b/internal/provider/anthropic_internal_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/omarluq/librecode/internal/anthropicmodel"
 	"github.com/omarluq/librecode/internal/llm"
 )
 
@@ -65,17 +66,57 @@ func TestAnthropicPayloadAddsBudgetThinking(t *testing.T) {
 	}, payload[jsonThinkingKey])
 }
 
-func TestAnthropicPayloadDisablesThinkingWhenOff(t *testing.T) {
+func TestAnthropicPayloadThinkingWhenOff(t *testing.T) {
 	t.Parallel()
 
-	request := testCompletionRequestAuth("sk-ant-api03-secret")
-	setTestRequestModelID(request, testAdaptiveAnthropicModelID)
-	setTestRequestReasoning(request, true)
-	setTestRequestThinkingLevel(request, thinkingOff)
-	payload := anthropicPayload(request, nil)
+	tests := []struct {
+		wantThinking map[string]any
+		name         string
+		modelID      string
+		wantEffort   string
+	}{
+		{
+			name:         "adaptive capable model can disable thinking",
+			modelID:      testAdaptiveAnthropicModelID,
+			wantThinking: map[string]any{jsonTypeKey: "disabled"},
+			wantEffort:   "",
+		},
+		{
+			name:         "fable omits unsupported disabled thinking",
+			modelID:      anthropicmodel.Fable5,
+			wantThinking: nil,
+			wantEffort:   "",
+		},
+		{
+			name:         "mythos omits unsupported disabled thinking",
+			modelID:      anthropicmodel.Mythos5,
+			wantThinking: nil,
+			wantEffort:   "",
+		},
+	}
 
-	assert.Equal(t, map[string]any{jsonTypeKey: "disabled"}, payload[jsonThinkingKey])
-	assert.NotContains(t, payload, "output_config")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			request := testCompletionRequestAuth("sk-ant-api03-secret")
+			setTestRequestModelID(request, test.modelID)
+			setTestRequestReasoning(request, true)
+			setTestRequestThinkingLevel(request, thinkingOff)
+			payload := anthropicPayload(request, nil)
+
+			if test.wantThinking == nil {
+				assert.NotContains(t, payload, jsonThinkingKey)
+			} else {
+				assert.Equal(t, test.wantThinking, payload[jsonThinkingKey])
+			}
+			if test.wantEffort == "" {
+				assert.NotContains(t, payload, "output_config")
+				return
+			}
+			assert.Equal(t, map[string]any{reasoningEffortKey: test.wantEffort}, payload["output_config"])
+		})
+	}
 }
 
 func TestAnthropicToolNameMapping(t *testing.T) {

--- a/internal/provider/anthropic_mapping_internal_test.go
+++ b/internal/provider/anthropic_mapping_internal_test.go
@@ -80,28 +80,45 @@ func TestParseAnthropicResultMapsFinishReason(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		want llm.FinishReason
-		name string
-		body string
+		want     llm.FinishReason
+		name     string
+		body     string
+		wantText string
 	}{
 		{
-			name: "max tokens",
-			body: `{"stop_reason":"max_tokens","content":[{"type":"text","text":"partial"}]}`,
-			want: llm.FinishReasonLength,
+			name:     "max tokens",
+			body:     `{"stop_reason":"max_tokens","content":[{"type":"text","text":"partial"}]}`,
+			want:     llm.FinishReasonLength,
+			wantText: "",
 		},
 		{
-			name: "context exceeded",
-			body: `{"stop_reason":"model_context_window_exceeded","content":[{"type":"text","text":"partial"}]}`,
-			want: llm.FinishReasonLength,
+			name:     "context exceeded",
+			body:     `{"stop_reason":"model_context_window_exceeded","content":[{"type":"text","text":"partial"}]}`,
+			want:     llm.FinishReasonLength,
+			wantText: "",
 		},
 		{
-			name: "refusal",
+			name: "refusal keeps provider text and drops tool calls",
 			body: `{
 				"stop_reason":"refusal",
 				"stop_details":{"type":"refusal","category":"cyber","explanation":"declined"},
-				"content":[{"type":"text","text":"partial"}]
+				"content":[
+					{"type":"text","text":"partial"},
+					{"type":"tool_use","id":"toolu_1","name":"read","input":{"path":"README.md"}}
+				]
 			}`,
-			want: llm.FinishReasonRefusal,
+			want:     llm.FinishReasonRefusal,
+			wantText: "partial",
+		},
+		{
+			name: "refusal without provider text uses stop details",
+			body: `{
+				"stop_reason":"refusal",
+				"stop_details":{"type":"refusal","category":"cyber","explanation":"declined"},
+				"content":[]
+			}`,
+			want:     llm.FinishReasonRefusal,
+			wantText: "The model refused the request (cyber): declined",
 		},
 	}
 
@@ -113,8 +130,11 @@ func TestParseAnthropicResultMapsFinishReason(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, test.want, result.FinishReason)
+			if test.wantText != "" {
+				assert.Equal(t, test.wantText, result.Text)
+			}
 			if test.want == llm.FinishReasonRefusal {
-				assert.Equal(t, "The model refused the request (cyber): declined", result.Text)
+				assert.Empty(t, result.ToolCalls)
 			}
 		})
 	}

--- a/internal/provider/anthropic_mapping_internal_test.go
+++ b/internal/provider/anthropic_mapping_internal_test.go
@@ -76,16 +76,48 @@ func TestAnthropicToolArgumentsHandlesMalformedAndScalarInput(t *testing.T) {
 	assert.JSONEq(t, `"plain"`, argumentsJSON)
 }
 
-func TestParseAnthropicResultMapsMaxTokensFinishReason(t *testing.T) {
+func TestParseAnthropicResultMapsFinishReason(t *testing.T) {
 	t.Parallel()
 
-	result, err := parseAnthropicResult([]byte(
-		`{"stop_reason":"max_tokens","content":[{"type":"text","text":"partial"}]}`,
-	))
+	tests := []struct {
+		want llm.FinishReason
+		name string
+		body string
+	}{
+		{
+			name: "max tokens",
+			body: `{"stop_reason":"max_tokens","content":[{"type":"text","text":"partial"}]}`,
+			want: llm.FinishReasonLength,
+		},
+		{
+			name: "context exceeded",
+			body: `{"stop_reason":"model_context_window_exceeded","content":[{"type":"text","text":"partial"}]}`,
+			want: llm.FinishReasonLength,
+		},
+		{
+			name: "refusal",
+			body: `{
+				"stop_reason":"refusal",
+				"stop_details":{"type":"refusal","category":"cyber","explanation":"declined"},
+				"content":[{"type":"text","text":"partial"}]
+			}`,
+			want: llm.FinishReasonRefusal,
+		},
+	}
 
-	require.NoError(t, err)
-	assert.Equal(t, "partial", result.Text)
-	assert.Equal(t, llm.FinishReasonLength, result.FinishReason)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := parseAnthropicResult([]byte(test.body))
+
+			require.NoError(t, err)
+			assert.Equal(t, test.want, result.FinishReason)
+			if test.want == llm.FinishReasonRefusal {
+				assert.Equal(t, "The model refused the request (cyber): declined", result.Text)
+			}
+		})
+	}
 }
 
 func TestAnthropicAssistantToolMessageMapsProviderNames(t *testing.T) {


### PR DESCRIPTION
## Summary
- add built-in Claude Fable/Mythos model metadata and make Fable the Anthropic default
- centralize Anthropic model capability detection for adaptive thinking
- map Anthropic refusal stop reasons to a dedicated finish reason

## Validation
- go test ./internal/anthropicmodel ./internal/provider ./internal/model ./internal/llm
- golangci-lint run ./internal/anthropicmodel ./internal/provider ./internal/model ./internal/llm
- task ci