### PR TITLE
perf(tui): reuse goldmark parser across markdown renders

### DIFF
--- a/internal/terminal/markdown.go
+++ b/internal/terminal/markdown.go
@@ -18,6 +18,7 @@ func (app *App) renderMarkdown(content string, width int) []tui.Line {
 			Code:      markdownCodeStyle(app.theme),
 			CodeTheme: codeTheme(app.theme),
 		},
+		Engine: &app.renderer.Markdown,
 	}
 
 	return view.Render(width, markdownRenderMaxHeight)

--- a/internal/tui/buffer.go
+++ b/internal/tui/buffer.go
@@ -1,6 +1,10 @@
 package tui
 
-import "github.com/gdamore/tcell/v3"
+import (
+	"sync"
+
+	"github.com/gdamore/tcell/v3"
+)
 
 // Cell is one rendered terminal cell.
 type Cell struct {
@@ -120,11 +124,12 @@ func (buffer *CellBuffer) Clone() *CellBuffer {
 type Renderer struct {
 	screen   ContentSetter
 	previous *CellBuffer
+	Markdown MarkdownEngine
 }
 
 // NewRenderer returns a screen renderer.
 func NewRenderer(screen ContentSetter) *Renderer {
-	return &Renderer{screen: screen, previous: nil}
+	return &Renderer{screen: screen, previous: nil, Markdown: MarkdownEngine{parser: nil, once: sync.Once{}}}
 }
 
 // Flush writes changed cells from frame to the screen.

--- a/internal/tui/markdown.go
+++ b/internal/tui/markdown.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/gdamore/tcell/v3"
 	"github.com/yuin/goldmark"
@@ -25,6 +26,37 @@ const (
 	markdownTableMaxHeight           = 10_000
 )
 
+// MarkdownEngine lazily initializes and caches a goldmark parser.
+// The zero value is ready to use. The parser is stateless and safe for
+// concurrent use — each Parse call creates its own reader and AST context.
+type MarkdownEngine struct {
+	parser parser.Parser
+	once   sync.Once
+}
+
+// render parses source and invokes the visitor for each top-level AST child.
+// The parser is initialized on first call and reused for all subsequent calls.
+func (engine *MarkdownEngine) render(source []byte, visitor func(ast.Node)) {
+	engine.once.Do(func() {
+		engine.parser = goldmark.New(
+			goldmark.WithParserOptions(
+				parser.WithParagraphTransformers(util.Prioritized(
+					extension.NewTableParagraphTransformer(),
+					markdownTableTransformerPriority,
+				)),
+				parser.WithASTTransformers(util.Prioritized(extension.NewTableASTTransformer(), 0)),
+				parser.WithInlineParsers(util.Prioritized(extension.NewStrikethroughParser(), markdownStrikePriority)),
+				parser.WithInlineParsers(util.Prioritized(extension.NewTaskCheckBoxParser(), 0)),
+			),
+		).Parser()
+	})
+
+	document := engine.parser.Parse(goldtext.NewReader(source))
+	for child := document.FirstChild(); child != nil; child = child.NextSibling() {
+		visitor(child)
+	}
+}
+
 // MarkdownStyles configures MarkdownView rendering.
 type MarkdownStyles struct {
 	Text      tcell.Style
@@ -35,8 +67,11 @@ type MarkdownStyles struct {
 }
 
 // MarkdownView renders markdown into terminal lines.
+// When Engine is non-nil the cached parser is reused; otherwise a throwaway
+// parser is created per call (backward-compatible behavior).
 type MarkdownView struct {
 	Text   string
+	Engine *MarkdownEngine
 	Styles MarkdownStyles
 }
 
@@ -52,19 +87,22 @@ func (view *MarkdownView) Render(width, height int) []Line {
 		lines:  []Line{},
 		width:  max(1, width),
 	}
-	markdownParser := goldmark.New(goldmark.WithParserOptions(
-		parser.WithParagraphTransformers(util.Prioritized(
-			extension.NewTableParagraphTransformer(),
-			markdownTableTransformerPriority,
-		)),
-		parser.WithASTTransformers(util.Prioritized(extension.NewTableASTTransformer(), 0)),
-		parser.WithInlineParsers(util.Prioritized(extension.NewStrikethroughParser(), markdownStrikePriority)),
-		parser.WithInlineParsers(util.Prioritized(extension.NewTaskCheckBoxParser(), 0)),
-	))
-	document := markdownParser.Parser().Parse(goldtext.NewReader(renderer.source))
-	renderer.renderChildren(document, markdownIndent)
+
+	engine := view.engine()
+	engine.render(renderer.source, func(child ast.Node) {
+		renderer.renderNode(child, markdownIndent)
+	})
 
 	return Tail(renderer.lines, height)
+}
+
+// engine returns the cached parser engine, falling back to a throwaway one.
+func (view *MarkdownView) engine() *MarkdownEngine {
+	if view.Engine != nil {
+		return view.Engine
+	}
+
+	return &MarkdownEngine{parser: nil, once: sync.Once{}}
 }
 
 // Draw draws markdown into rect.

--- a/internal/tui/markdown_test.go
+++ b/internal/tui/markdown_test.go
@@ -41,7 +41,7 @@ func TestMarkdownViewRendersCommonBlocks(t *testing.T) {
 		Code:      tcell.StyleDefault,
 		CodeTheme: testCodeTheme(),
 	}
-	view := &tui.MarkdownView{Text: markdown, Styles: styles}
+	view := &tui.MarkdownView{Text: markdown, Styles: styles, Engine: nil}
 
 	lines := view.Render(40, 100)
 	text := strings.Join(lineTexts(lines), "\n")
@@ -57,7 +57,7 @@ func TestMarkdownViewRendersCommonBlocks(t *testing.T) {
 	require.Contains(t, text, "Alpha")
 
 	buffer := tui.NewCellBuffer(40, 2, tcell.StyleDefault)
-	(&tui.MarkdownView{Text: "# Heading", Styles: styles}).Draw(buffer, testRect(0, 0, 40, 2))
+	(&tui.MarkdownView{Text: "# Heading", Styles: styles, Engine: nil}).Draw(buffer, testRect(0, 0, 40, 2))
 	require.Equal(t, '#', buffer.Cell(1, 0).Rune)
 }
 
@@ -65,15 +65,17 @@ func TestMarkdownCodeBlockWrapsInsteadOfSwallowingSymbols(t *testing.T) {
 	t.Parallel()
 
 	markdown := "```go\nfunc Fib(n int) int {\n    if n < 2 {\n        return n\n    }\n}\n```"
+	styles := tui.MarkdownStyles{
+		Text:      tcell.StyleDefault,
+		Accent:    tcell.StyleDefault,
+		Muted:     tcell.StyleDefault,
+		Code:      tcell.StyleDefault,
+		CodeTheme: testCodeTheme(),
+	}
 	view := tui.MarkdownView{
-		Text: markdown,
-		Styles: tui.MarkdownStyles{
-			Text:      tcell.StyleDefault,
-			Accent:    tcell.StyleDefault,
-			Muted:     tcell.StyleDefault,
-			Code:      tcell.StyleDefault,
-			CodeTheme: testCodeTheme(),
-		},
+		Text:   markdown,
+		Styles: styles,
+		Engine: nil,
 	}
 
 	lines := view.Render(20, 100)


### PR DESCRIPTION
`MarkdownView.Render()` created a new goldmark instance with full
extension configuration on every call. During transcript rendering,
cache warming, and resize this caused 20+ instantiations per session.
Add `MarkdownEngine` with `sync.Once` lazy initialization stored on the
`Renderer` struct so a single parser instance serves the entire terminal
session.