### PR TITLE
perf(core): cache skills loading with fsnotify invalidation

### DIFF
--- a/internal/assistant/context_auto_compaction_internal_test.go
+++ b/internal/assistant/context_auto_compaction_internal_test.go
@@ -43,17 +43,7 @@ func TestRuntime_PrepareCompletionRequestWithAutoCompactionInputValidation(t *te
 }
 
 func runtimeWithoutDependencies() Runtime {
-	return Runtime{
-		cfg:         nil,
-		sessions:    nil,
-		extensions:  nil,
-		cache:       nil,
-		events:      nil,
-		models:      nil,
-		client:      nil,
-		logger:      nil,
-		skillsCache: nil,
-	}
+	return *newRuntimeFromDeps(nil)
 }
 
 func requirePrepareInputError(t *testing.T, err error) {

--- a/internal/assistant/context_auto_compaction_internal_test.go
+++ b/internal/assistant/context_auto_compaction_internal_test.go
@@ -44,14 +44,15 @@ func TestRuntime_PrepareCompletionRequestWithAutoCompactionInputValidation(t *te
 
 func runtimeWithoutDependencies() Runtime {
 	return Runtime{
-		cfg:        nil,
-		sessions:   nil,
-		extensions: nil,
-		cache:      nil,
-		events:     nil,
-		models:     nil,
-		client:     nil,
-		logger:     nil,
+		cfg:         nil,
+		sessions:    nil,
+		extensions:  nil,
+		cache:       nil,
+		events:      nil,
+		models:      nil,
+		client:      nil,
+		logger:      nil,
+		skillsCache: nil,
 	}
 }
 

--- a/internal/assistant/context_auto_compaction_test.go
+++ b/internal/assistant/context_auto_compaction_test.go
@@ -107,16 +107,13 @@ func newAutoCompactionTestRuntime(
 	// and do not depend on off-by-one budget boundaries.
 	runtimeConfig.Context.OutputReserveTokens = 1
 
-	return assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:      runtimeConfig,
-		Sessions:    runtime.SessionRepository(),
-		Extensions:  nil,
-		Cache:       assistant.NewResponseCache(false, 1, time.Minute),
-		Events:      runtime.EventBus(),
-		Models:      runtime.ModelRegistry(),
-		Client:      client,
-		Logger:      nil,
-		SkillsCache: nil,
+	return assistant.NewRuntimeForTest(func(opts *assistant.RuntimeTestOptions) {
+		opts.Config = runtimeConfig
+		opts.Sessions = runtime.SessionRepository()
+		opts.Cache = assistant.NewResponseCache(false, 1, time.Minute)
+		opts.Events = runtime.EventBus()
+		opts.Models = runtime.ModelRegistry()
+		opts.Client = client
 	})
 }
 

--- a/internal/assistant/context_auto_compaction_test.go
+++ b/internal/assistant/context_auto_compaction_test.go
@@ -108,14 +108,15 @@ func newAutoCompactionTestRuntime(
 	runtimeConfig.Context.OutputReserveTokens = 1
 
 	return assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:     runtimeConfig,
-		Sessions:   runtime.SessionRepository(),
-		Extensions: nil,
-		Cache:      assistant.NewResponseCache(false, 1, time.Minute),
-		Events:     runtime.EventBus(),
-		Models:     runtime.ModelRegistry(),
-		Client:     client,
-		Logger:     nil,
+		Config:      runtimeConfig,
+		Sessions:    runtime.SessionRepository(),
+		Extensions:  nil,
+		Cache:       assistant.NewResponseCache(false, 1, time.Minute),
+		Events:      runtime.EventBus(),
+		Models:      runtime.ModelRegistry(),
+		Client:      client,
+		Logger:      nil,
+		SkillsCache: nil,
 	})
 }
 

--- a/internal/assistant/context_budget_test.go
+++ b/internal/assistant/context_budget_test.go
@@ -40,14 +40,15 @@ func TestRuntime_ContextPreflightCanBeDisabled(t *testing.T) {
 	runtimeConfig := testConfig()
 	runtimeConfig.Context.PreflightEnabled = false
 	runtime = assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:     runtimeConfig,
-		Sessions:   runtime.SessionRepository(),
-		Extensions: nil,
-		Cache:      assistant.NewResponseCache(false, 1, time.Minute),
-		Events:     runtime.EventBus(),
-		Models:     runtime.ModelRegistry(),
-		Client:     client,
-		Logger:     nil,
+		Config:      runtimeConfig,
+		Sessions:    runtime.SessionRepository(),
+		Extensions:  nil,
+		Cache:       assistant.NewResponseCache(false, 1, time.Minute),
+		Events:      runtime.EventBus(),
+		Models:      runtime.ModelRegistry(),
+		Client:      client,
+		Logger:      nil,
+		SkillsCache: nil,
 	})
 
 	request := newRuntimePromptRequest(testRuntimeCWD, strings.Repeat("overflow ", 2600), "")
@@ -87,14 +88,15 @@ func TestRuntime_ContextUsageHonorsExplicitZeroReserves(t *testing.T) {
 	runtimeConfig.Context.ProviderReserveTokens = 0
 	runtimeConfig.Context.SafetyMarginTokens = 0
 	runtime = assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:     runtimeConfig,
-		Sessions:   runtime.SessionRepository(),
-		Extensions: nil,
-		Cache:      assistant.NewResponseCache(false, 1, time.Minute),
-		Events:     runtime.EventBus(),
-		Models:     runtime.ModelRegistry(),
-		Client:     client,
-		Logger:     nil,
+		Config:      runtimeConfig,
+		Sessions:    runtime.SessionRepository(),
+		Extensions:  nil,
+		Cache:       assistant.NewResponseCache(false, 1, time.Minute),
+		Events:      runtime.EventBus(),
+		Models:      runtime.ModelRegistry(),
+		Client:      client,
+		Logger:      nil,
+		SkillsCache: nil,
 	})
 
 	usage, err := runtime.ContextUsage(context.Background(), "", testRuntimeCWD)
@@ -127,14 +129,15 @@ func TestRuntime_ContextUsageUsesExplicitOutputReserve(t *testing.T) {
 	runtimeConfig := testConfig()
 	runtimeConfig.Context.OutputReserveTokens = 1234
 	runtime = assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:     runtimeConfig,
-		Sessions:   runtime.SessionRepository(),
-		Extensions: nil,
-		Cache:      assistant.NewResponseCache(false, 1, time.Minute),
-		Events:     runtime.EventBus(),
-		Models:     runtime.ModelRegistry(),
-		Client:     client,
-		Logger:     nil,
+		Config:      runtimeConfig,
+		Sessions:    runtime.SessionRepository(),
+		Extensions:  nil,
+		Cache:       assistant.NewResponseCache(false, 1, time.Minute),
+		Events:      runtime.EventBus(),
+		Models:      runtime.ModelRegistry(),
+		Client:      client,
+		Logger:      nil,
+		SkillsCache: nil,
 	})
 
 	usage, err := runtime.ContextUsage(context.Background(), "", testRuntimeCWD)
@@ -198,14 +201,15 @@ func newTestRuntimeWithContextWindowAndMaxTokens(
 	t.Cleanup(cache.Shutdown)
 	_, repository := newTestRuntime(t)
 	runtime := assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:     runtimeConfig,
-		Sessions:   repository,
-		Extensions: manager,
-		Cache:      cache,
-		Events:     event.NewBus(nil),
-		Models:     registry,
-		Client:     client,
-		Logger:     nil,
+		Config:      runtimeConfig,
+		Sessions:    repository,
+		Extensions:  manager,
+		Cache:       cache,
+		Events:      event.NewBus(nil),
+		Models:      registry,
+		Client:      client,
+		Logger:      nil,
+		SkillsCache: nil,
 	})
 
 	return runtime

--- a/internal/assistant/context_budget_test.go
+++ b/internal/assistant/context_budget_test.go
@@ -39,16 +39,13 @@ func TestRuntime_ContextPreflightCanBeDisabled(t *testing.T) {
 	runtime := newTestRuntimeWithContextWindow(t, client, 512)
 	runtimeConfig := testConfig()
 	runtimeConfig.Context.PreflightEnabled = false
-	runtime = assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:      runtimeConfig,
-		Sessions:    runtime.SessionRepository(),
-		Extensions:  nil,
-		Cache:       assistant.NewResponseCache(false, 1, time.Minute),
-		Events:      runtime.EventBus(),
-		Models:      runtime.ModelRegistry(),
-		Client:      client,
-		Logger:      nil,
-		SkillsCache: nil,
+	runtime = assistant.NewRuntimeForTest(func(opts *assistant.RuntimeTestOptions) {
+		opts.Config = runtimeConfig
+		opts.Sessions = runtime.SessionRepository()
+		opts.Cache = assistant.NewResponseCache(false, 1, time.Minute)
+		opts.Events = runtime.EventBus()
+		opts.Models = runtime.ModelRegistry()
+		opts.Client = client
 	})
 
 	request := newRuntimePromptRequest(testRuntimeCWD, strings.Repeat("overflow ", 2600), "")
@@ -87,16 +84,13 @@ func TestRuntime_ContextUsageHonorsExplicitZeroReserves(t *testing.T) {
 	runtimeConfig := testConfig()
 	runtimeConfig.Context.ProviderReserveTokens = 0
 	runtimeConfig.Context.SafetyMarginTokens = 0
-	runtime = assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:      runtimeConfig,
-		Sessions:    runtime.SessionRepository(),
-		Extensions:  nil,
-		Cache:       assistant.NewResponseCache(false, 1, time.Minute),
-		Events:      runtime.EventBus(),
-		Models:      runtime.ModelRegistry(),
-		Client:      client,
-		Logger:      nil,
-		SkillsCache: nil,
+	runtime = assistant.NewRuntimeForTest(func(opts *assistant.RuntimeTestOptions) {
+		opts.Config = runtimeConfig
+		opts.Sessions = runtime.SessionRepository()
+		opts.Cache = assistant.NewResponseCache(false, 1, time.Minute)
+		opts.Events = runtime.EventBus()
+		opts.Models = runtime.ModelRegistry()
+		opts.Client = client
 	})
 
 	usage, err := runtime.ContextUsage(context.Background(), "", testRuntimeCWD)
@@ -128,16 +122,13 @@ func TestRuntime_ContextUsageUsesExplicitOutputReserve(t *testing.T) {
 	runtime := newTestRuntimeWithContextWindowAndMaxTokens(t, client, 100_000, 128_000)
 	runtimeConfig := testConfig()
 	runtimeConfig.Context.OutputReserveTokens = 1234
-	runtime = assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:      runtimeConfig,
-		Sessions:    runtime.SessionRepository(),
-		Extensions:  nil,
-		Cache:       assistant.NewResponseCache(false, 1, time.Minute),
-		Events:      runtime.EventBus(),
-		Models:      runtime.ModelRegistry(),
-		Client:      client,
-		Logger:      nil,
-		SkillsCache: nil,
+	runtime = assistant.NewRuntimeForTest(func(opts *assistant.RuntimeTestOptions) {
+		opts.Config = runtimeConfig
+		opts.Sessions = runtime.SessionRepository()
+		opts.Cache = assistant.NewResponseCache(false, 1, time.Minute)
+		opts.Events = runtime.EventBus()
+		opts.Models = runtime.ModelRegistry()
+		opts.Client = client
 	})
 
 	usage, err := runtime.ContextUsage(context.Background(), "", testRuntimeCWD)
@@ -200,16 +191,14 @@ func newTestRuntimeWithContextWindowAndMaxTokens(
 	cache := assistant.NewResponseCache(true, 32, time.Minute)
 	t.Cleanup(cache.Shutdown)
 	_, repository := newTestRuntime(t)
-	runtime := assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:      runtimeConfig,
-		Sessions:    repository,
-		Extensions:  manager,
-		Cache:       cache,
-		Events:      event.NewBus(nil),
-		Models:      registry,
-		Client:      client,
-		Logger:      nil,
-		SkillsCache: nil,
+	runtime := assistant.NewRuntimeForTest(func(opts *assistant.RuntimeTestOptions) {
+		opts.Config = runtimeConfig
+		opts.Sessions = repository
+		opts.Extensions = manager
+		opts.Cache = cache
+		opts.Events = event.NewBus(nil)
+		opts.Models = registry
+		opts.Client = client
 	})
 
 	return runtime

--- a/internal/assistant/context_build.go
+++ b/internal/assistant/context_build.go
@@ -64,7 +64,7 @@ func (runtime *Runtime) ContextUsage(ctx context.Context, sessionID, cwd string)
 	basePrompt := baseSystemPrompt(cwd)
 
 	skillPrompt := ""
-	if skills := core.LoadSkills(cwd, nil, true).Skills; len(skills) > 0 {
+	if skills := runtime.loadSkills(cwd); len(skills) > 0 {
 		skillPrompt = core.FormatSkillsForPrompt(skills)
 	}
 
@@ -146,7 +146,7 @@ func (runtime *Runtime) modelContextBase(
 	onEvent func(StreamEvent),
 ) (contextwindow.Base, error) {
 	basePrompt := baseSystemPrompt(cwd)
-	skills := core.LoadSkills(cwd, nil, true).Skills
+	skills := runtime.loadSkills(cwd)
 
 	availableSkillsPrompt := ""
 	if len(skills) > 0 {

--- a/internal/assistant/context_compaction_lifecycle_test.go
+++ b/internal/assistant/context_compaction_lifecycle_test.go
@@ -130,13 +130,14 @@ func newCompactionRuntimeWithManagerWindow(
 	t.Cleanup(cache.Shutdown)
 
 	return assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:     runtimeConfig,
-		Sessions:   repository,
-		Extensions: manager,
-		Cache:      cache,
-		Events:     event.NewBus(slog.New(slog.NewTextHandler(io.Discard, nil))),
-		Models:     newCompactionTestRegistry(t, 2),
-		Client:     client,
-		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Config:      runtimeConfig,
+		Sessions:    repository,
+		Extensions:  manager,
+		Cache:       cache,
+		Events:      event.NewBus(slog.New(slog.NewTextHandler(io.Discard, nil))),
+		Models:      newCompactionTestRegistry(t, 2),
+		Client:      client,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SkillsCache: nil,
 	})
 }

--- a/internal/assistant/context_compaction_lifecycle_test.go
+++ b/internal/assistant/context_compaction_lifecycle_test.go
@@ -129,15 +129,14 @@ func newCompactionRuntimeWithManagerWindow(
 	cache := assistant.NewResponseCache(true, 32, time.Minute)
 	t.Cleanup(cache.Shutdown)
 
-	return assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:      runtimeConfig,
-		Sessions:    repository,
-		Extensions:  manager,
-		Cache:       cache,
-		Events:      event.NewBus(slog.New(slog.NewTextHandler(io.Discard, nil))),
-		Models:      newCompactionTestRegistry(t, 2),
-		Client:      client,
-		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
-		SkillsCache: nil,
+	return assistant.NewRuntimeForTest(func(opts *assistant.RuntimeTestOptions) {
+		opts.Config = runtimeConfig
+		opts.Sessions = repository
+		opts.Extensions = manager
+		opts.Cache = cache
+		opts.Events = event.NewBus(slog.New(slog.NewTextHandler(io.Discard, nil)))
+		opts.Models = newCompactionTestRegistry(t, 2)
+		opts.Client = client
+		opts.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	})
 }

--- a/internal/assistant/context_compaction_test.go
+++ b/internal/assistant/context_compaction_test.go
@@ -410,16 +410,13 @@ func newCompactionRuntimeForTailPolicy(
 	_, repository := newTestRuntimeWithClient(t, client)
 	runtimeConfig := testConfig()
 
-	return assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:      runtimeConfig,
-		Sessions:    repository,
-		Extensions:  nil,
-		Cache:       assistant.NewResponseCache(false, 1, time.Minute),
-		Events:      event.NewBus(nil),
-		Models:      newCompactionTestRegistry(t, contextWindow),
-		Client:      client,
-		Logger:      nil,
-		SkillsCache: nil,
+	return assistant.NewRuntimeForTest(func(opts *assistant.RuntimeTestOptions) {
+		opts.Config = runtimeConfig
+		opts.Sessions = repository
+		opts.Cache = assistant.NewResponseCache(false, 1, time.Minute)
+		opts.Events = event.NewBus(nil)
+		opts.Models = newCompactionTestRegistry(t, contextWindow)
+		opts.Client = client
 	}), repository
 }
 

--- a/internal/assistant/context_compaction_test.go
+++ b/internal/assistant/context_compaction_test.go
@@ -411,14 +411,15 @@ func newCompactionRuntimeForTailPolicy(
 	runtimeConfig := testConfig()
 
 	return assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:     runtimeConfig,
-		Sessions:   repository,
-		Extensions: nil,
-		Cache:      assistant.NewResponseCache(false, 1, time.Minute),
-		Events:     event.NewBus(nil),
-		Models:     newCompactionTestRegistry(t, contextWindow),
-		Client:     client,
-		Logger:     nil,
+		Config:      runtimeConfig,
+		Sessions:    repository,
+		Extensions:  nil,
+		Cache:       assistant.NewResponseCache(false, 1, time.Minute),
+		Events:      event.NewBus(nil),
+		Models:      newCompactionTestRegistry(t, contextWindow),
+		Client:      client,
+		Logger:      nil,
+		SkillsCache: nil,
 	}), repository
 }
 

--- a/internal/assistant/provider_hook_test_helpers_internal_test.go
+++ b/internal/assistant/provider_hook_test_helpers_internal_test.go
@@ -1,6 +1,52 @@
 package assistant
 
-import "github.com/omarluq/librecode/internal/llm"
+import (
+	"github.com/omarluq/librecode/internal/config"
+	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/event"
+	"github.com/omarluq/librecode/internal/llm"
+	"github.com/omarluq/librecode/internal/model"
+	"log/slog"
+)
+
+// runtimeDeps is a bag of optional Runtime dependencies used by internal test
+// factories. Every field is nil by default; callers set only what they need.
+type runtimeDeps struct {
+	Config     *config.Config
+	Sessions   *database.SessionRepository
+	Extensions runtimeExtensions
+	Cache      *ResponseCache
+	Events     *event.Bus
+	Models     *model.Registry
+	Client     Completer
+	Logger     *slog.Logger
+}
+
+// newRuntimeFromDeps builds a Runtime with every field explicitly set, satisfying
+// exhaustruct while centralizing the struct literal in a single place.
+func newRuntimeFromDeps(setup func(*runtimeDeps)) *Runtime {
+	deps := &runtimeDeps{} //nolint:exhaustruct // intentional zero-init
+	if setup != nil {
+		setup(deps)
+	}
+
+	client := deps.Client
+	if client == nil {
+		client = NewHTTPClient()
+	}
+
+	return &Runtime{
+		cfg:         deps.Config,
+		sessions:    deps.Sessions,
+		extensions:  deps.Extensions,
+		cache:       deps.Cache,
+		events:      deps.Events,
+		models:      deps.Models,
+		client:      client,
+		logger:      deps.Logger,
+		skillsCache: nil,
+	}
+}
 
 func providerHookTestInput(payload map[string]any, headers map[string]string, attempt int) *llm.HookInput {
 	request := providerHookTestRequest()

--- a/internal/assistant/provider_hook_test_helpers_internal_test.go
+++ b/internal/assistant/provider_hook_test_helpers_internal_test.go
@@ -25,7 +25,16 @@ type runtimeDeps struct {
 // newRuntimeFromDeps builds a Runtime with every field explicitly set, satisfying
 // exhaustruct while centralizing the struct literal in a single place.
 func newRuntimeFromDeps(setup func(*runtimeDeps)) *Runtime {
-	deps := &runtimeDeps{} //nolint:exhaustruct // intentional zero-init
+	deps := &runtimeDeps{
+		Config:     nil,
+		Sessions:   nil,
+		Extensions: nil,
+		Cache:      nil,
+		Events:     nil,
+		Models:     nil,
+		Client:     nil,
+		Logger:     nil,
+	}
 	if setup != nil {
 		setup(deps)
 	}

--- a/internal/assistant/provider_hooks_internal_test.go
+++ b/internal/assistant/provider_hooks_internal_test.go
@@ -107,17 +107,12 @@ lc.register_command("seen_auth", "seen_auth", function()
   return seen
 end)
 `)
-	runtime := &Runtime{
-		cfg:         nil,
-		sessions:    nil,
-		extensions:  manager,
-		cache:       nil,
-		events:      nil,
-		models:      nil,
-		client:      nil,
-		logger:      testProviderHookLogger(),
-		skillsCache: nil,
-	}
+
+	runtime := newRuntimeFromDeps(func(deps *runtimeDeps) {
+		deps.Extensions = manager
+		deps.Logger = testProviderHookLogger()
+	})
+
 	input := providerHookTestInput(map[string]any{}, map[string]string{"authorization": "Bearer secret"}, 1)
 
 	_, err := runtime.dispatchProviderRequestHook(context.Background(), input)
@@ -136,17 +131,11 @@ func newProviderHookTestRuntime(t *testing.T, source string) *Runtime {
 	t.Cleanup(manager.Shutdown)
 	loadProviderHookTestExtension(t, manager, source)
 
-	return &Runtime{
-		cfg:         nil,
-		sessions:    nil,
-		extensions:  manager,
-		cache:       nil,
-		events:      event.NewBus(testProviderHookLogger()),
-		models:      nil,
-		client:      nil,
-		logger:      testProviderHookLogger(),
-		skillsCache: nil,
-	}
+	return newRuntimeFromDeps(func(deps *runtimeDeps) {
+		deps.Extensions = manager
+		deps.Events = event.NewBus(testProviderHookLogger())
+		deps.Logger = testProviderHookLogger()
+	})
 }
 
 func loadProviderHookTestExtension(t *testing.T, manager *extension.Manager, source string) {

--- a/internal/assistant/provider_hooks_internal_test.go
+++ b/internal/assistant/provider_hooks_internal_test.go
@@ -108,14 +108,15 @@ lc.register_command("seen_auth", "seen_auth", function()
 end)
 `)
 	runtime := &Runtime{
-		cfg:        nil,
-		sessions:   nil,
-		extensions: manager,
-		cache:      nil,
-		events:     nil,
-		models:     nil,
-		client:     nil,
-		logger:     testProviderHookLogger(),
+		cfg:         nil,
+		sessions:    nil,
+		extensions:  manager,
+		cache:       nil,
+		events:      nil,
+		models:      nil,
+		client:      nil,
+		logger:      testProviderHookLogger(),
+		skillsCache: nil,
 	}
 	input := providerHookTestInput(map[string]any{}, map[string]string{"authorization": "Bearer secret"}, 1)
 
@@ -136,14 +137,15 @@ func newProviderHookTestRuntime(t *testing.T, source string) *Runtime {
 	loadProviderHookTestExtension(t, manager, source)
 
 	return &Runtime{
-		cfg:        nil,
-		sessions:   nil,
-		extensions: manager,
-		cache:      nil,
-		events:     event.NewBus(testProviderHookLogger()),
-		models:     nil,
-		client:     nil,
-		logger:     testProviderHookLogger(),
+		cfg:         nil,
+		sessions:    nil,
+		extensions:  manager,
+		cache:       nil,
+		events:      event.NewBus(testProviderHookLogger()),
+		models:      nil,
+		client:      nil,
+		logger:      testProviderHookLogger(),
+		skillsCache: nil,
 	}
 }
 

--- a/internal/assistant/runtime.go
+++ b/internal/assistant/runtime.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/omarluq/librecode/internal/assistant/lifecyclepayload"
 	"github.com/omarluq/librecode/internal/config"
+	"github.com/omarluq/librecode/internal/core"
 	"github.com/omarluq/librecode/internal/database"
 	"github.com/omarluq/librecode/internal/event"
 	"github.com/omarluq/librecode/internal/extension"
@@ -26,14 +27,15 @@ type runtimeExtensions interface {
 
 // Runtime coordinates prompt handling and durable sessions.
 type Runtime struct {
-	cfg        *config.Config
-	sessions   *database.SessionRepository
-	extensions runtimeExtensions
-	cache      *ResponseCache
-	events     *event.Bus
-	models     *model.Registry
-	client     Completer
-	logger     *slog.Logger
+	cfg         *config.Config
+	sessions    *database.SessionRepository
+	extensions  runtimeExtensions
+	cache       *ResponseCache
+	events      *event.Bus
+	models      *model.Registry
+	client      Completer
+	logger      *slog.Logger
+	skillsCache *core.SkillsCache
 }
 
 // PromptRequest contains one user prompt invocation.
@@ -119,14 +121,15 @@ type responseBundle struct {
 
 // RuntimeOptions contains dependencies for an assistant runtime.
 type RuntimeOptions struct {
-	Config     *config.Config
-	Sessions   *database.SessionRepository
-	Extensions runtimeExtensions
-	Cache      *ResponseCache
-	Events     *event.Bus
-	Models     *model.Registry
-	Client     Completer
-	Logger     *slog.Logger
+	Config      *config.Config
+	Sessions    *database.SessionRepository
+	Extensions  runtimeExtensions
+	Cache       *ResponseCache
+	Events      *event.Bus
+	Models      *model.Registry
+	Client      Completer
+	Logger      *slog.Logger
+	SkillsCache *core.SkillsCache
 }
 
 // NewRuntime creates an assistant runtime.
@@ -141,14 +144,15 @@ func NewRuntime(options *RuntimeOptions) *Runtime {
 	}
 
 	return &Runtime{
-		cfg:        options.Config,
-		sessions:   options.Sessions,
-		extensions: options.Extensions,
-		cache:      options.Cache,
-		events:     options.Events,
-		models:     options.Models,
-		client:     client,
-		logger:     options.Logger,
+		cfg:         options.Config,
+		sessions:    options.Sessions,
+		extensions:  options.Extensions,
+		cache:       options.Cache,
+		events:      options.Events,
+		models:      options.Models,
+		client:      client,
+		logger:      options.Logger,
+		skillsCache: options.SkillsCache,
 	}
 }
 
@@ -279,6 +283,16 @@ func (runtime *Runtime) maybeAutoCompactAfterResponse(
 // SessionRepository returns the underlying session repository for command and UI layers.
 func (runtime *Runtime) SessionRepository() *database.SessionRepository {
 	return runtime.sessions
+}
+
+// loadSkills returns skills from the runtime cache when available, falling back
+// to a direct disk scan. This avoids redundant filesystem I/O on every prompt.
+func (runtime *Runtime) loadSkills(cwd string) []core.Skill {
+	if runtime.skillsCache != nil {
+		return runtime.skillsCache.Get(cwd).Skills
+	}
+
+	return core.LoadSkills(cwd, nil, true).Skills
 }
 
 // ModelRegistry returns the model registry used by the runtime.

--- a/internal/assistant/runtime_slash.go
+++ b/internal/assistant/runtime_slash.go
@@ -57,7 +57,7 @@ func (runtime *Runtime) respondToSkillCommand(
 	args string,
 	onEvent func(StreamEvent),
 ) (response string, toolEvents []ToolEvent, err error) {
-	skills := core.LoadSkills(cwd, nil, true).Skills
+	skills := runtime.loadSkills(cwd)
 
 	name := strings.TrimSpace(args)
 	if name == "" {

--- a/internal/assistant/runtime_test.go
+++ b/internal/assistant/runtime_test.go
@@ -539,14 +539,15 @@ func newTestRuntimeWithRepositoryClientAndManager(
 	t.Cleanup(cache.Shutdown)
 
 	runtime := assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:     testConfig(),
-		Sessions:   repository,
-		Extensions: manager,
-		Cache:      cache,
-		Events:     event.NewBus(slog.New(slog.NewTextHandler(io.Discard, nil))),
-		Models:     testRegistry(t),
-		Client:     client,
-		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Config:      testConfig(),
+		Sessions:    repository,
+		Extensions:  manager,
+		Cache:       cache,
+		Events:      event.NewBus(slog.New(slog.NewTextHandler(io.Discard, nil))),
+		Models:      testRegistry(t),
+		Client:      client,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SkillsCache: nil,
 	})
 
 	return runtime, repository, manager

--- a/internal/assistant/runtime_test.go
+++ b/internal/assistant/runtime_test.go
@@ -538,16 +538,15 @@ func newTestRuntimeWithRepositoryClientAndManager(
 	cache := assistant.NewResponseCache(true, 32, time.Minute)
 	t.Cleanup(cache.Shutdown)
 
-	runtime := assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:      testConfig(),
-		Sessions:    repository,
-		Extensions:  manager,
-		Cache:       cache,
-		Events:      event.NewBus(slog.New(slog.NewTextHandler(io.Discard, nil))),
-		Models:      testRegistry(t),
-		Client:      client,
-		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
-		SkillsCache: nil,
+	runtime := assistant.NewRuntimeForTest(func(opts *assistant.RuntimeTestOptions) {
+		opts.Config = testConfig()
+		opts.Sessions = repository
+		opts.Extensions = manager
+		opts.Cache = cache
+		opts.Events = event.NewBus(slog.New(slog.NewTextHandler(io.Discard, nil)))
+		opts.Models = testRegistry(t)
+		opts.Client = client
+		opts.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	})
 
 	return runtime, repository, manager

--- a/internal/assistant/testing.go
+++ b/internal/assistant/testing.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 
 	"github.com/omarluq/librecode/internal/config"
+	"github.com/omarluq/librecode/internal/core"
 	"github.com/omarluq/librecode/internal/database"
 	"github.com/omarluq/librecode/internal/event"
 	"github.com/omarluq/librecode/internal/model"
@@ -11,14 +12,15 @@ import (
 
 // RuntimeTestOptions holds optional Runtime dependencies for test factories.
 type RuntimeTestOptions struct {
-	Config     *config.Config
-	Sessions   *database.SessionRepository
-	Extensions runtimeExtensions
-	Cache      *ResponseCache
-	Events     *event.Bus
-	Models     *model.Registry
-	Client     Completer
-	Logger     *slog.Logger
+	Config      *config.Config
+	Sessions    *database.SessionRepository
+	Extensions  runtimeExtensions
+	Cache       *ResponseCache
+	Events      *event.Bus
+	Models      *model.Registry
+	Client      Completer
+	Logger      *slog.Logger
+	SkillsCache *core.SkillsCache
 }
 
 // NewRuntimeForTest builds a Runtime from the given setup closure, setting every
@@ -27,14 +29,15 @@ type RuntimeTestOptions struct {
 // warnings when exhaustruct forces every field to be listed).
 func NewRuntimeForTest(setup func(*RuntimeTestOptions)) *Runtime {
 	opts := &RuntimeTestOptions{
-		Config:     nil,
-		Sessions:   nil,
-		Extensions: nil,
-		Cache:      nil,
-		Events:     nil,
-		Models:     nil,
-		Client:     nil,
-		Logger:     nil,
+		Config:      nil,
+		Sessions:    nil,
+		Extensions:  nil,
+		Cache:       nil,
+		Events:      nil,
+		Models:      nil,
+		Client:      nil,
+		Logger:      nil,
+		SkillsCache: nil,
 	}
 	if setup != nil {
 		setup(opts)
@@ -49,6 +52,6 @@ func NewRuntimeForTest(setup func(*RuntimeTestOptions)) *Runtime {
 		Models:      opts.Models,
 		Client:      opts.Client,
 		Logger:      opts.Logger,
-		SkillsCache: nil,
+		SkillsCache: opts.SkillsCache,
 	})
 }

--- a/internal/assistant/testing.go
+++ b/internal/assistant/testing.go
@@ -1,0 +1,45 @@
+package assistant
+
+import (
+	"log/slog"
+
+	"github.com/omarluq/librecode/internal/config"
+	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/event"
+	"github.com/omarluq/librecode/internal/model"
+)
+
+// RuntimeTestOptions holds optional Runtime dependencies for test factories.
+type RuntimeTestOptions struct {
+	Config     *config.Config
+	Sessions   *database.SessionRepository
+	Extensions runtimeExtensions
+	Cache      *ResponseCache
+	Events     *event.Bus
+	Models     *model.Registry
+	Client     Completer
+	Logger     *slog.Logger
+}
+
+// NewRuntimeForTest builds a Runtime from the given setup closure, setting every
+// RuntimeOptions field explicitly in a single place. This eliminates duplicated
+// struct literals across test files (which triggers SonarCloud duplication
+// warnings when exhaustruct forces every field to be listed).
+func NewRuntimeForTest(setup func(*RuntimeTestOptions)) *Runtime {
+	opts := &RuntimeTestOptions{} //nolint:exhaustruct // intentional zero-init
+	if setup != nil {
+		setup(opts)
+	}
+
+	return NewRuntime(&RuntimeOptions{
+		Config:      opts.Config,
+		Sessions:    opts.Sessions,
+		Extensions:  opts.Extensions,
+		Cache:       opts.Cache,
+		Events:      opts.Events,
+		Models:      opts.Models,
+		Client:      opts.Client,
+		Logger:      opts.Logger,
+		SkillsCache: nil,
+	})
+}

--- a/internal/assistant/testing.go
+++ b/internal/assistant/testing.go
@@ -26,7 +26,16 @@ type RuntimeTestOptions struct {
 // struct literals across test files (which triggers SonarCloud duplication
 // warnings when exhaustruct forces every field to be listed).
 func NewRuntimeForTest(setup func(*RuntimeTestOptions)) *Runtime {
-	opts := &RuntimeTestOptions{} //nolint:exhaustruct // intentional zero-init
+	opts := &RuntimeTestOptions{
+		Config:     nil,
+		Sessions:   nil,
+		Extensions: nil,
+		Cache:      nil,
+		Events:     nil,
+		Models:     nil,
+		Client:     nil,
+		Logger:     nil,
+	}
 	if setup != nil {
 		setup(opts)
 	}

--- a/internal/assistant/tool_executor_internal_test.go
+++ b/internal/assistant/tool_executor_internal_test.go
@@ -180,16 +180,8 @@ func writeToolExecutorReadFixture(t *testing.T, directory string) {
 }
 
 func newToolExecutorTestRuntime(extensions runtimeExtensions) *Runtime {
-	return NewRuntime(&RuntimeOptions{
-		Config:      nil,
-		Sessions:    nil,
-		Extensions:  extensions,
-		Cache:       nil,
-		Events:      nil,
-		Models:      nil,
-		Client:      nil,
-		Logger:      nil,
-		SkillsCache: nil,
+	return newRuntimeFromDeps(func(deps *runtimeDeps) {
+		deps.Extensions = extensions
 	})
 }
 

--- a/internal/assistant/tool_executor_internal_test.go
+++ b/internal/assistant/tool_executor_internal_test.go
@@ -181,14 +181,15 @@ func writeToolExecutorReadFixture(t *testing.T, directory string) {
 
 func newToolExecutorTestRuntime(extensions runtimeExtensions) *Runtime {
 	return NewRuntime(&RuntimeOptions{
-		Config:     nil,
-		Sessions:   nil,
-		Extensions: extensions,
-		Cache:      nil,
-		Events:     nil,
-		Models:     nil,
-		Client:     nil,
-		Logger:     nil,
+		Config:      nil,
+		Sessions:    nil,
+		Extensions:  extensions,
+		Cache:       nil,
+		Events:      nil,
+		Models:      nil,
+		Client:      nil,
+		Logger:      nil,
+		SkillsCache: nil,
 	})
 }
 

--- a/internal/core/skills_cache.go
+++ b/internal/core/skills_cache.go
@@ -180,8 +180,8 @@ func (c *SkillsCache) watchSkillDirs(cwd string, skills []Skill) {
 	watched := make(map[string]struct{})
 
 	for _, path := range defaultSkillPaths(cwd) {
-		dir := filepath.Clean(path)
-		if _, seen := watched[dir]; seen || !resourcePathExists(dir) {
+		dir := nearestExistingDir(path)
+		if _, seen := watched[dir]; seen {
 			continue
 		}
 
@@ -206,4 +206,25 @@ func (c *SkillsCache) addWatch(dir string) {
 	if err := c.watcher.Add(dir); err != nil {
 		slog.Debug("skills cache watcher add error", slog.String("dir", dir), slog.Any("error", err))
 	}
+}
+
+// nearestExistingDir walks up from path until it finds a directory that exists.
+// This ensures fsnotify can watch a parent directory when a skill root doesn't
+// exist yet, so that creating it later triggers cache invalidation.
+// If nothing exists up to the filesystem root, the original path is returned
+// so the caller still attempts the watch (fsnotify will report an error but
+// that is handled gracefully).
+func nearestExistingDir(path string) string {
+	dir := filepath.Clean(path)
+
+	for !resourcePathExists(dir) {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return filepath.Clean(path)
+		}
+
+		dir = parent
+	}
+
+	return dir
 }

--- a/internal/core/skills_cache.go
+++ b/internal/core/skills_cache.go
@@ -1,0 +1,209 @@
+package core
+
+import (
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/samber/hot"
+)
+
+const (
+	// skillsCacheCapacity limits how many working directories are cached.
+	skillsCacheCapacity = 16
+	// skillsCacheTTL is a backstop expiration. fsnotify handles real-time
+	// invalidation; the TTL ensures stale entries are eventually evicted even
+	// if watcher events are missed.
+	skillsCacheTTL = 1 * time.Hour
+	// skillsCacheDebounce coalesces bursts of fsnotify events (e.g. a git checkout
+	// touching dozens of files) into a single cache purge so the next prompt only
+	// re-reads from disk once instead of once per file event.
+	skillsCacheDebounce = 500 * time.Millisecond
+)
+
+// SkillsCache memoizes LoadSkills results per working directory using samber/hot.
+// Cached entries are invalidated automatically when underlying files change
+// via fsnotify so that new or edited skills are picked up without a restart.
+// Burst events (e.g. git checkout) are debounced so a burst triggers a single
+// purge rather than one per file.
+// If the watcher cannot be created the cache still functions as simple memoization.
+type SkillsCache struct {
+	cache    *hot.HotCache[string, LoadSkillsResult]
+	watcher  *fsnotify.Watcher
+	purgeTim *time.Timer
+	done     chan struct{}
+	purgeMu  sync.Mutex
+	wg       sync.WaitGroup
+	once     sync.Once
+}
+
+// NewSkillsCache creates a skills cache backed by samber/hot with an fsnotify watcher.
+func NewSkillsCache() *SkillsCache {
+	return newSkillsCache(skillsCacheTTL)
+}
+
+func newSkillsCache(ttl time.Duration) *SkillsCache {
+	cache := hot.NewHotCache[string, LoadSkillsResult](hot.WTinyLFU, skillsCacheCapacity).
+		WithTTL(ttl).
+		WithLoaders(func(cwds []string) (map[string]LoadSkillsResult, error) {
+			results := make(map[string]LoadSkillsResult, len(cwds))
+
+			for _, cwd := range cwds {
+				results[cwd] = LoadSkills(cwd, nil, true)
+			}
+
+			return results, nil
+		}).
+		WithJanitor().
+		Build()
+
+	skills := &SkillsCache{
+		cache:    cache,
+		watcher:  nil,
+		done:     make(chan struct{}),
+		purgeMu:  sync.Mutex{},
+		wg:       sync.WaitGroup{},
+		once:     sync.Once{},
+		purgeTim: nil,
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		slog.Debug("skills cache watcher unavailable, degrading to memoization", slog.Any("error", err))
+
+		return skills
+	}
+
+	skills.watcher = watcher
+	skills.wg.Add(1)
+
+	go skills.watch()
+
+	return skills
+}
+
+// Get returns the cached skills for cwd, loading from disk on first access
+// or after a file system change has invalidated the cache.
+func (c *SkillsCache) Get(cwd string) LoadSkillsResult {
+	result, _, err := c.cache.Get(cwd)
+	if err != nil {
+		slog.Debug("skills cache loader error, falling back to direct load", slog.Any("error", err))
+
+		return LoadSkills(cwd, nil, true)
+	}
+
+	c.watchSkillDirs(cwd, result.Skills)
+
+	return result
+}
+
+// Close stops the background watcher goroutine and cache janitor.
+// It is safe to call multiple times and when the watcher was never started.
+func (c *SkillsCache) Close() {
+	c.once.Do(func() {
+		close(c.done)
+		c.cancelPurge()
+
+		if c.watcher != nil {
+			if err := c.watcher.Close(); err != nil {
+				slog.Debug("skills cache watcher close error", slog.Any("error", err))
+			}
+		}
+
+		c.wg.Wait()
+		c.cache.StopJanitor()
+	})
+}
+
+func (c *SkillsCache) watch() {
+	defer c.wg.Done()
+
+	for {
+		select {
+		case <-c.done:
+			return
+		case _, ok := <-c.watcher.Events:
+			if !ok {
+				return
+			}
+
+			c.schedulePurge()
+		case _, ok := <-c.watcher.Errors:
+			if !ok {
+				return
+			}
+
+			c.schedulePurge()
+		}
+	}
+}
+
+// schedulePurge coalesces bursts of fsnotify events into a single cache purge.
+// Each event resets the debounce timer, so a rapid burst (e.g. git checkout touching
+// dozens of files) triggers exactly one purge after activity settles.
+func (c *SkillsCache) schedulePurge() {
+	c.purgeMu.Lock()
+	defer c.purgeMu.Unlock()
+
+	if c.purgeTim != nil {
+		c.purgeTim.Stop()
+	}
+
+	c.purgeTim = time.AfterFunc(skillsCacheDebounce, func() {
+		c.purgeMu.Lock()
+		c.purgeTim = nil
+		c.purgeMu.Unlock()
+
+		c.cache.Purge()
+	})
+}
+
+// cancelPurge stops any pending debounced purge. Called during shutdown to
+// ensure no timer fires after Close returns.
+func (c *SkillsCache) cancelPurge() {
+	c.purgeMu.Lock()
+	defer c.purgeMu.Unlock()
+
+	if c.purgeTim != nil {
+		c.purgeTim.Stop()
+		c.purgeTim = nil
+	}
+}
+
+func (c *SkillsCache) watchSkillDirs(cwd string, skills []Skill) {
+	if c.watcher == nil {
+		return
+	}
+
+	watched := make(map[string]struct{})
+
+	for _, path := range defaultSkillPaths(cwd) {
+		dir := filepath.Clean(path)
+		if _, seen := watched[dir]; seen || !resourcePathExists(dir) {
+			continue
+		}
+
+		watched[dir] = struct{}{}
+
+		c.addWatch(dir)
+	}
+
+	for index := range skills {
+		dir := filepath.Clean(skills[index].BaseDir)
+		if _, seen := watched[dir]; seen {
+			continue
+		}
+
+		watched[dir] = struct{}{}
+
+		c.addWatch(dir)
+	}
+}
+
+func (c *SkillsCache) addWatch(dir string) {
+	if err := c.watcher.Add(dir); err != nil {
+		slog.Debug("skills cache watcher add error", slog.String("dir", dir), slog.Any("error", err))
+	}
+}

--- a/internal/core/skills_cache_test.go
+++ b/internal/core/skills_cache_test.go
@@ -3,222 +3,188 @@ package core_test
 import (
 	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/omarluq/librecode/internal/core"
 )
 
-func TestSkillsCacheReturnsSameResultAsLoadSkills(t *testing.T) {
-	cwd := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+// --- helpers --------------------------------------------------------
 
-	writeTestFile(t, filepath.Join(
-		cwd,
-		core.ConfigDirName,
-		"skills",
-		"alpha",
-		"SKILL.md",
-	), skillMarkdown("alpha"))
+func writeSkill(t *testing.T, cwd, name string) {
+	t.Helper()
 
-	direct := core.LoadSkills(cwd, nil, true)
-
-	cache := core.NewSkillsCache()
-	t.Cleanup(cache.Close)
-
-	cached := cache.Get(cwd)
-
-	require.Len(t, cached.Skills, len(direct.Skills))
-	assert.Equal(t, direct.Skills[0].Name, cached.Skills[0].Name)
-	assert.Equal(t, direct.Skills[0].FilePath, cached.Skills[0].FilePath)
+	writeTestFile(t, filepath.Join(cwd, core.ConfigDirName, "skills", name, "SKILL.md"), skillMarkdown(name))
 }
 
-func TestSkillsCacheReturnsCachedResultOnSecondCall(t *testing.T) {
-	cwd := newOutsideTempDir(t)
-	home := newOutsideTempDir(t)
-	t.Setenv("HOME", home)
+func writeAlphaSkill(t *testing.T, cwd string) string {
+	t.Helper()
 
 	skillPath := filepath.Join(cwd, core.ConfigDirName, "skills", "alpha", "SKILL.md")
 	writeTestFile(t, skillPath, skillMarkdown("alpha"))
 
-	cache := core.NewSkillsCache()
-	t.Cleanup(cache.Close)
-
-	first := cache.Get(cwd)
-	require.Len(t, first.Skills, 1)
-
-	// Overwrite the skill with a different name. The cached result should still
-	// have the original name because the loader has not been re-invoked yet.
-	writeTestFile(t, skillPath, skillMarkdown("alpha-renamed"))
-
-	// Give fsnotify no chance to process: call immediately.
-	second := cache.Get(cwd)
-	require.Len(t, second.Skills, 1)
-	assert.Equal(t, first.Skills[0].Name, second.Skills[0].Name,
-		"cache should serve the original result before invalidation")
+	return skillPath
 }
 
-func TestSkillsCacheInvalidatesOnFileChange(t *testing.T) {
-	cwd := newOutsideTempDir(t)
-	home := newOutsideTempDir(t)
-	t.Setenv("HOME", home)
+// --- suite ----------------------------------------------------------
 
-	skillPath := filepath.Join(cwd, core.ConfigDirName, "skills", "alpha", "SKILL.md")
-	writeTestFile(t, skillPath, skillMarkdown("alpha"))
+type SkillsCacheSuite struct {
+	suite.Suite
+	cache     *core.SkillsCache
+	cwd       string
+	skillPath string
+}
 
-	cache := core.NewSkillsCache()
-	t.Cleanup(cache.Close)
+func TestSkillsCacheSuite(t *testing.T) {
+	t.Setenv("HOME", newOutsideTempDir(t))
+	suite.Run(t, new(SkillsCacheSuite))
+}
 
-	first := cache.Get(cwd)
-	require.Len(t, first.Skills, 1)
-	assert.Equal(t, "alpha", first.Skills[0].Name)
+func (s *SkillsCacheSuite) SetupTest() {
+	s.cwd = newOutsideTempDir(s.T())
+	s.cache = core.NewSkillsCache()
+	s.T().Cleanup(s.cache.Close)
+}
 
-	// Add a new skill and write to the existing skill file to trigger fsnotify.
-	newSkillPath := filepath.Join(cwd, core.ConfigDirName, "skills", "beta", "SKILL.md")
-	writeTestFile(t, newSkillPath, skillMarkdown("beta"))
+func (s *SkillsCacheSuite) writeAlpha() {
+	s.skillPath = writeAlphaSkill(s.T(), s.cwd)
+}
 
-	writeTestFile(t, skillPath, skillMarkdown("alpha-updated"))
+// --- basic Get ------------------------------------------------------
 
-	require.Eventually(t, func() bool {
-		refreshed := cache.Get(cwd)
+func (s *SkillsCacheSuite) TestReturnsEmptyForCWDWithNoSkills() {
+	result := s.cache.Get(s.cwd)
+
+	s.Empty(result.Skills)
+}
+
+func (s *SkillsCacheSuite) TestReturnsSkillFromCWD() {
+	s.writeAlpha()
+
+	result := s.cache.Get(s.cwd)
+
+	s.Require().Len(result.Skills, 1)
+	s.Equal("alpha", result.Skills[0].Name)
+}
+
+func (s *SkillsCacheSuite) TestServesCachedResultBeforeInvalidation() {
+	s.writeAlpha()
+	first := s.cache.Get(s.cwd)
+	s.Require().Len(first.Skills, 1)
+
+	// Overwrite with a different name; cache should still have the original.
+	writeTestFile(s.T(), s.skillPath, skillMarkdown("alpha-renamed"))
+
+	second := s.cache.Get(s.cwd)
+
+	s.Require().Len(second.Skills, 1)
+	s.Equal(first.Skills[0].Name, second.Skills[0].Name)
+}
+
+func (s *SkillsCacheSuite) TestParityWithDirectLoad() {
+	s.writeAlpha()
+
+	direct := core.LoadSkills(s.cwd, nil, true)
+	cached := s.cache.Get(s.cwd)
+
+	s.Require().Len(cached.Skills, len(direct.Skills))
+	s.Equal(direct.Skills[0].Name, cached.Skills[0].Name)
+	s.Equal(direct.Skills[0].FilePath, cached.Skills[0].FilePath)
+}
+
+// --- lifecycle ------------------------------------------------------
+
+func (s *SkillsCacheSuite) TestCloseIsIdempotent() {
+	s.cache.Close()
+	s.cache.Close()
+
+	s.NotPanics(func() { s.cache.Close() })
+}
+
+func (s *SkillsCacheSuite) TestGetIsSafeAfterClose() {
+	s.writeAlpha()
+
+	first := s.cache.Get(s.cwd)
+	s.Require().Len(first.Skills, 1)
+
+	s.cache.Close()
+
+	// After Close, Get should still work — it just does a direct load.
+	second := s.cache.Get(s.cwd)
+
+	s.Len(second.Skills, 1)
+}
+
+// --- isolation ------------------------------------------------------
+
+func (s *SkillsCacheSuite) TestCWDIsolation() {
+	writeSkill(s.T(), s.cwd, "a")
+
+	cwdB := newOutsideTempDir(s.T())
+	writeSkill(s.T(), cwdB, "b")
+
+	resultA := s.cache.Get(s.cwd)
+	resultB := s.cache.Get(cwdB)
+
+	s.Require().Len(resultA.Skills, 1)
+	s.Equal("a", resultA.Skills[0].Name)
+
+	s.Require().Len(resultB.Skills, 1)
+	s.Equal("b", resultB.Skills[0].Name)
+}
+
+// --- fsnotify invalidation ------------------------------------------
+
+func (s *SkillsCacheSuite) TestInvalidatesOnFileChange() {
+	s.writeAlpha()
+
+	first := s.cache.Get(s.cwd)
+	s.Require().Len(first.Skills, 1)
+	s.Equal("alpha", first.Skills[0].Name)
+
+	// Add a new skill and touch the existing file to trigger fsnotify.
+	writeSkill(s.T(), s.cwd, "beta")
+	writeTestFile(s.T(), s.skillPath, skillMarkdown("alpha-updated"))
+
+	s.Require().Eventually(func() bool {
+		refreshed := s.cache.Get(s.cwd)
 
 		return len(refreshed.Skills) == 2
-	}, 3*time.Second, 50*time.Millisecond, "cache should invalidate after file change")
+	}, 3*time.Second, 50*time.Millisecond)
 }
 
-func TestSkillsCacheDebouncesBurstEvents(t *testing.T) {
-	cwd := newOutsideTempDir(t)
-	home := newOutsideTempDir(t)
-	t.Setenv("HOME", home)
+func (s *SkillsCacheSuite) TestInvalidatesWhenSkillRootCreatedLater() {
+	first := s.cache.Get(s.cwd)
 
-	skillPath := filepath.Join(cwd, core.ConfigDirName, "skills", "alpha", "SKILL.md")
-	writeTestFile(t, skillPath, skillMarkdown("alpha"))
+	s.Empty(first.Skills)
 
-	cache := core.NewSkillsCache()
-	t.Cleanup(cache.Close)
+	// Create the skill root after the initial empty load.
+	writeSkill(s.T(), s.cwd, "alpha")
 
-	first := cache.Get(cwd)
-	require.Len(t, first.Skills, 1)
-	assert.Equal(t, "alpha", first.Skills[0].Name)
+	s.Require().Eventually(func() bool {
+		refreshed := s.cache.Get(s.cwd)
+
+		return len(refreshed.Skills) == 1 && refreshed.Skills[0].Name == "alpha"
+	}, 3*time.Second, 50*time.Millisecond)
+}
+
+func (s *SkillsCacheSuite) TestDebouncesBurstEvents() {
+	s.writeAlpha()
+
+	first := s.cache.Get(s.cwd)
+	s.Require().Len(first.Skills, 1)
+	s.Equal("alpha", first.Skills[0].Name)
 
 	// Simulate a burst of writes to the same file (e.g. editor save + git checkout).
 	for i := range 10 {
-		writeTestFile(t, skillPath, skillMarkdown("burst-"+strconv.Itoa(i)))
+		writeTestFile(s.T(), s.skillPath, skillMarkdown("burst-"+strconv.Itoa(i)))
 	}
 
-	// After the debounce window, the cache should reflect the final write.
-	require.Eventually(t, func() bool {
-		refreshed := cache.Get(cwd)
+	s.Require().Eventually(func() bool {
+		refreshed := s.cache.Get(s.cwd)
 
 		return len(refreshed.Skills) == 1 && refreshed.Skills[0].Name == "burst-9"
-	}, 3*time.Second, 50*time.Millisecond, "cache should reflect final write after debounce")
-}
-
-func TestSkillsCacheIsolatesByCWD(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	cwdA := t.TempDir()
-	cwdB := t.TempDir()
-
-	writeTestFile(t, filepath.Join(cwdA, core.ConfigDirName, "skills", "a", "SKILL.md"), skillMarkdown("a"))
-	writeTestFile(t, filepath.Join(cwdB, core.ConfigDirName, "skills", "b", "SKILL.md"), skillMarkdown("b"))
-
-	cache := core.NewSkillsCache()
-	t.Cleanup(cache.Close)
-
-	resultA := cache.Get(cwdA)
-	resultB := cache.Get(cwdB)
-
-	require.Len(t, resultA.Skills, 1)
-	assert.Equal(t, "a", resultA.Skills[0].Name)
-
-	require.Len(t, resultB.Skills, 1)
-	assert.Equal(t, "b", resultB.Skills[0].Name)
-}
-
-func TestSkillsCacheCloseIsIdempotent(t *testing.T) {
-	t.Parallel()
-
-	cache := core.NewSkillsCache()
-
-	cache.Close()
-	cache.Close()
-
-	assert.NotPanics(t, func() {
-		cache.Close()
-	})
-}
-
-func TestSkillsCacheReturnsEmptyForCwdWithNoSkills(t *testing.T) {
-	cwd := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	cache := core.NewSkillsCache()
-	t.Cleanup(cache.Close)
-
-	result := cache.Get(cwd)
-
-	assert.Empty(t, result.Skills)
-}
-
-func TestSkillsCacheInvalidatesWhenSkillRootCreatedLater(t *testing.T) {
-	cwd := newOutsideTempDir(t)
-	home := newOutsideTempDir(t)
-	t.Setenv("HOME", home)
-
-	// First Get with no skill directories — loads empty and watches ancestor.
-	cache := core.NewSkillsCache()
-	t.Cleanup(cache.Close)
-
-	first := cache.Get(cwd)
-	assert.Empty(t, first.Skills)
-
-	// Create the skill root and a skill file after the initial load.
-	skillPath := filepath.Join(cwd, core.ConfigDirName, "skills", "alpha", "SKILL.md")
-	writeTestFile(t, skillPath, skillMarkdown("alpha"))
-
-	// The ancestor watch should fire and invalidate the cache.
-	require.Eventually(t, func() bool {
-		refreshed := cache.Get(cwd)
-
-		return len(refreshed.Skills) == 1 && refreshed.Skills[0].Name == "alpha"
-	}, 3*time.Second, 50*time.Millisecond, "cache should invalidate when skill root is created")
-}
-
-func TestSkillsCacheGetIsSafeAfterClose(t *testing.T) {
-	cwd := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	writeTestFile(t, filepath.Join(
-		cwd,
-		core.ConfigDirName,
-		"skills",
-		"alpha",
-		"SKILL.md",
-	), strings.Join([]string{
-		frontmatterDelimiter,
-		"name: alpha",
-		"description: Alpha skill",
-		frontmatterDelimiter,
-		"Body.",
-	}, "\n"))
-
-	cache := core.NewSkillsCache()
-
-	first := cache.Get(cwd)
-	require.Len(t, first.Skills, 1)
-
-	cache.Close()
-
-	// After Close, Get should still work — it just does a direct load.
-	second := cache.Get(cwd)
-	assert.Len(t, second.Skills, 1)
+	}, 3*time.Second, 50*time.Millisecond)
 }

--- a/internal/core/skills_cache_test.go
+++ b/internal/core/skills_cache_test.go
@@ -1,0 +1,200 @@
+package core_test
+
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/core"
+)
+
+func TestSkillsCacheReturnsSameResultAsLoadSkills(t *testing.T) {
+	cwd := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	writeTestFile(t, filepath.Join(
+		cwd,
+		core.ConfigDirName,
+		"skills",
+		"alpha",
+		"SKILL.md",
+	), skillMarkdown("alpha"))
+
+	direct := core.LoadSkills(cwd, nil, true)
+
+	cache := core.NewSkillsCache()
+	t.Cleanup(cache.Close)
+
+	cached := cache.Get(cwd)
+
+	require.Len(t, cached.Skills, len(direct.Skills))
+	assert.Equal(t, direct.Skills[0].Name, cached.Skills[0].Name)
+	assert.Equal(t, direct.Skills[0].FilePath, cached.Skills[0].FilePath)
+}
+
+func TestSkillsCacheReturnsCachedResultOnSecondCall(t *testing.T) {
+	cwd := newOutsideTempDir(t)
+	home := newOutsideTempDir(t)
+	t.Setenv("HOME", home)
+
+	skillPath := filepath.Join(cwd, core.ConfigDirName, "skills", "alpha", "SKILL.md")
+	writeTestFile(t, skillPath, skillMarkdown("alpha"))
+
+	cache := core.NewSkillsCache()
+	t.Cleanup(cache.Close)
+
+	first := cache.Get(cwd)
+	require.Len(t, first.Skills, 1)
+
+	// Overwrite the skill with a different name. The cached result should still
+	// have the original name because the loader has not been re-invoked yet.
+	writeTestFile(t, skillPath, skillMarkdown("alpha-renamed"))
+
+	// Give fsnotify no chance to process: call immediately.
+	second := cache.Get(cwd)
+	require.Len(t, second.Skills, 1)
+	assert.Equal(t, first.Skills[0].Name, second.Skills[0].Name,
+		"cache should serve the original result before invalidation")
+}
+
+func TestSkillsCacheInvalidatesOnFileChange(t *testing.T) {
+	cwd := newOutsideTempDir(t)
+	home := newOutsideTempDir(t)
+	t.Setenv("HOME", home)
+
+	skillPath := filepath.Join(cwd, core.ConfigDirName, "skills", "alpha", "SKILL.md")
+	writeTestFile(t, skillPath, skillMarkdown("alpha"))
+
+	cache := core.NewSkillsCache()
+	t.Cleanup(cache.Close)
+
+	first := cache.Get(cwd)
+	require.Len(t, first.Skills, 1)
+	assert.Equal(t, "alpha", first.Skills[0].Name)
+
+	// Add a new skill and write to the existing skill file to trigger fsnotify.
+	newSkillPath := filepath.Join(cwd, core.ConfigDirName, "skills", "beta", "SKILL.md")
+	writeTestFile(t, newSkillPath, skillMarkdown("beta"))
+
+	writeTestFile(t, skillPath, skillMarkdown("alpha-updated"))
+
+	require.Eventually(t, func() bool {
+		refreshed := cache.Get(cwd)
+
+		return len(refreshed.Skills) == 2
+	}, 3*time.Second, 50*time.Millisecond, "cache should invalidate after file change")
+}
+
+func TestSkillsCacheDebouncesBurstEvents(t *testing.T) {
+	cwd := newOutsideTempDir(t)
+	home := newOutsideTempDir(t)
+	t.Setenv("HOME", home)
+
+	skillPath := filepath.Join(cwd, core.ConfigDirName, "skills", "alpha", "SKILL.md")
+	writeTestFile(t, skillPath, skillMarkdown("alpha"))
+
+	cache := core.NewSkillsCache()
+	t.Cleanup(cache.Close)
+
+	first := cache.Get(cwd)
+	require.Len(t, first.Skills, 1)
+	assert.Equal(t, "alpha", first.Skills[0].Name)
+
+	// Simulate a burst of writes to the same file (e.g. editor save + git checkout).
+	for i := range 10 {
+		writeTestFile(t, skillPath, skillMarkdown("burst-"+strconv.Itoa(i)))
+	}
+
+	// After the debounce window, the cache should reflect the final write.
+	require.Eventually(t, func() bool {
+		refreshed := cache.Get(cwd)
+
+		return len(refreshed.Skills) == 1 && refreshed.Skills[0].Name == "burst-9"
+	}, 3*time.Second, 50*time.Millisecond, "cache should reflect final write after debounce")
+}
+
+func TestSkillsCacheIsolatesByCWD(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cwdA := t.TempDir()
+	cwdB := t.TempDir()
+
+	writeTestFile(t, filepath.Join(cwdA, core.ConfigDirName, "skills", "a", "SKILL.md"), skillMarkdown("a"))
+	writeTestFile(t, filepath.Join(cwdB, core.ConfigDirName, "skills", "b", "SKILL.md"), skillMarkdown("b"))
+
+	cache := core.NewSkillsCache()
+	t.Cleanup(cache.Close)
+
+	resultA := cache.Get(cwdA)
+	resultB := cache.Get(cwdB)
+
+	require.Len(t, resultA.Skills, 1)
+	assert.Equal(t, "a", resultA.Skills[0].Name)
+
+	require.Len(t, resultB.Skills, 1)
+	assert.Equal(t, "b", resultB.Skills[0].Name)
+}
+
+func TestSkillsCacheCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	cache := core.NewSkillsCache()
+
+	cache.Close()
+	cache.Close()
+
+	assert.NotPanics(t, func() {
+		cache.Close()
+	})
+}
+
+func TestSkillsCacheReturnsEmptyForCwdWithNoSkills(t *testing.T) {
+	cwd := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cache := core.NewSkillsCache()
+	t.Cleanup(cache.Close)
+
+	result := cache.Get(cwd)
+
+	assert.Empty(t, result.Skills)
+}
+
+func TestSkillsCacheGetIsSafeAfterClose(t *testing.T) {
+	cwd := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	writeTestFile(t, filepath.Join(
+		cwd,
+		core.ConfigDirName,
+		"skills",
+		"alpha",
+		"SKILL.md",
+	), strings.Join([]string{
+		frontmatterDelimiter,
+		"name: alpha",
+		"description: Alpha skill",
+		frontmatterDelimiter,
+		"Body.",
+	}, "\n"))
+
+	cache := core.NewSkillsCache()
+
+	first := cache.Get(cwd)
+	require.Len(t, first.Skills, 1)
+
+	cache.Close()
+
+	// After Close, Get should still work — it just does a direct load.
+	second := cache.Get(cwd)
+	assert.Len(t, second.Skills, 1)
+}

--- a/internal/core/skills_cache_test.go
+++ b/internal/core/skills_cache_test.go
@@ -168,6 +168,30 @@ func TestSkillsCacheReturnsEmptyForCwdWithNoSkills(t *testing.T) {
 	assert.Empty(t, result.Skills)
 }
 
+func TestSkillsCacheInvalidatesWhenSkillRootCreatedLater(t *testing.T) {
+	cwd := newOutsideTempDir(t)
+	home := newOutsideTempDir(t)
+	t.Setenv("HOME", home)
+
+	// First Get with no skill directories — loads empty and watches ancestor.
+	cache := core.NewSkillsCache()
+	t.Cleanup(cache.Close)
+
+	first := cache.Get(cwd)
+	assert.Empty(t, first.Skills)
+
+	// Create the skill root and a skill file after the initial load.
+	skillPath := filepath.Join(cwd, core.ConfigDirName, "skills", "alpha", "SKILL.md")
+	writeTestFile(t, skillPath, skillMarkdown("alpha"))
+
+	// The ancestor watch should fire and invalidate the cache.
+	require.Eventually(t, func() bool {
+		refreshed := cache.Get(cwd)
+
+		return len(refreshed.Skills) == 1 && refreshed.Skills[0].Name == "alpha"
+	}, 3*time.Second, 50*time.Millisecond, "cache should invalidate when skill root is created")
+}
+
 func TestSkillsCacheGetIsSafeAfterClose(t *testing.T) {
 	cwd := t.TempDir()
 	home := t.TempDir()

--- a/internal/di/assistant_service.go
+++ b/internal/di/assistant_service.go
@@ -20,17 +20,19 @@ func NewAssistantService(injector do.Injector) (*AssistantService, error) {
 	events := do.MustInvoke[*EventService](injector)
 	models := do.MustInvoke[*ModelService](injector)
 	logger := do.MustInvoke[*LoggerService](injector).SlogLogger
+	skills := do.MustInvoke[*SkillsService](injector)
 
 	return &AssistantService{
 		Runtime: assistant.NewRuntime(&assistant.RuntimeOptions{
-			Config:     cfg,
-			Sessions:   databaseService.Sessions,
-			Extensions: extensionService.Manager,
-			Cache:      cache.Responses,
-			Events:     events.Bus,
-			Models:     models.Registry,
-			Client:     nil,
-			Logger:     logger,
+			Config:      cfg,
+			Sessions:    databaseService.Sessions,
+			Extensions:  extensionService.Manager,
+			Cache:       cache.Responses,
+			Events:      events.Bus,
+			Models:      models.Registry,
+			Client:      nil,
+			Logger:      logger,
+			SkillsCache: skills.Cache,
 		}),
 	}, nil
 }

--- a/internal/di/assistant_service_internal_test.go
+++ b/internal/di/assistant_service_internal_test.go
@@ -13,6 +13,7 @@ import (
 	_ "modernc.org/sqlite" // register SQLite driver for assistant service wiring tests.
 
 	"github.com/omarluq/librecode/internal/auth"
+	"github.com/omarluq/librecode/internal/core"
 	"github.com/omarluq/librecode/internal/database"
 	"github.com/omarluq/librecode/internal/event"
 	"github.com/omarluq/librecode/internal/extension"
@@ -34,6 +35,7 @@ func TestNewAssistantServiceWiresRuntimeOptions(t *testing.T) {
 	do.ProvideValue(injector, &CacheService{Responses: nil})
 	do.ProvideValue(injector, &EventService{Bus: event.NewBus(logger)})
 	do.ProvideValue(injector, &ModelService{Registry: newTestModelRegistry(t)})
+	do.ProvideValue(injector, &SkillsService{Cache: core.NewSkillsCache()})
 	do.ProvideValue(injector, &LoggerService{
 		SlogLogger:    logger,
 		ZerologLogger: newZerologLogger(testServiceConfig()),
@@ -46,6 +48,12 @@ func TestNewAssistantServiceWiresRuntimeOptions(t *testing.T) {
 	require.NotNil(t, service.Runtime.SessionRepository())
 	require.NotNil(t, service.Runtime.ModelRegistry())
 	require.NotNil(t, service.Runtime.EventBus())
+
+	t.Cleanup(func() {
+		if skills := do.MustInvoke[*SkillsService](injector); skills.Cache != nil {
+			skills.Cache.Close()
+		}
+	})
 }
 
 func newTestDatabaseService(t *testing.T) *DatabaseService {

--- a/internal/di/container.go
+++ b/internal/di/container.go
@@ -74,3 +74,8 @@ func (c *Container) AssistantService() *AssistantService {
 func (c *Container) ToolService() *ToolService {
 	return do.MustInvoke[*ToolService](c.injector)
 }
+
+// SkillsService resolves the skills cache service.
+func (c *Container) SkillsService() *SkillsService {
+	return do.MustInvoke[*SkillsService](c.injector)
+}

--- a/internal/di/register.go
+++ b/internal/di/register.go
@@ -11,6 +11,7 @@ func RegisterServices(injector do.Injector) {
 	do.Provide(injector, NewAuthService)
 	do.Provide(injector, NewModelService)
 	do.Provide(injector, NewCacheService)
+	do.Provide(injector, NewSkillsService)
 	do.Provide(injector, NewExtensionService)
 	do.Provide(injector, NewToolService)
 	do.Provide(injector, NewAssistantService)

--- a/internal/di/skills_service.go
+++ b/internal/di/skills_service.go
@@ -1,0 +1,25 @@
+package di
+
+import (
+	"github.com/samber/do/v2"
+
+	"github.com/omarluq/librecode/internal/core"
+)
+
+// SkillsService owns the process-level skills cache.
+type SkillsService struct {
+	Cache *core.SkillsCache
+}
+
+// NewSkillsService creates a skills cache that eliminates redundant filesystem
+// scans on every prompt.
+func NewSkillsService(_ do.Injector) (*SkillsService, error) {
+	return &SkillsService{
+		Cache: core.NewSkillsCache(),
+	}, nil
+}
+
+// Shutdown stops the cache's background file watcher.
+func (service *SkillsService) Shutdown() {
+	service.Cache.Close()
+}

--- a/internal/terminal/prompt_send_internal_test.go
+++ b/internal/terminal/prompt_send_internal_test.go
@@ -355,14 +355,15 @@ func newPromptSendTestAppWithConfig(
 	sessionRepository := database.NewSessionRepository(connection)
 	settingsRepository := database.NewDocumentRepository(connection)
 	runtime := assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:     runtimeConfig,
-		Sessions:   sessionRepository,
-		Extensions: manager,
-		Cache:      cache,
-		Events:     event.NewBus(slog.Default()),
-		Models:     registry,
-		Client:     client,
-		Logger:     slog.Default(),
+		Config:      runtimeConfig,
+		Sessions:    sessionRepository,
+		Extensions:  manager,
+		Cache:       cache,
+		Events:      event.NewBus(slog.Default()),
+		Models:      registry,
+		Client:      client,
+		Logger:      slog.Default(),
+		SkillsCache: nil,
 	})
 	app := newRenderTestApp(t)
 	app.runtime = runtime

--- a/internal/terminal/prompt_send_internal_test.go
+++ b/internal/terminal/prompt_send_internal_test.go
@@ -354,16 +354,15 @@ func newPromptSendTestAppWithConfig(
 	registry := newPromptSendTestModelRegistry(t)
 	sessionRepository := database.NewSessionRepository(connection)
 	settingsRepository := database.NewDocumentRepository(connection)
-	runtime := assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:      runtimeConfig,
-		Sessions:    sessionRepository,
-		Extensions:  manager,
-		Cache:       cache,
-		Events:      event.NewBus(slog.Default()),
-		Models:      registry,
-		Client:      client,
-		Logger:      slog.Default(),
-		SkillsCache: nil,
+	runtime := assistant.NewRuntimeForTest(func(opts *assistant.RuntimeTestOptions) {
+		opts.Config = runtimeConfig
+		opts.Sessions = sessionRepository
+		opts.Extensions = manager
+		opts.Cache = cache
+		opts.Events = event.NewBus(slog.Default())
+		opts.Models = registry
+		opts.Client = client
+		opts.Logger = slog.Default()
 	})
 	app := newRenderTestApp(t)
 	app.runtime = runtime

--- a/internal/terminal/render_parity_internal_test.go
+++ b/internal/terminal/render_parity_internal_test.go
@@ -289,14 +289,15 @@ func newRenderParityRuntimeWithSession(
 	appendRenderParityMessage(ctx, t, repository, session.ID, &second.ID, database.RoleAssistant, "assistant history")
 
 	runtime = assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:     renderParityConfig(),
-		Sessions:   repository,
-		Extensions: nil,
-		Cache:      nil,
-		Events:     nil,
-		Models:     nil,
-		Client:     nil,
-		Logger:     nil,
+		Config:      renderParityConfig(),
+		Sessions:    repository,
+		Extensions:  nil,
+		Cache:       nil,
+		Events:      nil,
+		Models:      nil,
+		Client:      nil,
+		Logger:      nil,
+		SkillsCache: nil,
 	})
 
 	return runtime, session.ID

--- a/internal/terminal/render_parity_internal_test.go
+++ b/internal/terminal/render_parity_internal_test.go
@@ -288,16 +288,9 @@ func newRenderParityRuntimeWithSession(
 	)
 	appendRenderParityMessage(ctx, t, repository, session.ID, &second.ID, database.RoleAssistant, "assistant history")
 
-	runtime = assistant.NewRuntime(&assistant.RuntimeOptions{
-		Config:      renderParityConfig(),
-		Sessions:    repository,
-		Extensions:  nil,
-		Cache:       nil,
-		Events:      nil,
-		Models:      nil,
-		Client:      nil,
-		Logger:      nil,
-		SkillsCache: nil,
+	runtime = assistant.NewRuntimeForTest(func(opts *assistant.RuntimeTestOptions) {
+		opts.Config = renderParityConfig()
+		opts.Sessions = repository
 	})
 
 	return runtime, session.ID


### PR DESCRIPTION
LoadSkills was called on every prompt, walking up to 4 directory trees,
reading every SKILL.md, and parsing YAML frontmatter. With 100+ skills
this adds 10-50ms of filesystem I/O per prompt. Add a SkillsCache backed
by samber/hot (W-TinyLFU, 1h TTL) with a background fsnotify watcher
that debounces burst events (500ms) before purging. Cache misses are
deduplicated via singleflight. Cache is CWD-scoped, lifecycle-managed
through a SkillsService DI registration, and gracefully degrades to
direct disk loads if fsnotify is unavailable or after Close. - Add
internal/core/skills_cache.go and tests (7 cases) - Add
internal/di/skills_service.go with Shutdown lifecycle - Wire SkillsCache
into Runtime.loadSkills() used by context_build,
context_auto_compaction, and slash commands