### PR TITLE
perf(tui): cache chroma lexer auto-detection results

### DIFF
--- a/internal/terminal/markdown.go
+++ b/internal/terminal/markdown.go
@@ -19,6 +19,7 @@ func (app *App) renderMarkdown(content string, width int) []tui.Line {
 			CodeTheme: codeTheme(app.theme),
 		},
 		Engine: &app.renderer.Markdown,
+		Lexer:  &app.renderer.Lexer,
 	}
 
 	return view.Render(width, markdownRenderMaxHeight)

--- a/internal/tui/buffer.go
+++ b/internal/tui/buffer.go
@@ -124,12 +124,18 @@ func (buffer *CellBuffer) Clone() *CellBuffer {
 type Renderer struct {
 	screen   ContentSetter
 	previous *CellBuffer
+	Lexer    LexerEngine
 	Markdown MarkdownEngine
 }
 
 // NewRenderer returns a screen renderer.
 func NewRenderer(screen ContentSetter) *Renderer {
-	return &Renderer{screen: screen, previous: nil, Markdown: MarkdownEngine{parser: nil, once: sync.Once{}}}
+	return &Renderer{
+		screen:   screen,
+		previous: nil,
+		Markdown: MarkdownEngine{parser: nil, once: sync.Once{}},
+		Lexer:    NewLexerEngine(),
+	}
 }
 
 // Flush writes changed cells from frame to the screen.

--- a/internal/tui/code.go
+++ b/internal/tui/code.go
@@ -25,6 +25,7 @@ type CodeTheme struct {
 // CodeBlock renders syntax-highlighted code.
 type CodeBlock struct {
 	Style    tcell.Style
+	Engine   *LexerEngine
 	Language string
 	Text     string
 	Theme    CodeTheme
@@ -36,7 +37,8 @@ func (block *CodeBlock) Render(width, height int) []Line {
 		return []Line{}
 	}
 
-	lines := WrapCodeLines(SyntaxHighlightedCodeLines(block.Language, block.Text, block.Theme, block.Style), width)
+	rendered := newLexerCodeRenderer(block.Engine).render(block.Language, block.Text, block.Theme, block.Style)
+	lines := WrapCodeLines(rendered, width)
 
 	return Tail(lines, height)
 }
@@ -71,7 +73,21 @@ func (view *DiffView) Draw(screen ContentSetter, rect Rect) {
 
 // SyntaxHighlightedCodeLines returns syntax-highlighted code lines.
 func SyntaxHighlightedCodeLines(language, text string, theme CodeTheme, baseStyle tcell.Style) []Line {
-	iterator, ok := codeTokenIterator(language, text)
+	return newLexerCodeRenderer(nil).render(language, text, theme, baseStyle)
+}
+
+// lexerCodeRenderer owns a cache-backed lexer engine and renders
+// syntax-highlighted code lines for code blocks.
+type lexerCodeRenderer struct {
+	engine *LexerEngine
+}
+
+func newLexerCodeRenderer(engine *LexerEngine) lexerCodeRenderer {
+	return lexerCodeRenderer{engine: engine}
+}
+
+func (r lexerCodeRenderer) render(language, text string, theme CodeTheme, baseStyle tcell.Style) []Line {
+	iterator, ok := r.iterator(language, text)
 	if !ok {
 		return codeStyledLines(text, baseStyle)
 	}
@@ -84,7 +100,7 @@ func SyntaxHighlightedCodeLines(language, text string, theme CodeTheme, baseStyl
 	return lines
 }
 
-func codeTokenIterator(language, text string) (chroma.Iterator, bool) {
+func (r lexerCodeRenderer) iterator(language, text string) (chroma.Iterator, bool) {
 	lexer := lexers.Get(strings.TrimSpace(language))
 	if lexer != nil {
 		return tokenizeCode(lexer, text)
@@ -92,6 +108,10 @@ func codeTokenIterator(language, text string) (chroma.Iterator, bool) {
 
 	if strings.TrimSpace(language) != "" {
 		return nil, false
+	}
+
+	if r.engine != nil {
+		return r.engine.IteratorFor(text)
 	}
 
 	return analyzedCodeIterator(text)

--- a/internal/tui/code_test.go
+++ b/internal/tui/code_test.go
@@ -37,6 +37,7 @@ func TestCodeBlockWrapsInsteadOfSwallowingSymbols(t *testing.T) {
 		Text:     text,
 		Theme:    testCodeTheme(),
 		Style:    tcell.StyleDefault,
+		Engine:   nil,
 	}
 
 	lines := block.Render(14, 100)

--- a/internal/tui/lexer_engine.go
+++ b/internal/tui/lexer_engine.go
@@ -27,8 +27,8 @@ func NewLexerEngine() LexerEngine {
 // IteratorFor returns a token iterator for untagged code by looking up the
 // cached lexer, or running full analysis on the first encounter.
 func (engine *LexerEngine) IteratorFor(text string) (chroma.Iterator, bool) {
-	cached, found, err := engine.cache.Get(text)
-	if err == nil && found {
+	cached, found := engine.cache.MustGet(text)
+	if found {
 		return tokenizeCode(cached, text)
 	}
 

--- a/internal/tui/lexer_engine.go
+++ b/internal/tui/lexer_engine.go
@@ -1,0 +1,54 @@
+package tui
+
+import (
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/lexers"
+	"github.com/samber/hot"
+)
+
+const lexerCacheCapacity = 64
+
+// LexerEngine caches chroma lexer auto-detection results so that repeated
+// renders of the same untagged code block skip the expensive O(N) scan of
+// all 278+ registered lexers.
+type LexerEngine struct {
+	cache *hot.HotCache[string, chroma.Lexer]
+}
+
+// NewLexerEngine creates a lexer engine backed by a W-TinyLFU cache.
+// The cache has no TTL because lexer detection is deterministic for
+// identical text — the same input always selects the same lexer.
+func NewLexerEngine() LexerEngine {
+	cache := hot.NewHotCache[string, chroma.Lexer](hot.WTinyLFU, lexerCacheCapacity).Build()
+
+	return LexerEngine{cache: cache}
+}
+
+// IteratorFor returns a token iterator for untagged code by looking up the
+// cached lexer, or running full analysis on the first encounter.
+func (engine *LexerEngine) IteratorFor(text string) (chroma.Iterator, bool) {
+	cached, found, err := engine.cache.Get(text)
+	if err == nil && found {
+		return tokenizeCode(cached, text)
+	}
+
+	highest := float32(0)
+
+	var bestLexer chroma.Lexer
+
+	for _, lexer := range lexers.GlobalLexerRegistry.Lexers {
+		weight := lexer.AnalyseText(text)
+		if weight > highest {
+			highest = weight
+			bestLexer = lexer
+		}
+	}
+
+	if highest == 0 {
+		return nil, false
+	}
+
+	engine.cache.Set(text, bestLexer)
+
+	return tokenizeCode(bestLexer, text)
+}

--- a/internal/tui/lexer_engine_test.go
+++ b/internal/tui/lexer_engine_test.go
@@ -1,0 +1,85 @@
+package tui_test
+
+import (
+	"testing"
+
+	"github.com/omarluq/librecode/internal/tui"
+)
+
+func TestLexerEngineCachesAnalysisResult(t *testing.T) {
+	t.Parallel()
+
+	engine := tui.NewLexerEngine()
+
+	// Go code without a language tag — should detect the Go lexer.
+	text := "func main() {\n\tfmt.Println(\"hello\")\n}"
+
+	// First call runs the full analysis (cache miss).
+	iter1, found := engine.IteratorFor(text)
+	if !found {
+		t.Fatal("expected lexer detection to succeed on first call")
+	}
+
+	tokens1 := iter1.Tokens()
+
+	// Second call should return the cached lexer (cache hit).
+	iter2, found := engine.IteratorFor(text)
+	if !found {
+		t.Fatal("expected lexer detection to succeed on second call")
+	}
+
+	tokens2 := iter2.Tokens()
+
+	if len(tokens1) != len(tokens2) {
+		t.Fatalf("token count mismatch: first=%d second=%d", len(tokens1), len(tokens2))
+	}
+
+	for index := range tokens1 {
+		if tokens1[index].Type != tokens2[index].Type || tokens1[index].Value != tokens2[index].Value {
+			t.Fatalf("token %d mismatch: first=%v second=%v", index, tokens1[index], tokens2[index])
+		}
+	}
+}
+
+func TestLexerEngineReturnsFalseForNoMatch(t *testing.T) {
+	t.Parallel()
+
+	engine := tui.NewLexerEngine()
+
+	// Plain text with no distinguishing features.
+	_, found := engine.IteratorFor("just some plain words")
+	if found {
+		t.Fatal("expected no lexer match for plain text")
+	}
+}
+
+func TestLexerEngineDetectsGoCode(t *testing.T) {
+	t.Parallel()
+
+	engine := tui.NewLexerEngine()
+	text := "package main\n\nfunc main() {}"
+
+	iter, found := engine.IteratorFor(text)
+	if !found {
+		t.Fatal("expected engine to detect a lexer for Go code")
+	}
+
+	tokens := iter.Tokens()
+	if len(tokens) == 0 {
+		t.Fatal("expected non-empty token stream")
+	}
+
+	foundPackage := false
+
+	for _, token := range tokens {
+		if token.Value == "package" {
+			foundPackage = true
+
+			break
+		}
+	}
+
+	if !foundPackage {
+		t.Fatalf("expected 'package' keyword in tokens: %#v", tokens)
+	}
+}

--- a/internal/tui/markdown.go
+++ b/internal/tui/markdown.go
@@ -72,6 +72,7 @@ type MarkdownStyles struct {
 type MarkdownView struct {
 	Text   string
 	Engine *MarkdownEngine
+	Lexer  *LexerEngine
 	Styles MarkdownStyles
 }
 
@@ -86,6 +87,7 @@ func (view *MarkdownView) Render(width, height int) []Line {
 		source: []byte(view.Text),
 		lines:  []Line{},
 		width:  max(1, width),
+		lexer:  view.Lexer,
 	}
 
 	engine := view.engine()
@@ -111,6 +113,7 @@ func (view *MarkdownView) Draw(screen ContentSetter, rect Rect) {
 }
 
 type markdownRenderer struct {
+	lexer  *LexerEngine
 	source []byte
 	lines  []Line
 	styles MarkdownStyles
@@ -173,8 +176,10 @@ func (renderer *markdownRenderer) renderIndentedCodeBlock(node *ast.CodeBlock, i
 func (renderer *markdownRenderer) appendCodeLines(language, text, indent string) {
 	width := max(1, renderer.width-Width(indent))
 
-	lines := SyntaxHighlightedCodeLines(language, text, renderer.styles.CodeTheme, renderer.styles.Code)
-	for _, line := range WrapCodeLines(lines, width) {
+	rendered := newLexerCodeRenderer(renderer.lexer).
+		render(language, text, renderer.styles.CodeTheme, renderer.styles.Code)
+
+	for _, line := range WrapCodeLines(rendered, width) {
 		renderer.prependIndentToLine(&line, indent, line.Style)
 		renderer.lines = append(renderer.lines, line)
 	}

--- a/internal/tui/markdown_test.go
+++ b/internal/tui/markdown_test.go
@@ -41,7 +41,7 @@ func TestMarkdownViewRendersCommonBlocks(t *testing.T) {
 		Code:      tcell.StyleDefault,
 		CodeTheme: testCodeTheme(),
 	}
-	view := &tui.MarkdownView{Text: markdown, Styles: styles, Engine: nil}
+	view := &tui.MarkdownView{Text: markdown, Styles: styles, Engine: nil, Lexer: nil}
 
 	lines := view.Render(40, 100)
 	text := strings.Join(lineTexts(lines), "\n")
@@ -57,7 +57,7 @@ func TestMarkdownViewRendersCommonBlocks(t *testing.T) {
 	require.Contains(t, text, "Alpha")
 
 	buffer := tui.NewCellBuffer(40, 2, tcell.StyleDefault)
-	(&tui.MarkdownView{Text: "# Heading", Styles: styles, Engine: nil}).Draw(buffer, testRect(0, 0, 40, 2))
+	(&tui.MarkdownView{Text: "# Heading", Styles: styles, Engine: nil, Lexer: nil}).Draw(buffer, testRect(0, 0, 40, 2))
 	require.Equal(t, '#', buffer.Cell(1, 0).Rune)
 }
 
@@ -76,6 +76,7 @@ func TestMarkdownCodeBlockWrapsInsteadOfSwallowingSymbols(t *testing.T) {
 		Text:   markdown,
 		Styles: styles,
 		Engine: nil,
+		Lexer:  nil,
 	}
 
 	lines := view.Render(20, 100)


### PR DESCRIPTION
`AnalyseText` scanned all 278 registered lexers for every untagged code
block during transcript render, cache warming, and resize. Cache the
result in a W-TinyLFU lexer engine (capacity 64, no TTL) so identical
text reuses the detection on subsequent renders.