### PR TITLE
fix(auth): complete anthropic oauth login

### DIFF
--- a/internal/auth/oauth_anthropic.go
+++ b/internal/auth/oauth_anthropic.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -45,7 +46,7 @@ func AnthropicLoginURL() (string, error) {
 }
 
 // LoginAnthropic runs the Claude Pro/Max OAuth browser flow.
-func LoginAnthropic(ctx context.Context, onAuth func(OAuthAuthInfo)) (*Credential, error) {
+func LoginAnthropic(ctx context.Context, onAuth func(OAuthAuthInfo)) (credential *Credential, err error) {
 	flow, err := newAnthropicFlow()
 	if err != nil {
 		return nil, err
@@ -55,7 +56,9 @@ func LoginAnthropic(ctx context.Context, onAuth func(OAuthAuthInfo)) (*Credentia
 	if err != nil {
 		return nil, err
 	}
-	defer server.Close(ctx)
+	defer func() {
+		err = errors.Join(err, server.Close(ctx))
+	}()
 
 	if onAuth != nil {
 		onAuth(OAuthAuthInfo{

--- a/internal/auth/oauth_anthropic.go
+++ b/internal/auth/oauth_anthropic.go
@@ -16,6 +16,7 @@ const (
 	anthropicClaudeProvider = "anthropic-claude"
 	anthropicClientID       = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 	anthropicAuthorize      = "https://claude.ai/oauth/authorize"
+	anthropicCallback       = "127.0.0.1:53692"
 )
 
 const (
@@ -41,6 +42,34 @@ func AnthropicLoginURL() (string, error) {
 	}
 
 	return flow.URL, nil
+}
+
+// LoginAnthropic runs the Claude Pro/Max OAuth browser flow.
+func LoginAnthropic(ctx context.Context, onAuth func(OAuthAuthInfo)) (*Credential, error) {
+	flow, err := newAnthropicFlow()
+	if err != nil {
+		return nil, err
+	}
+
+	server, err := startAnthropicCallbackServer(flow.State)
+	if err != nil {
+		return nil, err
+	}
+	defer server.Close(ctx)
+
+	if onAuth != nil {
+		onAuth(OAuthAuthInfo{
+			URL:          flow.URL,
+			Instructions: "Complete login in your browser to finish authentication.",
+		})
+	}
+
+	code, err := server.Wait(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return exchangeAnthropicCode(ctx, code, flow.State, flow.Verifier, anthropicTokenEndpoint())
 }
 
 // LoginAnthropicWithCode completes Claude Pro/Max OAuth using the pasted code from Claude.
@@ -104,6 +133,12 @@ type anthropicFlow struct {
 	Verifier string
 	State    string
 	URL      string
+}
+
+type anthropicCallbackServer = oauthCallbackServer
+
+func startAnthropicCallbackServer(state string) (*anthropicCallbackServer, error) {
+	return startOAuthCallbackServer(anthropicCallback, "/callback", state, "anthropic")
 }
 
 func newAnthropicFlow() (*anthropicFlow, error) {

--- a/internal/auth/oauth_anthropic_internal_test.go
+++ b/internal/auth/oauth_anthropic_internal_test.go
@@ -38,6 +38,27 @@ func TestAnthropicLoginURL(t *testing.T) {
 	assert.Contains(t, loginURL, "code_challenge=")
 }
 
+func TestLoginAnthropicPublishesBrowserFlowAndHandlesCancellation(t *testing.T) {
+	t.Setenv("LIBRECODE_AUTH_TEST", "browser-flow")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var authInfo OAuthAuthInfo
+
+	credential, err := LoginAnthropic(ctx, func(info OAuthAuthInfo) {
+		authInfo = info
+
+		cancel()
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, credential)
+	assert.Contains(t, err.Error(), "wait for oauth callback")
+	assert.Contains(t, authInfo.Instructions, "browser")
+	assert.Contains(t, authInfo.URL, "code_challenge=")
+}
+
 func TestLoginAnthropicWithCode(t *testing.T) {
 	t.Parallel()
 
@@ -86,7 +107,10 @@ func TestAnthropicCallbackReceivesCodeAndHandlesContext(t *testing.T) {
 	if err != nil {
 		t.Skipf("callback port unavailable: %v", err)
 	}
-	defer server.Close(context.Background())
+
+	t.Cleanup(func() {
+		require.NoError(t, server.Close(context.Background()))
+	})
 
 	request, err := http.NewRequestWithContext(
 		t.Context(),

--- a/internal/auth/oauth_anthropic_internal_test.go
+++ b/internal/auth/oauth_anthropic_internal_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -76,6 +77,66 @@ func TestLoginAnthropicWithCodeRejectsInvalidCode(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, credential)
 	assert.Contains(t, err.Error(), "code#state")
+}
+
+func TestAnthropicCallbackReceivesCodeAndHandlesContext(t *testing.T) {
+	t.Parallel()
+
+	server, err := startAnthropicCallbackServer("state")
+	if err != nil {
+		t.Skipf("callback port unavailable: %v", err)
+	}
+	defer server.Close(context.Background())
+
+	request, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodGet,
+		anthropicRedirectEndpoint()+"?state=state&code=auth-code",
+		http.NoBody,
+	)
+	require.NoError(t, err)
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	require.NoError(t, response.Body.Close())
+
+	code, err := server.Wait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "auth-code", code)
+
+	waiting := &anthropicCallbackServer{
+		server:     &http.Server{ReadHeaderTimeout: oauthCallbackTimeout},
+		codes:      make(chan callbackResult),
+		codePrefix: "anthropic",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	code, err = waiting.Wait(ctx)
+	require.Error(t, err)
+	assert.Empty(t, code)
+}
+
+func TestAnthropicCallbackRejectsStateMismatch(t *testing.T) {
+	t.Parallel()
+
+	codes := make(chan callbackResult, 1)
+	handler := oauthCallbackHandler("expected-state", codes)
+	request := httptest.NewRequestWithContext(
+		t.Context(),
+		http.MethodGet,
+		anthropicRedirectEndpoint()+"?state=wrong&code=auth-code",
+		nil,
+	)
+	response := httptest.NewRecorder()
+
+	handler(response, request)
+
+	assert.Equal(t, http.StatusBadRequest, response.Code)
+
+	result := <-codes
+	require.Error(t, result.Err)
+	assert.Contains(t, result.Err.Error(), "state mismatch")
 }
 
 func TestAnthropicAPIKey(t *testing.T) {

--- a/internal/auth/oauth_codex.go
+++ b/internal/auth/oauth_codex.go
@@ -168,10 +168,13 @@ func newOpenAICodexFlow() (*openAICodexFlow, error) {
 	return &openAICodexFlow{Verifier: verifier, State: state, URL: authURL.String()}, nil
 }
 
-type openAICodexCallbackServer struct {
-	server *http.Server
-	codes  chan callbackResult
+type oauthCallbackServer struct {
+	server     *http.Server
+	codes      chan callbackResult
+	codePrefix string
 }
+
+type openAICodexCallbackServer = oauthCallbackServer
 
 type callbackResult struct {
 	Err  error
@@ -179,9 +182,39 @@ type callbackResult struct {
 }
 
 func startOpenAICodexCallbackServer(state string) (*openAICodexCallbackServer, error) {
+	return startOAuthCallbackServer(openAICodexCallback, "/auth/callback", state, "codex")
+}
+
+func startOAuthCallbackServer(address, callbackPath, state, codePrefix string) (*oauthCallbackServer, error) {
 	codes := make(chan callbackResult, 1)
 	mux := http.NewServeMux()
-	mux.HandleFunc("/auth/callback", func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc(callbackPath, oauthCallbackHandler(state, codes))
+	mux.HandleFunc("/", func(writer http.ResponseWriter, _ *http.Request) {
+		writeOAuthHTML(writer, http.StatusNotFound, "Callback route not found.")
+	})
+
+	server := &http.Server{
+		Addr:              address,
+		Handler:           mux,
+		ReadHeaderTimeout: oauthCallbackTimeout,
+	}
+
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", address)
+	if err != nil {
+		return nil, oops.In("auth").Code(codePrefix+"_callback_listen").Wrapf(err, "listen for oauth callback")
+	}
+
+	go func() {
+		if serveErr := server.Serve(listener); serveErr != nil && serveErr != http.ErrServerClosed {
+			codes <- callbackResult{Code: "", Err: serveErr}
+		}
+	}()
+
+	return &oauthCallbackServer{server: server, codes: codes, codePrefix: codePrefix}, nil
+}
+
+func oauthCallbackHandler(state string, codes chan<- callbackResult) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
 		query := request.URL.Query()
 		if query.Get("state") != state {
 			writeOAuthHTML(writer, http.StatusBadRequest, "Authentication state mismatch.")
@@ -203,45 +236,26 @@ func startOpenAICodexCallbackServer(state string) (*openAICodexCallbackServer, e
 		writeOAuthHTML(writer, http.StatusOK, "librecode authentication complete. You can close this tab.")
 
 		codes <- callbackResult{Code: code, Err: nil}
-	})
-	mux.HandleFunc("/", func(writer http.ResponseWriter, _ *http.Request) {
-		writeOAuthHTML(writer, http.StatusNotFound, "Callback route not found.")
-	})
-
-	server := &http.Server{
-		Addr:              openAICodexCallback,
-		Handler:           mux,
-		ReadHeaderTimeout: oauthCallbackTimeout,
 	}
-
-	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", openAICodexCallback)
-	if err != nil {
-		return nil, oops.In("auth").Code("codex_callback_listen").Wrapf(err, "listen for oauth callback")
-	}
-
-	go func() {
-		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
-			codes <- callbackResult{Code: "", Err: err}
-		}
-	}()
-
-	return &openAICodexCallbackServer{server: server, codes: codes}, nil
 }
 
-func (server *openAICodexCallbackServer) Wait(ctx context.Context) (string, error) {
+func (server *oauthCallbackServer) Wait(ctx context.Context) (string, error) {
 	select {
 	case result := <-server.codes:
 		if result.Err != nil {
-			return "", oops.In("auth").Code("codex_callback").Wrapf(result.Err, "receive oauth callback")
+			return "", oops.In("auth").Code(server.codePrefix+"_callback").Wrapf(result.Err, "receive oauth callback")
 		}
 
 		return result.Code, nil
 	case <-ctx.Done():
-		return "", oops.In("auth").Code("codex_callback_canceled").Wrapf(ctx.Err(), "wait for oauth callback")
+		return "", oops.In("auth").Code(server.codePrefix+"_callback_canceled").Wrapf(
+			ctx.Err(),
+			"wait for oauth callback",
+		)
 	}
 }
 
-func (server *openAICodexCallbackServer) Close(ctx context.Context) {
+func (server *oauthCallbackServer) Close(ctx context.Context) {
 	shutdownCtx, cancel := context.WithTimeout(ctx, oauthShutdownTimeout)
 	defer cancel()
 

--- a/internal/auth/oauth_codex.go
+++ b/internal/auth/oauth_codex.go
@@ -52,7 +52,7 @@ type OAuthAuthInfo struct {
 }
 
 // LoginOpenAICodex runs the ChatGPT/Codex OAuth browser flow.
-func LoginOpenAICodex(ctx context.Context, onAuth func(OAuthAuthInfo)) (*Credential, error) {
+func LoginOpenAICodex(ctx context.Context, onAuth func(OAuthAuthInfo)) (credential *Credential, err error) {
 	flow, err := newOpenAICodexFlow()
 	if err != nil {
 		return nil, err
@@ -62,7 +62,9 @@ func LoginOpenAICodex(ctx context.Context, onAuth func(OAuthAuthInfo)) (*Credent
 	if err != nil {
 		return nil, err
 	}
-	defer server.Close(ctx)
+	defer func() {
+		err = errors.Join(err, server.Close(ctx))
+	}()
 
 	if onAuth != nil {
 		onAuth(OAuthAuthInfo{
@@ -76,7 +78,7 @@ func LoginOpenAICodex(ctx context.Context, onAuth func(OAuthAuthInfo)) (*Credent
 		return nil, err
 	}
 
-	credential, err := exchangeOpenAICodexCode(ctx, code, flow.Verifier)
+	credential, err = exchangeOpenAICodexCode(ctx, code, flow.Verifier)
 	if err != nil {
 		return nil, err
 	}
@@ -255,13 +257,21 @@ func (server *oauthCallbackServer) Wait(ctx context.Context) (string, error) {
 	}
 }
 
-func (server *oauthCallbackServer) Close(ctx context.Context) {
+func (server *oauthCallbackServer) Close(ctx context.Context) error {
 	shutdownCtx, cancel := context.WithTimeout(ctx, oauthShutdownTimeout)
 	defer cancel()
 
-	if err := server.server.Shutdown(shutdownCtx); err != nil {
-		return
+	shutdownErr := server.server.Shutdown(shutdownCtx)
+	if shutdownErr == nil {
+		return nil
 	}
+
+	closeErr := server.server.Close()
+
+	return oops.In("auth").Code(server.codePrefix+"_callback_shutdown").Wrapf(
+		errors.Join(shutdownErr, closeErr),
+		"shut down oauth callback server",
+	)
 }
 
 func writeOAuthHTML(writer http.ResponseWriter, status int, message string) {

--- a/internal/auth/oauth_errors_internal_test.go
+++ b/internal/auth/oauth_errors_internal_test.go
@@ -120,7 +120,10 @@ func TestOpenAICodexOAuthTopLevelAndCallback(t *testing.T) {
 	if err != nil {
 		t.Skipf("callback port unavailable: %v", err)
 	}
-	defer server.Close(context.Background())
+
+	t.Cleanup(func() {
+		require.NoError(t, server.Close(context.Background()))
+	})
 
 	status := getCallbackStatusForTest(t, "/auth/callback?state=wrong&code=abc")
 	assert.Equal(t, http.StatusBadRequest, status)
@@ -137,7 +140,10 @@ func TestOpenAICodexCallbackReceivesCodeAndHandlesContext(t *testing.T) {
 	if err != nil {
 		t.Skipf("callback port unavailable: %v", err)
 	}
-	defer server.Close(context.Background())
+
+	t.Cleanup(func() {
+		require.NoError(t, server.Close(context.Background()))
+	})
 
 	status := getCallbackStatusForTest(t, "/auth/callback?state=state&code=auth-code")
 	assert.Equal(t, http.StatusOK, status)
@@ -157,6 +163,64 @@ func TestOpenAICodexCallbackReceivesCodeAndHandlesContext(t *testing.T) {
 	code, err = waiting.Wait(ctx)
 	require.Error(t, err)
 	assert.Empty(t, code)
+}
+
+func TestOAuthCallbackServerCloseForceClosesAfterCanceledShutdown(t *testing.T) {
+	t.Parallel()
+
+	requestStarted := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	httpServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		close(requestStarted)
+		<-request.Context().Done()
+		close(requestCanceled)
+	}))
+
+	requestDone := make(chan error, 1)
+
+	go func() {
+		request, requestErr := http.NewRequestWithContext(t.Context(), http.MethodGet, httpServer.URL, http.NoBody)
+		if requestErr != nil {
+			requestDone <- requestErr
+
+			return
+		}
+
+		response, requestErr := http.DefaultClient.Do(request)
+		if requestErr != nil {
+			requestDone <- nil
+
+			return
+		}
+
+		requestDone <- response.Body.Close()
+	}()
+
+	<-requestStarted
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	server := &oauthCallbackServer{server: httpServer.Config, codes: nil, codePrefix: "test"}
+	err := server.Close(ctx)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Contains(t, err.Error(), "shut down oauth callback server")
+
+	select {
+	case <-requestCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("active callback request was not canceled")
+	}
+
+	select {
+	case requestErr := <-requestDone:
+		require.NoError(t, requestErr)
+	case <-time.After(time.Second):
+		t.Fatal("callback client did not return after force close")
+	}
+
+	httpServer.Close()
 }
 
 func TestWriteOAuthHTML(t *testing.T) {

--- a/internal/auth/oauth_errors_internal_test.go
+++ b/internal/auth/oauth_errors_internal_test.go
@@ -147,8 +147,9 @@ func TestOpenAICodexCallbackReceivesCodeAndHandlesContext(t *testing.T) {
 	assert.Equal(t, "auth-code", code)
 
 	waiting := &openAICodexCallbackServer{
-		server: &http.Server{ReadHeaderTimeout: oauthCallbackTimeout},
-		codes:  make(chan callbackResult),
+		server:     &http.Server{ReadHeaderTimeout: oauthCallbackTimeout},
+		codes:      make(chan callbackResult),
+		codePrefix: "codex",
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/terminal/auth_commands.go
+++ b/internal/terminal/auth_commands.go
@@ -238,26 +238,14 @@ type oauthLoginConfig struct {
 	LoginFailed    string
 }
 
-func (app *App) startAnthropicClaudeLogin(_ context.Context) error {
-	if app.auth == nil {
-		return errors.New(authStorageUnavailableMessage)
-	}
-
-	flowURL, err := auth.AnthropicLoginURL()
-	if err != nil {
-		return terminalError(err, "build anthropic login url")
-	}
-
-	text := authInfoText("Claude", auth.OAuthAuthInfo{
-		URL: flowURL,
-		Instructions: "Complete login in your browser, then paste the authorization code with: /login " +
-			anthropicClaudeProviderID + " <code#state>",
+func (app *App) startAnthropicClaudeLogin(ctx context.Context) error {
+	return app.loginOAuthProvider(ctx, oauthLoginConfig{
+		Provider:       anthropicClaudeProviderID,
+		DisplayName:    "Claude",
+		AlreadyMessage: "Claude auth is already configured",
+		LoginFailed:    "Claude login failed: ",
+		LoginFunc:      auth.LoginAnthropic,
 	})
-	app.addMessage(transcript.RoleCustom, text)
-	app.resetPromptHistoryNavigation()
-	app.composerBuffer.SetText("/login " + anthropicClaudeProviderID + " ")
-
-	return nil
 }
 
 func (app *App) completeAnthropicClaudeLogin(ctx context.Context, code string) error {
@@ -296,9 +284,8 @@ func (app *App) loginOAuthProvider(ctx context.Context, config oauthLoginConfig)
 		return errors.New(authStorageUnavailableMessage)
 	}
 
-	if _, ok, err := app.auth.APIKeyContext(ctx, config.Provider); err != nil {
-		return terminalError(err, "save anthropic credential")
-	} else if ok {
+	_, ok, err := app.auth.APIKeyContext(ctx, config.Provider)
+	if oauthCredentialIsReady(ok, err) {
 		app.refreshModels()
 		app.setModel(config.Provider, model.DefaultModelPerProvider()[config.Provider])
 		app.addSystemMessage(config.AlreadyMessage)
@@ -313,6 +300,10 @@ func (app *App) loginOAuthProvider(ctx context.Context, config oauthLoginConfig)
 	go app.runOAuthLogin(ctx, config)
 
 	return nil
+}
+
+func oauthCredentialIsReady(found bool, err error) bool {
+	return err == nil && found
 }
 
 func (app *App) runOAuthLogin(ctx context.Context, config oauthLoginConfig) {

--- a/internal/terminal/auth_commands_internal_test.go
+++ b/internal/terminal/auth_commands_internal_test.go
@@ -98,6 +98,28 @@ func TestShowAuthInfoAndReloadRuntime(t *testing.T) {
 	assert.Contains(t, app.transcript.History[len(app.transcript.History)-1].Content, "reloaded auth and models")
 }
 
+func TestOAuthCredentialIsReady(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		err   error
+		name  string
+		found bool
+		want  bool
+	}{
+		{name: "valid credential", found: true, err: nil, want: true},
+		{name: "missing credential", found: false, err: nil, want: false},
+		{name: "expired refresh token", found: false, err: assert.AnError, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.want, oauthCredentialIsReady(test.found, test.err))
+		})
+	}
+}
+
 func TestRunOAuthLoginPostsDoneAndErrorEvents(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Start the localhost callback listener before opening the browser and allow re-authentication when stored credential refresh fails.