### PR TITLE
fix(tui): preserve list border styling

### DIFF
--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -246,14 +246,14 @@ func (list *List) Render(options *ListRenderOptions) []Line {
 
 	lines = append(lines,
 		NewLine(options.Styles.Border, TopBorder(width, "")),
-		NewLine(options.Styles.Accent.Bold(true), listRow(list.Title, contentWidth)),
+		listRow(list.Title, contentWidth, options.Styles.Accent.Bold(true), options.Styles.Border),
 	)
 	if list.Subtitle != "" {
-		lines = append(lines, NewLine(options.Styles.Muted, listRow(list.Subtitle, contentWidth)))
+		lines = append(lines, listRow(list.Subtitle, contentWidth, options.Styles.Muted, options.Styles.Border))
 	}
 
 	if list.searchable {
-		lines = append(lines, NewLine(options.Styles.Text, listRow("Search: "+list.query, contentWidth)))
+		lines = append(lines, listRow("Search: "+list.query, contentWidth, options.Styles.Text, options.Styles.Border))
 	}
 
 	lines = append(lines, NewLine(options.Styles.Border, MiddleBorder(width)))
@@ -272,8 +272,16 @@ func (list *List) Draw(screen ContentSetter, rect Rect, styles *ListStyles, hint
 	DrawLines(screen, rect, list.Render(&options))
 }
 
-func listRow(text string, width int) string {
-	return "│ " + PadRight(text, width) + " │"
+func listRow(text string, width int, contentStyle, borderStyle tcell.Style) Line {
+	return Line{
+		Text:  "│ " + PadRight(text, width) + " │",
+		Style: contentStyle,
+		Spans: []Span{
+			{Text: "│", Style: borderStyle},
+			{Text: " " + PadRight(text, width) + " ", Style: contentStyle},
+			{Text: "│", Style: borderStyle},
+		},
+	}
 }
 
 func safeListStyles(styles *ListStyles) ListStyles {
@@ -293,7 +301,7 @@ func safeListStyles(styles *ListStyles) ListStyles {
 
 func (list *List) itemLines(contentWidth, maxItems int, styles *ListStyles) []Line {
 	if len(list.filtered) == 0 {
-		return []Line{NewLine(styles.Muted, listRow("No matches", contentWidth))}
+		return []Line{listRow("No matches", contentWidth, styles.Muted, styles.Border)}
 	}
 
 	startIndex := list.windowStart(maxItems)
@@ -309,7 +317,7 @@ func (list *List) itemLines(contentWidth, maxItems int, styles *ListStyles) []Li
 
 func (list *List) itemLine(index, width int, styles *ListStyles) Line {
 	if index < 0 || index >= len(list.filtered) {
-		return NewLine(styles.Muted, listRow("", width))
+		return listRow("", width, styles.Muted, styles.Border)
 	}
 
 	item := list.filtered[index]
@@ -330,7 +338,7 @@ func (list *List) itemLine(index, width int, styles *ListStyles) Line {
 		text += " — " + item.Description
 	}
 
-	return NewLine(style, listRow(text, width))
+	return listRow(text, width, style, styles.Border)
 }
 
 func (list *List) windowStart(maxItems int) int {
@@ -356,7 +364,7 @@ func (list *List) hintLine(contentWidth, width int, styles *ListStyles, hints Li
 	hint := hints.Up + "/" + hints.Down + " navigate · " +
 		hints.Confirm + " select · " + hints.Cancel + " cancel" + position
 
-	return NewLine(styles.Dim, listRow(hint, contentWidth))
+	return listRow(hint, contentWidth, styles.Dim, styles.Border)
 }
 
 // SelectList is an alias for List when used as a picker.

--- a/internal/tui/list_test.go
+++ b/internal/tui/list_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gdamore/tcell/v3"
+	cellcolor "github.com/gdamore/tcell/v3/color"
 	"github.com/stretchr/testify/require"
 
 	"github.com/omarluq/librecode/internal/tui"
@@ -47,20 +48,68 @@ func TestListModelFilteringSelectionRenderingAndDraw(t *testing.T) {
 
 	list.ShowDetails = false
 	list.AppendQueryRune('w')
-	lines := list.Render(listOptions(28, 8, tui.ListHints{Up: "↑", Down: "↓", Confirm: "enter", Cancel: "esc"}))
+	lines := list.Render(listOptions(28, 8, tui.ListHints{Up: "↑", Down: "↓", Confirm: testEnter, Cancel: testEsc}))
 	rendered := strings.Join(lineTexts(lines), "\n")
 	require.Contains(t, rendered, "Pick")
 	require.Contains(t, rendered, "Search: tw")
 	require.Contains(t, rendered, "→ Beta two")
 
 	buffer := tui.NewCellBuffer(28, 8, tcell.StyleDefault)
-	list.Draw(buffer, testRect(0, 0, 28, 8), nil, tui.ListHints{Up: "k", Down: "j", Confirm: "enter", Cancel: "esc"})
+	list.Draw(
+		buffer,
+		testRect(0, 0, 28, 8),
+		nil,
+		tui.ListHints{Up: "k", Down: "j", Confirm: testEnter, Cancel: testEsc},
+	)
 	require.Equal(t, '╭', buffer.Cell(0, 0).Rune)
 
 	empty := tui.NewList("Empty", "", []tui.ListItem{testListItem("", "Hidden", "", "")}, true)
 	empty.AppendQueryRune('z')
 	emptyLines := strings.Join(lineTexts(empty.Render(listOptions(20, 6, emptyListHints()))), "\n")
 	require.Contains(t, emptyLines, "No matches")
+}
+
+func TestListRowsKeepBorderStyleSeparateFromContentStyle(t *testing.T) {
+	t.Parallel()
+
+	border := tcell.StyleDefault.Foreground(cellcolor.Blue)
+	accent := tcell.StyleDefault.Foreground(cellcolor.Red)
+	selected := tcell.StyleDefault.Foreground(cellcolor.Green)
+	list := tui.NewList("Pick", "", []tui.ListItem{testListItem("a", "Alpha", "", "")}, false)
+
+	lines := list.Render(&tui.ListRenderOptions{
+		Styles: tui.ListStyles{
+			Border:   border,
+			Accent:   accent,
+			Muted:    tcell.StyleDefault,
+			Text:     tcell.StyleDefault,
+			Selected: selected,
+			Dim:      tcell.StyleDefault,
+		},
+		Hints:  tui.ListHints{Up: "up", Down: "down", Confirm: testEnter, Cancel: testEsc},
+		Width:  16,
+		Height: 6,
+	})
+	require.Equal(t, "│", lines[1].Spans[0].Text)
+	require.Equal(t, cellcolor.Blue, lines[1].Spans[0].Style.GetForeground())
+	require.Equal(t, cellcolor.Red, lines[1].Spans[1].Style.GetForeground())
+	require.Equal(t, cellcolor.Blue, lines[1].Spans[2].Style.GetForeground())
+
+	buffer := tui.NewCellBuffer(16, 6, tcell.StyleDefault)
+	list.Draw(buffer, testRect(0, 0, 16, 6), &tui.ListStyles{
+		Border:   border,
+		Accent:   accent,
+		Muted:    tcell.StyleDefault,
+		Text:     tcell.StyleDefault,
+		Selected: selected,
+		Dim:      tcell.StyleDefault,
+	}, tui.ListHints{Up: "up", Down: "down", Confirm: testEnter, Cancel: testEsc})
+	require.Equal(t, cellcolor.Blue, buffer.Cell(0, 1).Style.GetForeground())
+	require.Equal(t, cellcolor.Red, buffer.Cell(2, 1).Style.GetForeground())
+	require.Equal(t, cellcolor.Blue, buffer.Cell(15, 1).Style.GetForeground())
+	require.Equal(t, cellcolor.Blue, buffer.Cell(0, 3).Style.GetForeground())
+	require.Equal(t, cellcolor.Green, buffer.Cell(2, 3).Style.GetForeground())
+	require.Equal(t, cellcolor.Blue, buffer.Cell(15, 3).Style.GetForeground())
 }
 
 func TestAutocompleteCreatesList(t *testing.T) {

--- a/internal/tui/test_helpers_test.go
+++ b/internal/tui/test_helpers_test.go
@@ -11,6 +11,8 @@ import (
 const (
 	testAlpha = "alpha"
 	testBeta  = "beta"
+	testEnter = "enter"
+	testEsc   = "esc"
 	testHello = "hello"
 	testOne   = "one"
 )


### PR DESCRIPTION
## Summary
- render list row borders as separate styled spans
- keep panel border colors independent from row content colors
- add regression coverage for rendered list border styles

## Tests
- go test ./internal/tui