### PR TITLE
perf(provider): tune HTTP transport for connection reuse

### DIFF
--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -140,9 +140,29 @@ type HTTPCompletionClient struct {
 
 const providerHTTPTimeout = 10 * time.Minute
 
+const (
+	providerMaxIdleConns          = 100
+	providerMaxIdleConnsPerHost   = 10
+	providerIdleConnTimeout       = 90 * time.Second
+	providerTLSHandshakeTimeout   = 10 * time.Second
+	providerResponseHeaderTimeout = 120 * time.Second
+)
+
 // NewHTTPCompletionClient creates an HTTP-backed completion client.
 func NewHTTPCompletionClient() *HTTPCompletionClient {
-	return &HTTPCompletionClient{client: &http.Client{Timeout: providerHTTPTimeout}}
+	return &HTTPCompletionClient{client: &http.Client{
+		Timeout: providerHTTPTimeout,
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			MaxIdleConns:          providerMaxIdleConns,
+			MaxIdleConnsPerHost:   providerMaxIdleConnsPerHost,
+			IdleConnTimeout:       providerIdleConnTimeout,
+			TLSHandshakeTimeout:   providerTLSHandshakeTimeout,
+			ExpectContinueTimeout: 1 * time.Second,
+			ResponseHeaderTimeout: providerResponseHeaderTimeout,
+			ForceAttemptHTTP2:     true,
+		},
+	}}
 }
 
 // Generate sends a provider-neutral request without runtime callbacks.

--- a/internal/provider/transport_internal_test.go
+++ b/internal/provider/transport_internal_test.go
@@ -1,0 +1,26 @@
+package provider
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHTTPCompletionClientTunedTransport(t *testing.T) {
+	t.Parallel()
+
+	client := NewHTTPCompletionClient()
+	require.NotNil(t, client.client.Transport)
+
+	transport, ok := client.client.Transport.(*http.Transport)
+	require.True(t, ok)
+
+	assert.Equal(t, providerMaxIdleConns, transport.MaxIdleConns)
+	assert.Equal(t, providerMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+	assert.Equal(t, providerIdleConnTimeout, transport.IdleConnTimeout)
+	assert.Equal(t, providerTLSHandshakeTimeout, transport.TLSHandshakeTimeout)
+	assert.Equal(t, providerResponseHeaderTimeout, transport.ResponseHeaderTimeout)
+	assert.True(t, transport.ForceAttemptHTTP2)
+}


### PR DESCRIPTION
`http.DefaultTransport` defaults to 2 idle connections per host. During multi-turn tool loops each prompt makes 3-10 sequential requests to the same provider endpoint, so most required fresh TCP + TLS handshakes. Add a custom transport with `MaxIdleConnsPerHost=10`, TLS handshake and response header timeouts, and HTTP/2 negotiation directly on the `HTTPCompletionClient`