### PR TITLE
fix(database): wait for SQLite writer contention

### DIFF
--- a/cmd/librecode/config_internal_test.go
+++ b/cmd/librecode/config_internal_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:paralleltest // Uses package-level cfgFile flag state.
+func TestConfigShowCommandPrintsResolvedConfig(t *testing.T) {
+	configPath := writeTestConfig(t, "database:\n  busy_timeout: 7s\nextensions:\n  use: []\n")
+	withConfigFile(t, configPath)
+
+	cmd := newConfigShowCmd()
+	output := new(bytes.Buffer)
+	cmd.SetOut(output)
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, output.String(), "Environment: development")
+	assert.Contains(t, output.String(), "database.busy_timeout")
+	assert.Contains(t, output.String(), "7s")
+}
+
+//nolint:paralleltest // Uses package-level cfgFile flag state.
+func TestConfigValidateCommandPrintsSuccess(t *testing.T) {
+	configPath := writeTestConfig(t, "extensions:\n  use: []\n")
+	withConfigFile(t, configPath)
+
+	cmd := newConfigValidateCmd()
+	output := new(bytes.Buffer)
+	cmd.SetOut(output)
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "configuration is valid\n", output.String())
+}
+
+//nolint:paralleltest // Uses package-level cfgFile flag state.
+func TestLoadConfigWrapsInvalidConfig(t *testing.T) {
+	configPath := writeTestConfig(t, "database:\n  busy_timeout: -1s\nextensions:\n  use: []\n")
+	withConfigFile(t, configPath)
+
+	_, err := loadConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load configuration")
+	assert.Contains(t, err.Error(), "database.busy_timeout cannot be negative")
+}
+
+func writeTestConfig(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	writeCLIFile(t, path, content)
+
+	return path
+}
+
+var cfgFileTestMu sync.Mutex
+
+func withConfigFile(t *testing.T, path string) {
+	t.Helper()
+
+	cfgFileTestMu.Lock()
+	previous := cfgFile
+	cfgFile = path
+	t.Cleanup(func() {
+		cfgFile = previous
+		cfgFileTestMu.Unlock()
+	})
+}

--- a/cmd/librecode/root_test.go
+++ b/cmd/librecode/root_test.go
@@ -10,9 +10,8 @@ import (
 	main "github.com/omarluq/librecode/cmd/librecode"
 )
 
+//nolint:paralleltest // newRootCmd binds package-level flag variables.
 func TestRootCmd_HelpFlagShowsHelp(t *testing.T) {
-	t.Parallel()
-
 	cmd := main.NewRootCmdForTest()
 	buf := new(bytes.Buffer)
 	cmd.SetOut(buf)
@@ -21,4 +20,16 @@ func TestRootCmd_HelpFlagShowsHelp(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "librecode")
+}
+
+//nolint:paralleltest // newRootCmd binds package-level flag variables.
+func TestRootCmd_VersionFlagShowsVersion(t *testing.T) {
+	cmd := main.NewRootCmdForTest()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"version"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.NotEmpty(t, buf.String())
 }

--- a/cmd/librecode/runtime.go
+++ b/cmd/librecode/runtime.go
@@ -22,7 +22,7 @@ func withContainer(ctx context.Context, handler func(*di.Container) error) error
 }
 
 func finishContainerRun(runErr error, shutdownReport *do.ShutdownReport) error {
-	if !shutdownReport.Succeed && shutdownReport.Error() != "" {
+	if shutdownReport != nil && !shutdownReport.Succeed && shutdownReport.Error() != "" {
 		shutdownErr := fmt.Errorf("%w", shutdownReport)
 		if runErr != nil {
 			return errors.Join(runErr, shutdownErr)

--- a/cmd/librecode/runtime.go
+++ b/cmd/librecode/runtime.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/samber/do/v2"
+
 	"github.com/omarluq/librecode/internal/di"
 )
 
@@ -15,7 +17,11 @@ func withContainer(ctx context.Context, handler func(*di.Container) error) error
 	}
 
 	runErr := handler(container)
-	shutdownReport := container.ShutdownWithContext(ctx)
+
+	return finishContainerRun(runErr, container.ShutdownWithContext(ctx))
+}
+
+func finishContainerRun(runErr error, shutdownReport *do.ShutdownReport) error {
 	if !shutdownReport.Succeed && shutdownReport.Error() != "" {
 		shutdownErr := fmt.Errorf("%w", shutdownReport)
 		if runErr != nil {

--- a/cmd/librecode/runtime_internal_test.go
+++ b/cmd/librecode/runtime_internal_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/samber/do/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/di"
+)
+
+//nolint:paralleltest // Uses package-level cfgFile and disableExtensions flag state.
+func TestWithContainerRunsHandler(t *testing.T) {
+	withConfigFile(t, writeTestConfig(t, "extensions:\n  use: []\n"))
+	withDisableExtensions(t, true)
+
+	called := false
+	err := withContainer(context.Background(), func(container *di.Container) error {
+		called = true
+		require.NotNil(t, container)
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+//nolint:paralleltest // Uses package-level cfgFile and disableExtensions flag state.
+func TestWithContainerReturnsHandlerError(t *testing.T) {
+	withConfigFile(t, writeTestConfig(t, "extensions:\n  use: []\n"))
+	withDisableExtensions(t, true)
+
+	expectedErr := errors.New("handler failed")
+	err := withContainer(context.Background(), func(*di.Container) error {
+		return expectedErr
+	})
+
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestFinishContainerRunCombinesRunAndShutdownErrors(t *testing.T) {
+	t.Parallel()
+	runErr := errors.New("run failed")
+	err := finishContainerRun(runErr, failedShutdownReport(errors.New("shutdown failed")))
+
+	require.ErrorIs(t, err, runErr)
+	assert.Contains(t, err.Error(), "shutdown failed")
+}
+
+func TestFinishContainerRunReturnsShutdownError(t *testing.T) {
+	t.Parallel()
+	err := finishContainerRun(nil, failedShutdownReport(errors.New("shutdown failed")))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shutdown failed")
+}
+
+//nolint:paralleltest // Uses package-level cfgFile and disableExtensions flag state.
+func TestWithContainerReturnsConfigError(t *testing.T) {
+	withConfigFile(t, writeTestConfig(t, "database:\n  busy_timeout: -1s\nextensions:\n  use: []\n"))
+	withDisableExtensions(t, true)
+
+	err := withContainer(context.Background(), func(*di.Container) error {
+		return nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database.busy_timeout cannot be negative")
+}
+
+func failedShutdownReport(err error) *do.ShutdownReport {
+	return &do.ShutdownReport{
+		Succeed: false,
+		Errors: map[do.ServiceDescription]error{
+			{Service: "database"}: err,
+		},
+	}
+}
+
+func withDisableExtensions(t *testing.T, disabled bool) {
+	t.Helper()
+
+	previous := disableExtensions
+	disableExtensions = disabled
+	t.Cleanup(func() { disableExtensions = previous })
+}

--- a/cmd/librecode/runtime_internal_test.go
+++ b/cmd/librecode/runtime_internal_test.go
@@ -42,21 +42,72 @@ func TestWithContainerReturnsHandlerError(t *testing.T) {
 	require.ErrorIs(t, err, expectedErr)
 }
 
-func TestFinishContainerRunCombinesRunAndShutdownErrors(t *testing.T) {
+func TestFinishContainerRun(t *testing.T) {
 	t.Parallel()
+
 	runErr := errors.New("run failed")
-	err := finishContainerRun(runErr, failedShutdownReport(errors.New("shutdown failed")))
 
-	require.ErrorIs(t, err, runErr)
-	assert.Contains(t, err.Error(), "shutdown failed")
-}
+	tests := []struct {
+		name           string
+		report         *do.ShutdownReport
+		runErr         error
+		expectErrIs    error
+		expectContains string
+		expectErr      bool
+	}{
+		{
+			name:           "run and shutdown errors",
+			report:         failedShutdownReport(errors.New("shutdown failed")),
+			runErr:         runErr,
+			expectErrIs:    runErr,
+			expectContains: "shutdown failed",
+			expectErr:      true,
+		},
+		{
+			name:           "shutdown error only",
+			report:         failedShutdownReport(errors.New("shutdown failed")),
+			runErr:         nil,
+			expectErrIs:    nil,
+			expectContains: "shutdown failed",
+			expectErr:      true,
+		},
+		{
+			name:           "run error only",
+			report:         nil,
+			runErr:         runErr,
+			expectErrIs:    runErr,
+			expectContains: "",
+			expectErr:      true,
+		},
+		{
+			name:           "nil shutdown report success",
+			report:         nil,
+			runErr:         nil,
+			expectErrIs:    nil,
+			expectContains: "",
+			expectErr:      false,
+		},
+	}
 
-func TestFinishContainerRunReturnsShutdownError(t *testing.T) {
-	t.Parallel()
-	err := finishContainerRun(nil, failedShutdownReport(errors.New("shutdown failed")))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "shutdown failed")
+			err := finishContainerRun(test.runErr, test.report)
+			if !test.expectErr {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			if test.expectErrIs != nil {
+				require.ErrorIs(t, err, test.expectErrIs)
+			}
+			if test.expectContains != "" {
+				assert.Contains(t, err.Error(), test.expectContains)
+			}
+		})
+	}
 }
 
 //nolint:paralleltest // Uses package-level cfgFile and disableExtensions flag state.

--- a/internal/database/repository_helpers_internal_test.go
+++ b/internal/database/repository_helpers_internal_test.go
@@ -1,0 +1,134 @@
+package database
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectSQLRowsReturnsConvertedRows(t *testing.T) {
+	t.Parallel()
+
+	rows, err := collectSQLRows([]string{"alpha", "beta"}, func(row *string) (*int, error) {
+		length := len(*row)
+		return &length, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []int{5, 4}, rows)
+}
+
+func TestCollectSQLRowsReturnsConversionError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("bad row")
+	rows, err := collectSQLRows([]string{"alpha"}, func(*string) (*int, error) {
+		return nil, expectedErr
+	})
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Nil(t, rows)
+}
+
+const (
+	testRowSessionID = "session-id"
+	testRowCreatedAt = "2026-01-01T00:00:00Z"
+)
+
+func TestRowConvertersReturnTimestampErrors(t *testing.T) {
+	t.Parallel()
+
+	const invalidTimestamp = "not-time"
+
+	session := validSessionRow()
+	session.CreatedAt = invalidTimestamp
+	_, err := sessionFromRow(&session)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "parse timestamp")
+
+	session = validSessionRow()
+	session.UpdatedAt = invalidTimestamp
+	_, err = sessionFromRow(&session)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "parse timestamp")
+
+	entry := validEntryRow()
+	entry.CreatedAt = invalidTimestamp
+	_, err = entryFromRow(&entry)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "parse timestamp")
+
+	message := validSessionMessageRow()
+	message.CreatedAt = invalidTimestamp
+	_, err = sessionMessageFromRow(&message)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "parse timestamp")
+
+	document := validDocumentRow()
+	document.UpdatedAt = invalidTimestamp
+	_, err = documentFromRow(&document)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "parse timestamp")
+}
+
+func validSessionRow() sessionRow {
+	return sessionRow{
+		ID:            testRowSessionID,
+		CWD:           "/work",
+		Name:          "session",
+		ParentSession: "",
+		CreatedAt:     testRowCreatedAt,
+		UpdatedAt:     "2026-01-01T00:00:01Z",
+	}
+}
+
+func validEntryRow() entryRow {
+	return entryRow{
+		ParentID:                   nil,
+		ID:                         "entry-id",
+		SessionID:                  testRowSessionID,
+		EntryType:                  string(EntryTypeMessage),
+		Role:                       string(RoleUser),
+		Content:                    "hello",
+		Provider:                   "",
+		Model:                      "",
+		CustomType:                 "",
+		DataJSON:                   "{}",
+		Summary:                    "",
+		CreatedAt:                  testRowCreatedAt,
+		ToolName:                   "",
+		ToolStatus:                 "",
+		ToolArgsJSON:               "",
+		CompactionFirstKeptEntryID: "",
+		BranchFromEntryID:          "",
+		TokenEstimate:              1,
+		ModelFacing:                1,
+		Display:                    1,
+		CompactionTokensBefore:     0,
+	}
+}
+
+func validSessionMessageRow() sessionMessageRow {
+	return sessionMessageRow{
+		ID:        "message-id",
+		SessionID: testRowSessionID,
+		EntryID:   "entry-id",
+		Sender:    string(RoleUser),
+		Role:      string(RoleUser),
+		Content:   "hello",
+		Provider:  "",
+		Model:     "",
+		CreatedAt: testRowCreatedAt,
+	}
+}
+
+func validDocumentRow() documentRow {
+	return documentRow{
+		Namespace: "settings",
+		Key:       "global",
+		ValueJSON: "{}",
+		UpdatedAt: testRowCreatedAt,
+	}
+}

--- a/internal/database/repository_helpers_internal_test.go
+++ b/internal/database/repository_helpers_internal_test.go
@@ -42,35 +42,66 @@ func TestRowConvertersReturnTimestampErrors(t *testing.T) {
 
 	const invalidTimestamp = "not-time"
 
-	session := validSessionRow()
-	session.CreatedAt = invalidTimestamp
-	_, err := sessionFromRow(&session)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "parse timestamp")
+	tests := []struct {
+		run  func() error
+		name string
+	}{
+		{
+			name: "session created_at",
+			run: func() error {
+				row := validSessionRow()
+				row.CreatedAt = invalidTimestamp
+				_, err := sessionFromRow(&row)
+				return err
+			},
+		},
+		{
+			name: "session updated_at",
+			run: func() error {
+				row := validSessionRow()
+				row.UpdatedAt = invalidTimestamp
+				_, err := sessionFromRow(&row)
+				return err
+			},
+		},
+		{
+			name: "entry created_at",
+			run: func() error {
+				row := validEntryRow()
+				row.CreatedAt = invalidTimestamp
+				_, err := entryFromRow(&row)
+				return err
+			},
+		},
+		{
+			name: "session_message created_at",
+			run: func() error {
+				row := validSessionMessageRow()
+				row.CreatedAt = invalidTimestamp
+				_, err := sessionMessageFromRow(&row)
+				return err
+			},
+		},
+		{
+			name: "document updated_at",
+			run: func() error {
+				row := validDocumentRow()
+				row.UpdatedAt = invalidTimestamp
+				_, err := documentFromRow(&row)
+				return err
+			},
+		},
+	}
 
-	session = validSessionRow()
-	session.UpdatedAt = invalidTimestamp
-	_, err = sessionFromRow(&session)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "parse timestamp")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-	entry := validEntryRow()
-	entry.CreatedAt = invalidTimestamp
-	_, err = entryFromRow(&entry)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "parse timestamp")
-
-	message := validSessionMessageRow()
-	message.CreatedAt = invalidTimestamp
-	_, err = sessionMessageFromRow(&message)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "parse timestamp")
-
-	document := validDocumentRow()
-	document.UpdatedAt = invalidTimestamp
-	_, err = documentFromRow(&document)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "parse timestamp")
+			err := test.run()
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "parse timestamp")
+		})
+	}
 }
 
 func validSessionRow() sessionRow {

--- a/internal/database/runtime_document_repository_test.go
+++ b/internal/database/runtime_document_repository_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/omarluq/librecode/internal/database"
 )
 
+const testDocumentNamespace = "settings"
+
 func TestDocumentRepositoryStoresRuntimeDocuments(t *testing.T) {
 	t.Parallel()
 
@@ -21,25 +23,25 @@ func TestDocumentRepositoryStoresRuntimeDocuments(t *testing.T) {
 
 	document := database.DocumentEntity{
 		UpdatedAt: time.Time{},
-		Namespace: "settings",
+		Namespace: testDocumentNamespace,
 		Key:       "global",
 		ValueJSON: `{"ok":true}`,
 	}
 	require.NoError(t, repository.Put(ctx, &document))
 
-	loaded, found, err := repository.Get(ctx, "settings", "global")
+	loaded, found, err := repository.Get(ctx, testDocumentNamespace, "global")
 	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, document.ValueJSON, loaded.ValueJSON)
 
-	source := database.NewDocumentSource(repository, "settings", "global")
+	source := database.NewDocumentSource(repository, testDocumentNamespace, "global")
 	content, found, err := source.Read()
 	require.NoError(t, err)
 	require.True(t, found)
 	assert.JSONEq(t, document.ValueJSON, string(content))
 
-	require.NoError(t, repository.Delete(ctx, "settings", "global"))
-	_, found, err = repository.Get(ctx, "settings", "global")
+	require.NoError(t, repository.Delete(ctx, testDocumentNamespace, "global"))
+	_, found, err = repository.Get(ctx, testDocumentNamespace, "global")
 	require.NoError(t, err)
 	assert.False(t, found)
 }

--- a/internal/database/session_repository_test.go
+++ b/internal/database/session_repository_test.go
@@ -70,6 +70,15 @@ func TestSessionRepository_AppendsMessagesInSessionTree(t *testing.T) {
 	require.NotNil(t, entries[1].ParentID)
 	assert.Equal(t, firstEntry.ID, *entries[1].ParentID)
 
+	rootChildren, err := repository.Children(ctx, createdSession.ID, nil)
+	require.NoError(t, err)
+	require.Len(t, rootChildren, 1)
+	assert.Equal(t, firstEntry.ID, rootChildren[0].ID)
+	childEntries, err := repository.Children(ctx, createdSession.ID, &firstEntry.ID)
+	require.NoError(t, err)
+	require.Len(t, childEntries, 1)
+	assert.Equal(t, secondEntry.ID, childEntries[0].ID)
+
 	messages, err := repository.Messages(ctx, createdSession.ID)
 	require.NoError(t, err)
 	require.Len(t, messages, 2)
@@ -134,6 +143,31 @@ func TestSessionRepository_AppendMessagePreservesInputTimestamp(t *testing.T) {
 			assert.Equal(t, expectedTimestamp, storedMessage.CreatedAt)
 		})
 	}
+}
+
+func TestSessionRepository_LoadsAndListsSessions(t *testing.T) {
+	t.Parallel()
+
+	repository := newTestSessionRepository(t)
+	ctx := context.Background()
+
+	oldSession, err := repository.CreateSession(ctx, "/work", "old", "")
+	require.NoError(t, err)
+	newSession, err := repository.CreateSession(ctx, "/work", "new", oldSession.ID)
+	require.NoError(t, err)
+	_, err = repository.CreateSession(ctx, "/other", "other", "")
+	require.NoError(t, err)
+
+	foundSession, found, err := repository.GetSession(ctx, newSession.ID)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, oldSession.ID, foundSession.ParentSession)
+
+	sessions, err := repository.ListSessions(ctx, "/work")
+	require.NoError(t, err)
+	require.Len(t, sessions, 2)
+	assert.Equal(t, newSession.ID, sessions[0].ID)
+	assert.Equal(t, oldSession.ID, sessions[1].ID)
 }
 
 func TestSessionRepository_DeleteSessionRemovesSessionRows(t *testing.T) {

--- a/internal/database/validation_test.go
+++ b/internal/database/validation_test.go
@@ -19,6 +19,12 @@ type invalidUUIDCase struct {
 	wantError string
 }
 
+type invalidEntityCase struct {
+	run       func(context.Context, *database.SessionRepository, *database.SessionEntity) error
+	name      string
+	wantError string
+}
+
 func TestRepositoryRejectsInvalidUUIDs(t *testing.T) {
 	t.Parallel()
 
@@ -40,12 +46,118 @@ func TestRepositoryRejectsInvalidUUIDs(t *testing.T) {
 	}
 }
 
+func TestRepositoryRejectsInvalidEntities(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range invalidEntityCases() {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			repository := newTestSessionRepository(t)
+			session, err := repository.CreateSession(ctx, "/work", "validation", "")
+			require.NoError(t, err)
+
+			err = test.run(ctx, repository, session)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantError)
+		})
+	}
+}
+
 func invalidUUIDCases() []invalidUUIDCase {
 	return []invalidUUIDCase{
 		invalidSessionIDCase(),
 		invalidEntryIDCase(),
 		invalidMessageEntryIDCase(),
 		invalidMessageIDCase(),
+	}
+}
+
+func invalidEntityCases() []invalidEntityCase {
+	return []invalidEntityCase{
+		{
+			name: "blank session cwd",
+			run: func(ctx context.Context, repository *database.SessionRepository, _ *database.SessionEntity) error {
+				_, err := repository.CreateSession(ctx, "", "invalid", "")
+
+				return err
+			},
+			wantError: "session.cwd is required",
+		},
+		{
+			name:      "blank message sender",
+			run:       appendBlankCustomMessage,
+			wantError: "message.sender is required",
+		},
+	}
+}
+
+func appendBlankCustomMessage(
+	ctx context.Context,
+	repository *database.SessionRepository,
+	session *database.SessionEntity,
+) error {
+	_, err := repository.AppendCustomMessage(ctx, session.ID, nil, " ", "hello", true, nil)
+
+	return err
+}
+
+func TestDocumentRepositoryRejectsInvalidEntities(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range invalidDocumentCases() {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			documents := database.NewDocumentRepository(newTestConnection(t))
+			err := documents.Put(context.Background(), &test.document)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantError)
+		})
+	}
+}
+
+func invalidDocumentCases() []struct {
+	document  database.DocumentEntity
+	name      string
+	wantError string
+} {
+	return []struct {
+		document  database.DocumentEntity
+		name      string
+		wantError string
+	}{
+		{
+			name: "blank namespace",
+			document: database.DocumentEntity{
+				UpdatedAt: time.Time{},
+				Namespace: " ",
+				Key:       "app",
+				ValueJSON: "{}",
+			},
+			wantError: "document.namespace is required",
+		},
+		{
+			name: "blank key",
+			document: database.DocumentEntity{
+				UpdatedAt: time.Time{},
+				Namespace: testDocumentNamespace,
+				Key:       " ",
+				ValueJSON: "{}",
+			},
+			wantError: "document.key is required",
+		},
+		{
+			name: "invalid JSON",
+			document: database.DocumentEntity{
+				UpdatedAt: time.Time{},
+				Namespace: testDocumentNamespace,
+				Key:       "app",
+				ValueJSON: "{",
+			},
+			wantError: "document.value_json must be valid JSON",
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary
- harden SQLite connections with busy timeout, WAL, synchronous=NORMAL, and foreign keys
- migrate repositories to github.com/vingarcia/ksql with the modernc SQLite adapter
- remove the mistaken Confluent ksqlDB REST client/config/DI surface
- add contention, pragma, migration, and repository coverage

## Validation
- go test ./...
- golangci-lint run ./internal/database ./internal/di ./internal/config ./cmd/librecode
- task ci