### PR TITLE
fix(terminal): refine workflow summary layout

### DIFF
--- a/internal/database/agent_task_repository.go
+++ b/internal/database/agent_task_repository.go
@@ -208,11 +208,14 @@ func (repository *AgentTaskRepository) Finish(
 	return changed, nil
 }
 
-const agentTaskColumns = `t.id, t.kind, t.parent_task_id, t.owner_session_id, t.concurrency_key,
+const (
+	scanAgentTaskMessage = "scan agent task"
+	agentTaskColumns     = `t.id, t.kind, t.parent_task_id, t.owner_session_id, t.concurrency_key,
        t.state, t.result, t.error_code, t.error_message, t.created_at, t.started_at,
        t.finished_at, t.updated_at, t.lease_owner, t.lease_expires_at,
        a.child_session_id, a.agent_name, a.prompt,
        a.model, a.provider, a.policy_json, a.usage_json, a.depth`
+)
 
 // Get loads an agent task and its generic lifecycle by task ID.
 func (repository *AgentTaskRepository) Get(ctx context.Context, taskID string) (*AgentTaskEntity, bool, error) {
@@ -230,7 +233,7 @@ FROM tasks t JOIN agent_tasks a ON a.task_id = t.id WHERE t.id = ? AND t.kind = 
 
 	entity, err := agentTaskFromRow(&row)
 	if err != nil {
-		return nil, false, oops.In("database").Code("scan_agent_task").Wrapf(err, "scan agent task")
+		return nil, false, oops.In("database").Code("scan_agent_task").Wrapf(err, scanAgentTaskMessage)
 	}
 
 	return entity, true, nil
@@ -258,7 +261,7 @@ ORDER BY t.updated_at DESC, t.id DESC LIMIT ?`
 
 	entities, err := collectSQLRows(rows, agentTaskFromRow)
 	if err != nil {
-		return nil, oops.In("database").Code("scan_agent_task").Wrapf(err, "scan agent task")
+		return nil, oops.In("database").Code("scan_agent_task").Wrapf(err, scanAgentTaskMessage)
 	}
 
 	return entities, nil
@@ -292,7 +295,7 @@ WHERE t.kind = ? AND t.id IN (` + placeholders + `)`
 
 	entities, err := collectSQLRows(rows, agentTaskFromRow)
 	if err != nil {
-		return nil, oops.In("database").Code("scan_agent_task").Wrapf(err, "scan agent task")
+		return nil, oops.In("database").Code("scan_agent_task").Wrapf(err, scanAgentTaskMessage)
 	}
 
 	return entities, nil

--- a/internal/database/agent_task_repository.go
+++ b/internal/database/agent_task_repository.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/samber/oops"
@@ -253,6 +254,40 @@ ORDER BY t.updated_at DESC, t.id DESC LIMIT ?`
 	rows := []agentTaskRow{}
 	if err := repository.sql.Query(ctx, &rows, query, TaskKindAgent, ownerSessionID, limit); err != nil {
 		return nil, oops.In("database").Code("list_agent_tasks").Wrapf(err, "list agent tasks")
+	}
+
+	entities, err := collectSQLRows(rows, agentTaskFromRow)
+	if err != nil {
+		return nil, oops.In("database").Code("scan_agent_task").Wrapf(err, "scan agent task")
+	}
+
+	return entities, nil
+}
+
+// ListByIDs returns complete agent tasks matching the supplied IDs.
+func (repository *AgentTaskRepository) ListByIDs(
+	ctx context.Context,
+	taskIDs []string,
+) ([]AgentTaskEntity, error) {
+	if len(taskIDs) == 0 {
+		return []AgentTaskEntity{}, nil
+	}
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(taskIDs)), ",")
+	query := `SELECT ` + agentTaskColumns + `
+FROM tasks t JOIN agent_tasks a ON a.task_id = t.id
+WHERE t.kind = ? AND t.id IN (` + placeholders + `)`
+
+	arguments := make([]any, 0, len(taskIDs)+1)
+	arguments = append(arguments, TaskKindAgent)
+
+	for _, taskID := range taskIDs {
+		arguments = append(arguments, taskID)
+	}
+
+	rows := []agentTaskRow{}
+	if err := repository.sql.Query(ctx, &rows, query, arguments...); err != nil {
+		return nil, oops.In("database").Code("list_agent_tasks_by_id").Wrapf(err, "list agent tasks by id")
 	}
 
 	entities, err := collectSQLRows(rows, agentTaskFromRow)

--- a/internal/database/workflow_repository.go
+++ b/internal/database/workflow_repository.go
@@ -37,6 +37,12 @@ type WorkflowAgentTaskEntity struct {
 	Sequence        int64
 }
 
+// WorkflowAgentTaskDetail combines a workflow link with its complete agent task.
+type WorkflowAgentTaskDetail struct {
+	AgentTask AgentTaskEntity
+	Link      WorkflowAgentTaskEntity
+}
+
 // WorkflowRepository persists workflow metadata and composes generic lifecycle operations.
 type WorkflowRepository struct {
 	sql        ksql.Provider
@@ -401,6 +407,64 @@ FROM workflow_agent_tasks WHERE workflow_task_id = ? ORDER BY sequence ASC`
 	}
 
 	return links, nil
+}
+
+// ListAgentTaskDetails loads linked agent tasks for multiple workflows with two bulk queries.
+func (repository *WorkflowRepository) ListAgentTaskDetails(
+	ctx context.Context,
+	workflowTaskIDs []string,
+) ([]WorkflowAgentTaskDetail, error) {
+	if len(workflowTaskIDs) == 0 {
+		return []WorkflowAgentTaskDetail{}, nil
+	}
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(workflowTaskIDs)), ",")
+	query := `SELECT workflow_task_id, agent_task_id, sequence, node_key, invocation_index, created_at
+FROM workflow_agent_tasks WHERE workflow_task_id IN (` + placeholders + `)
+ORDER BY workflow_task_id ASC, sequence ASC`
+
+	arguments := make([]any, len(workflowTaskIDs))
+	for index, workflowTaskID := range workflowTaskIDs {
+		arguments[index] = workflowTaskID
+	}
+
+	rows := []workflowAgentTaskRow{}
+	if err := repository.sql.Query(ctx, &rows, query, arguments...); err != nil {
+		return nil, oops.In("database").Code("list_workflow_agent_task_details").
+			Wrapf(err, "list workflow agent task details")
+	}
+
+	links, err := collectSQLRows(rows, workflowAgentTaskFromRow)
+	if err != nil {
+		return nil, oops.In("database").Code("scan_workflow_agent_task").Wrapf(err, "scan workflow agent task")
+	}
+
+	taskIDs := make([]string, len(links))
+	for index := range links {
+		taskIDs[index] = links[index].AgentTaskID
+	}
+
+	tasks, err := repository.agentTasks.ListByIDs(ctx, taskIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	tasksByID := make(map[string]AgentTaskEntity, len(tasks))
+	for index := range tasks {
+		tasksByID[tasks[index].Task.ID] = tasks[index]
+	}
+
+	details := make([]WorkflowAgentTaskDetail, 0, len(links))
+	for index := range links {
+		task, found := tasksByID[links[index].AgentTaskID]
+		if !found {
+			continue
+		}
+
+		details = append(details, WorkflowAgentTaskDetail{AgentTask: task, Link: links[index]})
+	}
+
+	return details, nil
 }
 
 const workflowRunColumns = `t.id, t.kind, t.parent_task_id, t.owner_session_id, t.concurrency_key,

--- a/internal/database/workflow_repository_test.go
+++ b/internal/database/workflow_repository_test.go
@@ -78,6 +78,54 @@ func TestWorkflowRepositoryLifecycleAndAgentLinks(t *testing.T) {
 	assert.Len(t, events, 3)
 }
 
+func TestWorkflowRepositoryListAgentTaskDetails(t *testing.T) {
+	t.Parallel()
+
+	fixture := newTaskTestFixture(t)
+	ctx := t.Context()
+	owner, firstChild := fixture.createAgentTaskSessions(ctx)
+	secondChild, err := fixture.sessions.CreateSession(ctx, owner.CWD, "second", owner.ID)
+	require.NoError(t, err)
+
+	firstRun, err := fixture.workflows.Create(ctx, newWorkflowRun(owner.ID))
+	require.NoError(t, err)
+	secondRun, err := fixture.workflows.Create(ctx, newWorkflowRun(owner.ID))
+	require.NoError(t, err)
+
+	for index, creation := range []struct {
+		run   *database.WorkflowRunEntity
+		child string
+		node  string
+	}{
+		{run: firstRun, child: firstChild.ID, node: "inspect"},
+		{run: secondRun, child: secondChild.ID, node: "review"},
+	} {
+		task := newAgentTask(owner.ID, creation.child)
+		task.Task.ParentTaskID = creation.run.Task.ID
+		created, createErr := fixture.workflows.CreateAgentTask(ctx, creation.run.Task.ID, task, creation.node, index)
+		require.NoError(t, createErr)
+		assert.NotEmpty(t, created.Task.ID)
+	}
+
+	details, err := fixture.workflows.ListAgentTaskDetails(ctx, []string{firstRun.Task.ID, secondRun.Task.ID})
+	require.NoError(t, err)
+	require.Len(t, details, 2)
+
+	nodesByRun := map[string]string{}
+	for index := range details {
+		nodesByRun[details[index].Link.WorkflowTaskID] = details[index].Link.NodeKey
+	}
+
+	assert.Equal(t, map[string]string{
+		firstRun.Task.ID:  "inspect",
+		secondRun.Task.ID: "review",
+	}, nodesByRun)
+
+	empty, err := fixture.workflows.ListAgentTaskDetails(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+}
+
 func TestWorkflowRepositoryCreateAgentTaskAtomicallyLinks(t *testing.T) {
 	t.Parallel()
 

--- a/internal/database/workflow_repository_test.go
+++ b/internal/database/workflow_repository_test.go
@@ -81,49 +81,77 @@ func TestWorkflowRepositoryLifecycleAndAgentLinks(t *testing.T) {
 func TestWorkflowRepositoryListAgentTaskDetails(t *testing.T) {
 	t.Parallel()
 
-	fixture := newTaskTestFixture(t)
-	ctx := t.Context()
-	owner, firstChild := fixture.createAgentTaskSessions(ctx)
-	secondChild, err := fixture.sessions.CreateSession(ctx, owner.CWD, "second", owner.ID)
-	require.NoError(t, err)
-
-	firstRun, err := fixture.workflows.Create(ctx, newWorkflowRun(owner.ID))
-	require.NoError(t, err)
-	secondRun, err := fixture.workflows.Create(ctx, newWorkflowRun(owner.ID))
-	require.NoError(t, err)
-
-	for index, creation := range []struct {
-		run   *database.WorkflowRunEntity
-		child string
-		node  string
+	tests := []struct {
+		name      string
+		populated bool
 	}{
-		{run: firstRun, child: firstChild.ID, node: "inspect"},
-		{run: secondRun, child: secondChild.ID, node: "review"},
-	} {
-		task := newAgentTask(owner.ID, creation.child)
-		task.Task.ParentTaskID = creation.run.Task.ID
-		created, createErr := fixture.workflows.CreateAgentTask(ctx, creation.run.Task.ID, task, creation.node, index)
-		require.NoError(t, createErr)
-		assert.NotEmpty(t, created.Task.ID)
+		{name: "populated", populated: true},
+		{name: "nil run IDs", populated: false},
 	}
 
-	details, err := fixture.workflows.ListAgentTaskDetails(ctx, []string{firstRun.Task.ID, secondRun.Task.ID})
-	require.NoError(t, err)
-	require.Len(t, details, 2)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-	nodesByRun := map[string]string{}
-	for index := range details {
-		nodesByRun[details[index].Link.WorkflowTaskID] = details[index].Link.NodeKey
+			fixture := newTaskTestFixture(t)
+			ctx := t.Context()
+
+			if !test.populated {
+				details, err := fixture.workflows.ListAgentTaskDetails(ctx, nil)
+				require.NoError(t, err)
+				assert.Empty(t, details)
+
+				return
+			}
+
+			owner, firstChild := fixture.createAgentTaskSessions(ctx)
+			secondChild, err := fixture.sessions.CreateSession(ctx, owner.CWD, "second", owner.ID)
+			require.NoError(t, err)
+
+			firstRun, err := fixture.workflows.Create(ctx, newWorkflowRun(owner.ID))
+			require.NoError(t, err)
+			secondRun, err := fixture.workflows.Create(ctx, newWorkflowRun(owner.ID))
+			require.NoError(t, err)
+
+			for index, creation := range []struct {
+				run   *database.WorkflowRunEntity
+				child string
+				node  string
+			}{
+				{run: firstRun, child: firstChild.ID, node: "inspect"},
+				{run: secondRun, child: secondChild.ID, node: "review"},
+			} {
+				task := newAgentTask(owner.ID, creation.child)
+				task.Task.ParentTaskID = creation.run.Task.ID
+				created, createErr := fixture.workflows.CreateAgentTask(
+					ctx,
+					creation.run.Task.ID,
+					task,
+					creation.node,
+					index,
+				)
+				require.NoError(t, createErr)
+				assert.NotEmpty(t, created.Task.ID)
+			}
+
+			details, err := fixture.workflows.ListAgentTaskDetails(
+				ctx,
+				[]string{firstRun.Task.ID, secondRun.Task.ID},
+			)
+			require.NoError(t, err)
+			require.Len(t, details, 2)
+
+			nodesByRun := map[string]string{}
+			for index := range details {
+				nodesByRun[details[index].Link.WorkflowTaskID] = details[index].Link.NodeKey
+			}
+
+			assert.Equal(t, map[string]string{
+				firstRun.Task.ID:  "inspect",
+				secondRun.Task.ID: "review",
+			}, nodesByRun)
+		})
 	}
-
-	assert.Equal(t, map[string]string{
-		firstRun.Task.ID:  "inspect",
-		secondRun.Task.ID: "review",
-	}, nodesByRun)
-
-	empty, err := fixture.workflows.ListAgentTaskDetails(ctx, nil)
-	require.NoError(t, err)
-	assert.Empty(t, empty)
 }
 
 func TestWorkflowRepositoryCreateAgentTaskAtomicallyLinks(t *testing.T) {

--- a/internal/terminal/agent_task_summary.go
+++ b/internal/terminal/agent_task_summary.go
@@ -35,11 +35,25 @@ func (app *App) handleAgentTaskSummaryPriorityKey(
 	ctx context.Context,
 	event *tcell.EventKey,
 ) (bool, error) {
+	if app.workflowSummaryRunID != "" && app.agentTaskSummaryFocused() &&
+		app.keys.matches(event, actionSelectCancel) {
+		app.workflowSummaryRunID = ""
+		app.agentTaskSummarySelection.ItemIndex = 0
+
+		return true, nil
+	}
+
 	if app.agentTaskSummaryFocused() && app.keys.matches(event, actionSelectConfirm) {
+		index := app.agentTaskSummarySelection.ItemIndex
+		if index < len(app.activeWorkflows) {
+			app.workflowSummaryRunID = app.activeWorkflows[index].Task.ID
+			app.agentTaskSummarySelection.ItemIndex = 0
+
+			return true, nil
+		}
+
 		taskID, ok := app.selectedAgentTaskSummaryTaskID()
 		if !ok {
-			app.setStatus("workflow inspection is not available")
-
 			return true, nil
 		}
 
@@ -99,6 +113,10 @@ func (app *App) selectedAgentTaskSummaryTaskID() (string, bool) {
 }
 
 func (app *App) agentTaskSummaryItemCount() int {
+	if app.workflowSummaryRunID != "" {
+		return 1
+	}
+
 	count := len(app.activeWorkflows)
 	for index := range app.agentTasks {
 		if app.agentTasks[index].Task.ParentTaskID == "" {

--- a/internal/terminal/agent_task_summary.go
+++ b/internal/terminal/agent_task_summary.go
@@ -44,6 +44,10 @@ func (app *App) handleAgentTaskSummaryPriorityKey(
 	}
 
 	if app.agentTaskSummaryFocused() && app.keys.matches(event, actionSelectConfirm) {
+		if app.workflowSummaryRunID != "" {
+			return true, nil
+		}
+
 		index := app.agentTaskSummarySelection.ItemIndex
 		if index < len(app.activeWorkflows) {
 			app.workflowSummaryRunID = app.activeWorkflows[index].Task.ID

--- a/internal/terminal/agent_tasks.go
+++ b/internal/terminal/agent_tasks.go
@@ -111,6 +111,9 @@ func (app *App) resetAgentTaskTracking() {
 	app.stopAgentTaskWatches()
 	app.agentTasks = nil
 	app.activeWorkflows = nil
+	app.workflowProgress = map[string]workflowProgress{}
+	app.workflowSteps = map[string][]database.WorkflowAgentTaskDetail{}
+	app.workflowSummaryRunID = ""
 	app.agentTaskSummaryOwnerID = ""
 	app.agentTasksRefreshedAt = time.Time{}
 	app.deliveredAgentTasks = map[string]struct{}{}
@@ -161,7 +164,28 @@ func (app *App) refreshActiveWorkflows(ctx context.Context) {
 		listed[runs[index].Task.ID] = runs[index]
 	}
 
-	active := make([]database.WorkflowRunEntity, 0, len(runs))
+	active := app.reconcileTrackedWorkflows(ctx, listed, len(runs))
+	for index := range runs {
+		run, found := listed[runs[index].Task.ID]
+		if found && !isTerminalAgentTaskState(run.Task.State) {
+			active = append(active, run)
+		}
+	}
+
+	app.activeWorkflows = active
+	if !app.hasActiveWorkflow(app.workflowSummaryRunID) {
+		app.workflowSummaryRunID = ""
+	}
+
+	app.refreshWorkflowSummaryDetails(ctx)
+}
+
+func (app *App) reconcileTrackedWorkflows(
+	ctx context.Context,
+	listed map[string]database.WorkflowRunEntity,
+	capacity int,
+) []database.WorkflowRunEntity {
+	active := make([]database.WorkflowRunEntity, 0, capacity)
 
 	for index := range app.activeWorkflows {
 		previous := app.activeWorkflows[index]
@@ -182,14 +206,36 @@ func (app *App) refreshActiveWorkflows(ctx context.Context) {
 		active = append(active, latest)
 	}
 
-	for index := range runs {
-		run, found := listed[runs[index].Task.ID]
-		if found && !isTerminalAgentTaskState(run.Task.State) {
-			active = append(active, run)
+	return active
+}
+
+func (app *App) hasActiveWorkflow(runID string) bool {
+	if runID == "" {
+		return false
+	}
+
+	for index := range app.activeWorkflows {
+		if app.activeWorkflows[index].Task.ID == runID {
+			return true
 		}
 	}
 
-	app.activeWorkflows = active
+	return false
+}
+
+func (app *App) refreshWorkflowSummaryDetails(ctx context.Context) {
+	runIDs := make([]string, len(app.activeWorkflows))
+	for index := range app.activeWorkflows {
+		runIDs[index] = app.activeWorkflows[index].Task.ID
+	}
+
+	details, err := app.loadWorkflowDetails(ctx, runIDs)
+	if err != nil {
+		return
+	}
+
+	app.workflowProgress = details.ProgressByRun
+	app.workflowSteps = details.StepsByRun
 }
 
 func (app *App) reconcileActiveWorkflow(
@@ -1072,6 +1118,13 @@ func isTerminalAgentTaskState(state database.TaskState) bool {
 	}
 }
 
+const (
+	workflowStepMinimumWidth = 8
+	workflowStatusWidth      = 12
+	workflowTableFixedWidth  = 24
+	workflowDetailFixedRows  = 3
+)
+
 func (app *App) renderAgentTaskSummary(width int) []tui.Line {
 	if len(app.agentTasks) == 0 && len(app.activeWorkflows) == 0 {
 		return nil
@@ -1079,20 +1132,34 @@ func (app *App) renderAgentTaskSummary(width int) []tui.Line {
 
 	indicatorStyle := tcell.StyleDefault.Foreground(defaultWorkingShimmerBrightColor()).Bold(true)
 	labelStyle := tcell.StyleDefault.Foreground(app.theme.colors[colorMuted])
+	headerStyle := tcell.StyleDefault.Foreground(app.theme.colors[colorDim]).Bold(true)
 
 	lines := make([]tui.Line, 0, len(app.activeWorkflows)+len(app.agentTasks)+1)
 	selectedIndex := app.selectedAgentTaskSummaryIndex()
+	selectableIndex := 0
+
+	if run := app.expandedWorkflowSummaryRun(); run != nil {
+		lines = app.renderWorkflowSummaryDetail(run, width, labelStyle, headerStyle, selectedIndex == 0)
+
+		return padAgentTaskSummary(lines, app.agentTaskSummaryHeight())
+	}
 
 	for index := range app.activeWorkflows {
-		label := workflowSummaryLabel(&app.activeWorkflows[index])
+		run := &app.activeWorkflows[index]
+		label := app.workflowSummaryLabel(run)
 		line := tui.Line{
-			Text: pendingToolIndicator + " " + label, Style: labelStyle,
+			Text:  pendingToolIndicator + " " + label,
+			Style: labelStyle,
 			Spans: []tui.Span{
 				{Text: pendingToolIndicator, Style: indicatorStyle},
 				{Text: " " + label, Style: labelStyle},
 			},
 		}
-		lines = append(lines, app.styleAgentTaskSummaryLine(line, width, len(lines) == selectedIndex))
+		lines = append(
+			lines,
+			app.styleAgentTaskSummaryLine(line, width, selectableIndex == selectedIndex),
+		)
+		selectableIndex++
 	}
 
 	for index := range app.agentTasks {
@@ -1110,7 +1177,11 @@ func (app *App) renderAgentTaskSummary(width int) []tui.Line {
 				{Text: " " + label, Style: labelStyle},
 			},
 		}
-		lines = append(lines, app.styleAgentTaskSummaryLine(line, width, len(lines) == selectedIndex))
+		lines = append(
+			lines,
+			app.styleAgentTaskSummaryLine(line, width, selectableIndex == selectedIndex),
+		)
+		selectableIndex++
 	}
 
 	if len(lines) == 0 {
@@ -1119,7 +1190,88 @@ func (app *App) renderAgentTaskSummary(width int) []tui.Line {
 
 	lines = append(lines, tui.NewLine(tcell.StyleDefault, ""))
 
+	return padAgentTaskSummary(lines, app.agentTaskSummaryHeight())
+}
+
+func (app *App) agentTaskSummaryHeight() int {
+	collapsedHeight := len(app.activeWorkflows) + 1
+	for index := range app.agentTasks {
+		if app.agentTasks[index].Task.ParentTaskID == "" {
+			collapsedHeight++
+		}
+	}
+
+	if app.workflowSummaryRunID == "" {
+		return collapsedHeight
+	}
+
+	reservedHeight := collapsedHeight
+
+	for index := range app.activeWorkflows {
+		stepRows := max(1, len(app.workflowSteps[app.activeWorkflows[index].Task.ID]))
+		reservedHeight = max(reservedHeight, stepRows+workflowDetailFixedRows)
+	}
+
+	return reservedHeight
+}
+
+func padAgentTaskSummary(lines []tui.Line, height int) []tui.Line {
+	padding := height - len(lines)
+	if padding <= 0 {
+		return lines
+	}
+
+	for range padding {
+		lines = append(lines, tui.NewLine(tcell.StyleDefault, ""))
+	}
+
 	return lines
+}
+
+func (app *App) expandedWorkflowSummaryRun() *database.WorkflowRunEntity {
+	for index := range app.activeWorkflows {
+		if app.activeWorkflows[index].Task.ID == app.workflowSummaryRunID {
+			return &app.activeWorkflows[index]
+		}
+	}
+
+	return nil
+}
+
+func (app *App) renderWorkflowSummaryDetail(
+	run *database.WorkflowRunEntity,
+	width int,
+	labelStyle tcell.Style,
+	headerStyle tcell.Style,
+	selected bool,
+) []tui.Line {
+	lines := make([]tui.Line, 0, len(app.workflowSteps[run.Task.ID])+workflowDetailFixedRows)
+	heading := tui.NewLine(labelStyle, "Workflow: "+app.workflowSummaryLabel(run))
+	lines = append(lines, app.styleAgentTaskSummaryLine(heading, width, selected))
+
+	stepWidth := max(workflowStepMinimumWidth, width-workflowTableFixedWidth)
+	header := tui.PadRight("STEP", stepWidth) + "  " +
+		tui.PadRight("STATUS", workflowStatusWidth) + "  ELAPSED"
+	lines = append(lines, tui.NewLine(headerStyle, tui.Truncate(header, width)))
+
+	steps := app.workflowSteps[run.Task.ID]
+	if len(steps) == 0 {
+		row := workflowStepRow("workflow", run.Task.State, taskMeta(&run.Task, time.Now()), stepWidth)
+		lines = append(lines, tui.NewLine(labelStyle, tui.Truncate(row, width)))
+	} else {
+		for index := range steps {
+			detail := &steps[index]
+			row := workflowStepRow(
+				workflowStepName(&detail.Link),
+				detail.AgentTask.Task.State,
+				taskMeta(&detail.AgentTask.Task, time.Now()),
+				stepWidth,
+			)
+			lines = append(lines, tui.NewLine(labelStyle, tui.Truncate(row, width)))
+		}
+	}
+
+	return append(lines, tui.NewLine(tcell.StyleDefault, ""))
 }
 
 func (app *App) selectedAgentTaskSummaryIndex() int {
@@ -1139,17 +1291,39 @@ func (app *App) styleAgentTaskSummaryLine(line tui.Line, width int, selected boo
 	return line
 }
 
-func workflowSummaryLabel(run *database.WorkflowRunEntity) string {
+func workflowStepName(link *database.WorkflowAgentTaskEntity) string {
+	name := strings.TrimSpace(link.NodeKey)
+	if name == "" {
+		name = "agent"
+	}
+
+	return fmt.Sprintf("%s[%d]", name, link.InvocationIndex)
+}
+
+func workflowStepRow(name string, state database.TaskState, elapsed string, stepWidth int) string {
+	return tui.PadRight(tui.Truncate(name, stepWidth), stepWidth) + "  " +
+		tui.PadRight(string(state), workflowStatusWidth) + "  " + elapsed
+}
+
+func (app *App) workflowSummaryLabel(run *database.WorkflowRunEntity) string {
 	if run == nil {
 		return toolDisplayWorkflow
 	}
 
-	name := strings.Join(strings.Fields(run.Name), " ")
-	if name == "" {
-		return toolDisplayWorkflow
+	label := toolDisplayWorkflow + "(" + workflowName(run) + ")"
+
+	progress, ok := app.workflowProgress[run.Task.ID]
+	if !ok || progress.Total == 0 {
+		return label
 	}
 
-	return toolDisplayWorkflow + "(" + name + ")"
+	return fmt.Sprintf(
+		"%s  %d/%d agents · %s",
+		label,
+		progress.Succeeded+progress.Failed,
+		progress.Total,
+		taskMeta(&run.Task, time.Now()),
+	)
 }
 
 func agentTaskSummaryLabel(task *database.AgentTaskEntity) string {

--- a/internal/terminal/agent_tasks_behavior_internal_test.go
+++ b/internal/terminal/agent_tasks_behavior_internal_test.go
@@ -308,7 +308,9 @@ func TestWorkflowChildAgentTasksAreHiddenAndNotDelivered(t *testing.T) {
 	}
 	lines := app.renderAgentTaskSummary(80)
 	require.Len(t, lines, 2)
-	assert.Equal(t, "◌ workflow(active review)", lines[0].Text)
+	assert.Equal(t, pendingToolIndicator+" "+app.workflowSummaryLabel(&app.activeWorkflows[0]), lines[0].Text)
+	assert.NotContains(t, lines[0].Text, "STEP")
+	assert.NotContains(t, lines[0].Text, "STATUS")
 	assert.True(t, app.hasRunningAgentTasks())
 
 	app.trackStartedAgentTask(t.Context(), agentToolEvent("", `{"task_id":"workflow-child"}`, false))
@@ -1006,7 +1008,7 @@ func TestInspectAgentTaskLookupFailureDoesNotMutateState(t *testing.T) {
 			mutate: func(task *database.AgentTaskEntity) {
 				task.Task.ID = "missing-task"
 			},
-			wantErr: "not found",
+			wantErr: workflowNotFound,
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -1205,7 +1207,7 @@ func TestAgentTaskPanelRejectsTaskOwnedByAnotherSession(t *testing.T) {
 	handled, err := app.handleAgentTasksPanelKey(t.Context(), tcell.NewEventKey(tcell.KeyCtrlC, "", tcell.ModNone))
 	assert.True(t, handled)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), workflowNotFound)
 	assert.Empty(t, stub.cancelCalls)
 }
 

--- a/internal/terminal/app.go
+++ b/internal/terminal/app.go
@@ -25,6 +25,11 @@ import (
 type workflowInspector interface {
 	Get(context.Context, string) (*database.WorkflowRunEntity, bool, error)
 	List(context.Context, string, int) ([]database.WorkflowRunEntity, error)
+	Events(context.Context, string, int64, int) ([]database.TaskEventEntity, error)
+	AgentTasks(context.Context, string) ([]database.WorkflowAgentTaskEntity, error)
+	AgentTask(context.Context, string) (*database.AgentTaskEntity, bool, error)
+	AgentTaskDetails(context.Context, []string) ([]database.WorkflowAgentTaskDetail, error)
+	Cancel(context.Context, string, string) (bool, error)
 }
 
 const (
@@ -168,6 +173,10 @@ type App struct {
 	liveAgentCompletions      []chatMessage
 	agentTasks                []database.AgentTaskEntity
 	activeWorkflows           []database.WorkflowRunEntity
+	workflowProgress          map[string]workflowProgress
+	workflowSteps             map[string][]database.WorkflowAgentTaskDetail
+	workflowSummaryRunID      string
+	workflowPanelRunID        string
 	agentTasksRefreshedAt     time.Time
 	agentTaskWatches          map[string]context.CancelFunc
 	deliveredAgentTasks       map[string]struct{}
@@ -275,6 +284,10 @@ func newApp(screen terminalScreen, options *RunOptions) *App {
 		liveAgentCompletions:      []chatMessage{},
 		agentTasks:                []database.AgentTaskEntity{},
 		activeWorkflows:           []database.WorkflowRunEntity{},
+		workflowProgress:          map[string]workflowProgress{},
+		workflowSteps:             map[string][]database.WorkflowAgentTaskDetail{},
+		workflowSummaryRunID:      "",
+		workflowPanelRunID:        "",
 		agentTaskSummaryOwnerID:   "",
 		agentTasksRefreshedAt:     time.Time{},
 		agentTaskWatches:          map[string]context.CancelFunc{},
@@ -412,6 +425,7 @@ func (app *App) runLoopStep(
 		if time.Since(app.agentTasksRefreshedAt) >= agentTaskRefreshInterval {
 			app.refreshVisibleAgentTasks(ctx)
 			app.refreshAgentTasksPanel(ctx)
+			app.refreshWorkflowsPanel(ctx)
 		}
 
 		app.emitExtensionRuntimeEventOrMessage(ctx, extensionEventTick, map[string]any{})
@@ -521,7 +535,8 @@ func (app *App) coalesceResizeEvents(resize *tcell.EventResize) resizeCoalescedE
 }
 
 func (app *App) workTick(ticker *time.Ticker) <-chan time.Time {
-	if app.busy() || app.hasRunningAgentTasks() || app.selectedPanelKind == panelAgentTasks {
+	if app.busy() || app.hasRunningAgentTasks() ||
+		app.selectedPanelKind == panelAgentTasks || app.selectedPanelKind == panelWorkflows {
 		return ticker.C
 	}
 

--- a/internal/terminal/autocomplete.go
+++ b/internal/terminal/autocomplete.go
@@ -37,6 +37,7 @@ func slashSuggestions() []tui.ListItem {
 		autocompleteSuggestion("skill", "list or load an Agent Skill"),
 		autocompleteSuggestion(toolSectionTool, "run a built-in tool with JSON arguments"),
 		autocompleteSuggestion("tree", "open session tree"),
+		autocompleteSuggestion("workflows", "open dynamic workflows"),
 	}
 }
 

--- a/internal/terminal/autocomplete_internal_test.go
+++ b/internal/terminal/autocomplete_internal_test.go
@@ -20,7 +20,7 @@ func TestSlashSuggestionsOnlyIncludesImplementedCommands(t *testing.T) {
 	}
 
 	assert.Contains(t, names, "skill")
-	assert.NotContains(t, names, "workflows")
+	assert.Contains(t, names, "workflows")
 	assert.NotContains(t, names, "export")
 	assert.NotContains(t, names, "import")
 	assert.NotContains(t, names, "share")

--- a/internal/terminal/commands.go
+++ b/internal/terminal/commands.go
@@ -59,6 +59,12 @@ func (app *App) runSessionCommand(ctx context.Context, command, args, original s
 		return false, handler()
 	}
 
+	if command == "workflows" {
+		app.openWorkflowsPanel(ctx)
+
+		return false, nil
+	}
+
 	if command == "agents" {
 		switch args {
 		case "profiles":

--- a/internal/terminal/input.go
+++ b/internal/terminal/input.go
@@ -270,6 +270,12 @@ func (app *App) composerShortcut(action actionID, handler func()) shortcutHandle
 
 func (app *App) handlePanelKey(ctx context.Context, event *tcell.EventKey) error {
 	if event.Key() == tcell.KeyEscape {
+		if app.selectedPanelKind == panelWorkflows && app.workflowPanelRunID != "" {
+			app.openWorkflowsPanel(ctx)
+
+			return nil
+		}
+
 		app.closePanel()
 
 		return nil
@@ -301,6 +307,8 @@ func (app *App) handleSpecialPanelKey(ctx context.Context, event *tcell.EventKey
 		return app.handleScopedModelKey(event), nil
 	case panelAgentTasks:
 		return app.handleAgentTasksPanelKey(ctx, event)
+	case panelWorkflows:
+		return app.handleWorkflowsPanelKey(ctx, event)
 	case panelModel, panelAuthLogin, panelAuthLogout, panelSettings,
 		panelHotkeys, panelChangelog, panelTree:
 		return false, nil

--- a/internal/terminal/panel_actions.go
+++ b/internal/terminal/panel_actions.go
@@ -22,6 +22,14 @@ func (app *App) openPanel(panelModel *panel.Model) {
 }
 
 func (app *App) applyPanelSelection(ctx context.Context, value string) error {
+	if app.selectedPanelKind == panelWorkflows {
+		return app.applyWorkflowSelection(ctx, value)
+	}
+
+	return app.applyStandardPanelSelection(ctx, value)
+}
+
+func (app *App) applyStandardPanelSelection(ctx context.Context, value string) error {
 	switch app.selectedPanelKind {
 	case panelAuthLogin, panelAuthLogout:
 		return app.applyAuthSelection(ctx, value)

--- a/internal/terminal/transcript_list_internal_test.go
+++ b/internal/terminal/transcript_list_internal_test.go
@@ -48,7 +48,7 @@ func TestAgentTaskSummaryEnterOnWorkflowExpandsInline(t *testing.T) {
 	app := newRenderTestApp(t)
 	app.sessionID = workflowTestSessionID
 	app.workflows = &workflowInspectorStub{
-		listErr: nil, getErr: nil, eventsErr: nil, agentTasksErr: nil,
+		listErr: nil, getErr: nil, eventsErr: nil, agentTasksErr: nil, detailsErr: nil,
 		getRun: &run, runs: nil, events: nil, children: nil, details: nil, found: true,
 	}
 	app.activeWorkflows = []database.WorkflowRunEntity{run}
@@ -89,6 +89,22 @@ func TestAgentTaskSummaryEnterOnWorkflowExpandsInline(t *testing.T) {
 	require.Len(t, lines, 3)
 	assert.Equal(t, pendingToolIndicator+" "+app.workflowSummaryLabel(&app.activeWorkflows[0]), lines[0].Text)
 	assert.NotContains(t, lines[0].Text, "STEP")
+}
+
+func TestAgentTaskSummaryConfirmKeepsExpandedWorkflow(t *testing.T) {
+	t.Parallel()
+
+	first := workflowSummaryRun("first", database.TaskRunning)
+	second := workflowSummaryRun("second", database.TaskRunning)
+	app := newRenderTestApp(t)
+	app.activeWorkflows = []database.WorkflowRunEntity{first, second}
+	app.agentTaskSummarySelection = agentTaskSummarySelection{ItemIndex: 0, Active: true}
+	app.workflowSummaryRunID = second.Task.ID
+
+	pressTerminalKey(t, app, tcell.KeyEnter, "")
+
+	assert.Equal(t, second.Task.ID, app.workflowSummaryRunID)
+	assert.True(t, app.agentTaskSummaryFocused())
 }
 
 func TestValidateAgentTaskSummarySelectionClampsNegativeIndex(t *testing.T) {

--- a/internal/terminal/transcript_list_internal_test.go
+++ b/internal/terminal/transcript_list_internal_test.go
@@ -41,18 +41,54 @@ func TestTabFocusesAgentTaskSummaryBeforeTranscriptList(t *testing.T) {
 	assert.Equal(t, focusKindComposer, app.focusState().Kind)
 }
 
-func TestAgentTaskSummaryEnterOnWorkflowDoesNotInspectAgent(t *testing.T) {
+func TestAgentTaskSummaryEnterOnWorkflowExpandsInline(t *testing.T) {
 	t.Parallel()
 
+	run := workflowSummaryRun(toolDisplayWorkflow, database.TaskRunning)
 	app := newRenderTestApp(t)
-	app.activeWorkflows = []database.WorkflowRunEntity{workflowSummaryRun(toolDisplayWorkflow, database.TaskRunning)}
+	app.sessionID = workflowTestSessionID
+	app.workflows = &workflowInspectorStub{
+		listErr: nil, getErr: nil, eventsErr: nil, agentTasksErr: nil,
+		getRun: &run, runs: nil, events: nil, children: nil, details: nil, found: true,
+	}
+	app.activeWorkflows = []database.WorkflowRunEntity{run}
 	app.agentTasks = []database.AgentTaskEntity{behaviorAgentTask("top-level", database.TaskRunning)}
+	transcriptBefore := app.transcript
 
 	pressTerminalKey(t, app, tcell.KeyTab, "")
+	collapsedLayout := app.defaultRuntimeLayout(80, 24)
+	collapsedLines := app.renderAgentTaskSummary(80)
+	require.Len(t, collapsedLines, 3)
+	assert.Equal(t, pendingToolIndicator+" "+app.workflowSummaryLabel(&app.activeWorkflows[0]), collapsedLines[0].Text)
+	assert.Empty(t, collapsedLines[2].Text)
 	pressTerminalKey(t, app, tcell.KeyEnter, "")
 
 	assert.True(t, app.agentTaskSummaryFocused())
-	assert.Equal(t, "workflow inspection is not available", app.statusMessage)
+	assert.Equal(t, modeChat, app.mode)
+	assert.Equal(t, run.Task.ID, app.workflowSummaryRunID)
+	assert.Empty(t, app.workflowPanelRunID)
+	assert.Nil(t, app.panel)
+	assert.Equal(t, transcriptBefore, app.transcript)
+
+	lines := app.renderAgentTaskSummary(80)
+	require.Len(t, lines, 4)
+	assert.Contains(t, lines[0].Text, "Workflow:")
+	assert.Contains(t, lines[1].Text, "STEP")
+
+	expandedLayout := app.defaultRuntimeLayout(80, 24)
+	assert.NotEqual(t, collapsedLayout.Transcript, expandedLayout.Transcript)
+	assert.NotEqual(t, collapsedLayout.Composer, expandedLayout.Composer)
+	assert.NotEqual(t, collapsedLayout.Status, expandedLayout.Status)
+
+	pressTerminalKey(t, app, tcell.KeyEscape, "")
+	assert.Empty(t, app.workflowSummaryRunID)
+	assert.True(t, app.agentTaskSummaryFocused())
+	assert.Equal(t, transcriptBefore, app.transcript)
+
+	lines = app.renderAgentTaskSummary(80)
+	require.Len(t, lines, 3)
+	assert.Equal(t, pendingToolIndicator+" "+app.workflowSummaryLabel(&app.activeWorkflows[0]), lines[0].Text)
+	assert.NotContains(t, lines[0].Text, "STEP")
 }
 
 func TestValidateAgentTaskSummarySelectionClampsNegativeIndex(t *testing.T) {

--- a/internal/terminal/workflow_summary_internal_test.go
+++ b/internal/terminal/workflow_summary_internal_test.go
@@ -44,21 +44,64 @@ func (stub *activeWorkflowInspectorStub) AgentTasks(
 	return nil, nil
 }
 
+func (stub *activeWorkflowInspectorStub) AgentTask(
+	context.Context, string,
+) (*database.AgentTaskEntity, bool, error) {
+	return nil, false, nil
+}
+
+func (stub *activeWorkflowInspectorStub) AgentTaskDetails(
+	context.Context, []string,
+) ([]database.WorkflowAgentTaskDetail, error) {
+	return nil, nil
+}
+
+func (stub *activeWorkflowInspectorStub) Cancel(context.Context, string, string) (bool, error) {
+	return true, nil
+}
+
 func TestActiveWorkflowAppearsInAgentSummary(t *testing.T) {
 	t.Parallel()
 
+	running := workflowSummaryRun("active", database.TaskRunning)
+	child := testAgentTask(database.TaskRunning)
+	child.Task.ID = "reviewer-1"
 	app := newRenderTestApp(t)
 	app.sessionID = workflowTestSessionID
-	app.workflows = &activeWorkflowInspectorStub{byID: nil, runs: []database.WorkflowRunEntity{
-		workflowSummaryRun("active", database.TaskRunning),
-		workflowSummaryRun(statusDone, database.TaskSucceeded),
-	}}
+	app.workflows = &workflowInspectorStub{
+		listErr: nil, getErr: nil, eventsErr: nil, agentTasksErr: nil,
+		getRun: nil,
+		runs: []database.WorkflowRunEntity{
+			running,
+			workflowSummaryRun(statusDone, database.TaskSucceeded),
+		},
+		events: nil, children: nil,
+		details: []database.WorkflowAgentTaskDetail{{
+			AgentTask: child,
+			Link: database.WorkflowAgentTaskEntity{
+				CreatedAt: time.Time{}, WorkflowTaskID: running.Task.ID,
+				AgentTaskID: child.Task.ID, NodeKey: "review", InvocationIndex: 0, Sequence: 1,
+			},
+		}},
+		found: false,
+	}
 
 	app.refreshActiveWorkflows(t.Context())
 	require.Len(t, app.activeWorkflows, 1)
 	lines := app.renderAgentTaskSummary(80)
-	require.NotEmpty(t, lines)
-	assert.Contains(t, lines[0].Text, "workflow(active review)")
+	require.Len(t, lines, 2)
+	assert.Equal(t, pendingToolIndicator+" "+app.workflowSummaryLabel(&app.activeWorkflows[0]), lines[0].Text)
+	assert.NotContains(t, lines[0].Text, "STEP")
+	assert.Empty(t, lines[1].Text)
+
+	app.workflowSummaryRunID = running.Task.ID
+	lines = app.renderAgentTaskSummary(80)
+	require.Len(t, lines, 4)
+	assert.Contains(t, lines[0].Text, "Workflow: workflow(active review)")
+	assert.Contains(t, lines[1].Text, "STEP")
+	assert.Contains(t, lines[1].Text, "STATUS")
+	assert.Contains(t, lines[2].Text, "review[0]")
+	assert.Contains(t, lines[2].Text, string(database.TaskRunning))
 	assert.True(t, app.hasRunningAgentTasks())
 }
 
@@ -202,14 +245,14 @@ func TestTrackStartedWorkflowRejectsForeignRunAndInspectorError(t *testing.T) {
 			name: "foreign session",
 			inspector: &workflowInspectorStub{
 				listErr: nil, getErr: nil, eventsErr: nil, agentTasksErr: nil,
-				getRun: &foreign, runs: nil, events: nil, children: nil, found: true,
+				getRun: &foreign, runs: nil, events: nil, children: nil, details: nil, found: true,
 			},
 		},
 		{
 			name: "get error",
 			inspector: &workflowInspectorStub{
 				listErr: nil, getErr: assert.AnError, eventsErr: nil, agentTasksErr: nil,
-				getRun: nil, runs: nil, events: nil, children: nil, found: false,
+				getRun: nil, runs: nil, events: nil, children: nil, details: nil, found: false,
 			},
 		},
 	}

--- a/internal/terminal/workflow_summary_internal_test.go
+++ b/internal/terminal/workflow_summary_internal_test.go
@@ -69,7 +69,7 @@ func TestActiveWorkflowAppearsInAgentSummary(t *testing.T) {
 	app := newRenderTestApp(t)
 	app.sessionID = workflowTestSessionID
 	app.workflows = &workflowInspectorStub{
-		listErr: nil, getErr: nil, eventsErr: nil, agentTasksErr: nil,
+		listErr: nil, getErr: nil, eventsErr: nil, agentTasksErr: nil, detailsErr: nil,
 		getRun: nil,
 		runs: []database.WorkflowRunEntity{
 			running,
@@ -244,14 +244,14 @@ func TestTrackStartedWorkflowRejectsForeignRunAndInspectorError(t *testing.T) {
 		{
 			name: "foreign session",
 			inspector: &workflowInspectorStub{
-				listErr: nil, getErr: nil, eventsErr: nil, agentTasksErr: nil,
+				listErr: nil, getErr: nil, eventsErr: nil, agentTasksErr: nil, detailsErr: nil,
 				getRun: &foreign, runs: nil, events: nil, children: nil, details: nil, found: true,
 			},
 		},
 		{
 			name: "get error",
 			inspector: &workflowInspectorStub{
-				listErr: nil, getErr: assert.AnError, eventsErr: nil, agentTasksErr: nil,
+				listErr: nil, getErr: assert.AnError, eventsErr: nil, agentTasksErr: nil, detailsErr: nil,
 				getRun: nil, runs: nil, events: nil, children: nil, details: nil, found: false,
 			},
 		},

--- a/internal/terminal/workflow_test_helpers_internal_test.go
+++ b/internal/terminal/workflow_test_helpers_internal_test.go
@@ -22,6 +22,7 @@ type workflowInspectorStub struct {
 	runs          []database.WorkflowRunEntity
 	events        []database.TaskEventEntity
 	children      []database.WorkflowAgentTaskEntity
+	details       []database.WorkflowAgentTaskDetail
 	found         bool
 }
 
@@ -38,4 +39,32 @@ func (stub *workflowInspectorStub) List(
 	int,
 ) ([]database.WorkflowRunEntity, error) {
 	return stub.runs, stub.listErr
+}
+
+func (stub *workflowInspectorStub) Events(
+	context.Context, string, int64, int,
+) ([]database.TaskEventEntity, error) {
+	return stub.events, stub.eventsErr
+}
+
+func (stub *workflowInspectorStub) AgentTasks(
+	context.Context, string,
+) ([]database.WorkflowAgentTaskEntity, error) {
+	return stub.children, stub.agentTasksErr
+}
+
+func (stub *workflowInspectorStub) AgentTask(
+	context.Context, string,
+) (*database.AgentTaskEntity, bool, error) {
+	return nil, false, nil
+}
+
+func (stub *workflowInspectorStub) AgentTaskDetails(
+	context.Context, []string,
+) ([]database.WorkflowAgentTaskDetail, error) {
+	return stub.details, stub.agentTasksErr
+}
+
+func (stub *workflowInspectorStub) Cancel(context.Context, string, string) (bool, error) {
+	return true, nil
 }

--- a/internal/terminal/workflow_test_helpers_internal_test.go
+++ b/internal/terminal/workflow_test_helpers_internal_test.go
@@ -18,6 +18,7 @@ type workflowInspectorStub struct {
 	getErr        error
 	eventsErr     error
 	agentTasksErr error
+	detailsErr    error
 	getRun        *database.WorkflowRunEntity
 	runs          []database.WorkflowRunEntity
 	events        []database.TaskEventEntity
@@ -62,7 +63,7 @@ func (stub *workflowInspectorStub) AgentTask(
 func (stub *workflowInspectorStub) AgentTaskDetails(
 	context.Context, []string,
 ) ([]database.WorkflowAgentTaskDetail, error) {
-	return stub.details, stub.agentTasksErr
+	return stub.details, stub.detailsErr
 }
 
 func (stub *workflowInspectorStub) Cancel(context.Context, string, string) (bool, error) {

--- a/internal/terminal/workflows.go
+++ b/internal/terminal/workflows.go
@@ -58,8 +58,15 @@ func (app *App) refreshWorkflowsPanel(ctx context.Context) {
 	}
 
 	if app.workflowPanelRunID != "" {
+		selected, hasSelection := app.panel.SelectedValue()
 		if err := app.openWorkflowDetail(ctx, app.workflowPanelRunID); err != nil {
 			app.setStatus(err.Error())
+
+			return
+		}
+
+		if hasSelection {
+			app.restoreWorkflowPanelSelection(selected)
 		}
 
 		return
@@ -74,16 +81,18 @@ func (app *App) refreshWorkflowsPanel(ctx context.Context) {
 		return
 	}
 
-	model := panel.New(panelWorkflows, "Workflows", "Enter inspects; Ctrl+C cancels", items, true)
-	for index := range items {
-		if items[index].Value == selected {
-			model.SetSelectedIndex(index)
+	app.panel = panel.New(panelWorkflows, "Workflows", "Enter inspects; Ctrl+C cancels", items, true)
+	app.restoreWorkflowPanelSelection(selected)
+}
 
-			break
+func (app *App) restoreWorkflowPanelSelection(selected string) {
+	for index, item := range app.panel.Items() {
+		if item.Value == selected {
+			app.panel.SetSelectedIndex(index)
+
+			return
 		}
 	}
-
-	app.panel = model
 }
 
 func (app *App) workflowItems(ctx context.Context) ([]tui.ListItem, error) {

--- a/internal/terminal/workflows.go
+++ b/internal/terminal/workflows.go
@@ -1,0 +1,306 @@
+package terminal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gdamore/tcell/v3"
+
+	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/terminal/panel"
+	"github.com/omarluq/librecode/internal/tui"
+)
+
+const (
+	panelWorkflows     panel.Kind = "workflows"
+	workflowPanelLimit int        = 100
+	workflowEventLimit int        = 500
+	workflowRunPrefix  string     = "run:"
+	workflowTaskPrefix string     = "task:"
+)
+
+type workflowProgress struct {
+	Total     int
+	Succeeded int
+	Failed    int
+	Running   int
+}
+
+type workflowDetails struct {
+	ProgressByRun map[string]workflowProgress
+	StepsByRun    map[string][]database.WorkflowAgentTaskDetail
+}
+
+func (app *App) openWorkflowsPanel(ctx context.Context) {
+	items, err := app.workflowItems(ctx)
+	if err != nil {
+		app.addSystemMessage(err.Error())
+
+		return
+	}
+
+	app.workflowPanelRunID = ""
+	app.openPanel(panel.New(
+		panelWorkflows,
+		"Workflows",
+		"Enter inspects; Ctrl+C cancels",
+		items,
+		true,
+	))
+}
+
+func (app *App) refreshWorkflowsPanel(ctx context.Context) {
+	if app.selectedPanelKind != panelWorkflows || app.panel == nil {
+		return
+	}
+
+	if app.workflowPanelRunID != "" {
+		if err := app.openWorkflowDetail(ctx, app.workflowPanelRunID); err != nil {
+			app.setStatus(err.Error())
+		}
+
+		return
+	}
+
+	selected, _ := app.panel.SelectedValue()
+
+	items, err := app.workflowItems(ctx)
+	if err != nil {
+		app.setStatus(err.Error())
+
+		return
+	}
+
+	model := panel.New(panelWorkflows, "Workflows", "Enter inspects; Ctrl+C cancels", items, true)
+	for index := range items {
+		if items[index].Value == selected {
+			model.SetSelectedIndex(index)
+
+			break
+		}
+	}
+
+	app.panel = model
+}
+
+func (app *App) workflowItems(ctx context.Context) ([]tui.ListItem, error) {
+	if app.workflows == nil || app.sessionID == "" {
+		return []tui.ListItem{}, nil
+	}
+
+	runs, err := app.workflows.List(ctx, app.sessionID, workflowPanelLimit)
+	if err != nil {
+		return nil, terminalError(err, "list workflows")
+	}
+
+	runIDs := make([]string, len(runs))
+	for index := range runs {
+		runIDs[index] = runs[index].Task.ID
+	}
+
+	details, detailsErr := app.loadWorkflowDetails(ctx, runIDs)
+	if detailsErr != nil {
+		return nil, detailsErr
+	}
+
+	items := make([]tui.ListItem, 0, len(runs))
+	for index := range runs {
+		run := &runs[index]
+		progress := details.ProgressByRun[run.Task.ID]
+		app.workflowProgress[run.Task.ID] = progress
+
+		items = append(items, tui.ListItem{
+			Value:       workflowRunPrefix + run.Task.ID,
+			Title:       workflowTitle(run),
+			Description: workflowDescription(run, progress),
+			Meta:        taskMeta(&run.Task, time.Now()),
+		})
+	}
+
+	return items, nil
+}
+
+func (app *App) openWorkflowDetail(ctx context.Context, runID string) error {
+	if app.workflows == nil {
+		return errors.New("workflow runtime is not configured")
+	}
+
+	run, found, err := app.workflows.Get(ctx, runID)
+	if err != nil {
+		return terminalError(err, "load workflow")
+	}
+
+	if !found || run.Task.OwnerSessionID != app.sessionID {
+		return fmt.Errorf("workflow %q not found", runID)
+	}
+
+	details, err := app.workflows.AgentTaskDetails(ctx, []string{runID})
+	if err != nil {
+		return terminalError(err, "list workflow agent task details")
+	}
+
+	items := make([]tui.ListItem, 0, len(details)+1)
+	items = append(items, tui.ListItem{
+		Value:       workflowRunPrefix + runID,
+		Title:       workflowTitle(run),
+		Description: workflowRunOutcome(run),
+		Meta:        taskMeta(&run.Task, time.Now()),
+	})
+
+	for index := range details {
+		detail := &details[index]
+		link := &detail.Link
+		task := &detail.AgentTask
+
+		node := strings.TrimSpace(link.NodeKey)
+		if node == "" {
+			node = "agent"
+		}
+
+		items = append(items, tui.ListItem{
+			Value:       workflowTaskPrefix + task.Task.ID,
+			Title:       fmt.Sprintf("%s[%d]  %s", node, link.InvocationIndex, task.Task.State),
+			Description: agentTaskSummaryLabel(task),
+			Meta:        taskMeta(&task.Task, time.Now()),
+		})
+	}
+
+	app.workflowPanelRunID = runID
+	app.openPanel(panel.New(
+		panelWorkflows,
+		"Workflow: "+workflowName(run),
+		"Enter inspects an agent; Esc returns; Ctrl+C cancels workflow",
+		items,
+		true,
+	))
+
+	return nil
+}
+
+func (app *App) applyWorkflowSelection(ctx context.Context, value string) error {
+	if taskID, ok := strings.CutPrefix(value, workflowTaskPrefix); ok {
+		return app.inspectAgentTask(ctx, taskID)
+	}
+
+	if runID, ok := strings.CutPrefix(value, workflowRunPrefix); ok {
+		return app.openWorkflowDetail(ctx, runID)
+	}
+
+	return fmt.Errorf("unknown workflow selection %q", value)
+}
+
+func (app *App) handleWorkflowsPanelKey(ctx context.Context, event *tcell.EventKey) (bool, error) {
+	if event.Key() != tcell.KeyCtrlC || app.panel == nil {
+		return false, nil
+	}
+
+	runID := app.workflowPanelRunID
+	if runID == "" {
+		value, selected := app.panel.SelectedValue()
+		if !selected {
+			return true, nil
+		}
+
+		runID, selected = strings.CutPrefix(value, workflowRunPrefix)
+		if !selected {
+			return true, nil
+		}
+	}
+
+	changed, err := app.workflows.Cancel(ctx, app.sessionID, runID)
+	if err != nil {
+		return true, terminalError(err, "cancel workflow")
+	}
+
+	if changed {
+		app.setStatus("workflow cancel requested: " + runID)
+	}
+
+	return true, nil
+}
+
+func (app *App) loadWorkflowDetails(
+	ctx context.Context,
+	runIDs []string,
+) (workflowDetails, error) {
+	result := workflowDetails{
+		ProgressByRun: make(map[string]workflowProgress, len(runIDs)),
+		StepsByRun:    make(map[string][]database.WorkflowAgentTaskDetail, len(runIDs)),
+	}
+
+	for _, runID := range runIDs {
+		result.ProgressByRun[runID] = workflowProgress{
+			Total: 0, Succeeded: 0, Failed: 0, Running: 0,
+		}
+		result.StepsByRun[runID] = []database.WorkflowAgentTaskDetail{}
+	}
+
+	details, err := app.workflows.AgentTaskDetails(ctx, runIDs)
+	if err != nil {
+		return workflowDetails{}, terminalError(err, "list workflow agent task details")
+	}
+
+	for index := range details {
+		detail := details[index]
+		runID := detail.Link.WorkflowTaskID
+		result.StepsByRun[runID] = append(result.StepsByRun[runID], detail)
+		progress := result.ProgressByRun[runID]
+		progress.Total++
+
+		switch detail.AgentTask.Task.State {
+		case database.TaskSucceeded:
+			progress.Succeeded++
+		case database.TaskFailed, database.TaskCanceled, database.TaskInterrupted:
+			progress.Failed++
+		case database.TaskQueued, database.TaskRunning, database.TaskCanceling:
+			progress.Running++
+		}
+
+		result.ProgressByRun[runID] = progress
+	}
+
+	return result, nil
+}
+
+func workflowTitle(run *database.WorkflowRunEntity) string {
+	return string(run.Task.State) + "  " + workflowName(run)
+}
+
+func workflowName(run *database.WorkflowRunEntity) string {
+	name := strings.Join(strings.Fields(run.Name), " ")
+	if name == "" {
+		return "workflow"
+	}
+
+	return name
+}
+
+func workflowDescription(run *database.WorkflowRunEntity, progress workflowProgress) string {
+	outcome := workflowRunOutcome(run)
+
+	counts := fmt.Sprintf("%d/%d agents", progress.Succeeded+progress.Failed, progress.Total)
+	if progress.Failed > 0 {
+		counts += fmt.Sprintf(" · %d failed", progress.Failed)
+	}
+
+	if outcome == "" {
+		return counts
+	}
+
+	return counts + " · " + outcome
+}
+
+func workflowRunOutcome(run *database.WorkflowRunEntity) string {
+	if run.Task.ErrorMessage != "" {
+		return strings.Join(strings.Fields(run.Task.ErrorMessage), " ")
+	}
+
+	if run.Task.Result != "" {
+		return strings.Join(strings.Fields(run.Task.Result), " ")
+	}
+
+	return "durable dynamic workflow"
+}

--- a/internal/terminal/workflows_internal_test.go
+++ b/internal/terminal/workflows_internal_test.go
@@ -193,6 +193,42 @@ func TestWorkflowPanelNavigation(t *testing.T) {
 	assert.Equal(t, "Workflows", app.panel.Title)
 }
 
+func TestWorkflowDetailRefreshPreservesSelection(t *testing.T) {
+	t.Parallel()
+
+	run := workflowSummaryRun("run-1", database.TaskRunning)
+	first := behaviorAgentTask("agent-1", database.TaskRunning)
+	second := behaviorAgentTask("agent-2", database.TaskRunning)
+	stub := newWorkflowPanelInspector()
+	stub.run = &run
+	stub.links = []database.WorkflowAgentTaskEntity{
+		workflowLink(run.Task.ID, first.Task.ID, "inspect", 0),
+		workflowLink(run.Task.ID, second.Task.ID, "review", 0),
+	}
+	stub.tasks = map[string]*database.AgentTaskEntity{
+		first.Task.ID:  &first,
+		second.Task.ID: &second,
+	}
+	app := newRenderTestApp(t)
+	app.sessionID = workflowTestSessionID
+	app.workflows = stub
+	require.NoError(t, app.openWorkflowDetail(t.Context(), run.Task.ID))
+	app.panel.SetSelectedIndex(2)
+
+	app.refreshWorkflowsPanel(t.Context())
+
+	selected, hasSelection := app.panel.SelectedValue()
+	require.True(t, hasSelection)
+	assert.Equal(t, workflowTaskPrefix+second.Task.ID, selected)
+
+	stub.links = stub.links[:1]
+
+	app.refreshWorkflowsPanel(t.Context())
+	selected, hasSelection = app.panel.SelectedValue()
+	require.True(t, hasSelection)
+	assert.Equal(t, workflowRunPrefix+run.Task.ID, selected)
+}
+
 func TestWorkflowPanelCancellation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/terminal/workflows_internal_test.go
+++ b/internal/terminal/workflows_internal_test.go
@@ -1,0 +1,298 @@
+package terminal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/database"
+)
+
+const workflowNotFound = "not found"
+
+type workflowPanelInspector struct {
+	run           *database.WorkflowRunEntity
+	tasks         map[string]*database.AgentTaskEntity
+	cancelCall    *workflowCancelCall
+	links         []database.WorkflowAgentTaskEntity
+	detailCalls   [][]string
+	getFails      bool
+	linksFail     bool
+	cancelChanged bool
+}
+
+type workflowCancelCall struct {
+	ownerID string
+	runID   string
+}
+
+func newWorkflowPanelInspector() *workflowPanelInspector {
+	return &workflowPanelInspector{
+		run: nil, tasks: map[string]*database.AgentTaskEntity{}, links: nil, cancelCall: nil,
+		detailCalls: nil, getFails: false, linksFail: false, cancelChanged: false,
+	}
+}
+
+func (stub *workflowPanelInspector) Get(
+	context.Context,
+	string,
+) (*database.WorkflowRunEntity, bool, error) {
+	if stub.getFails {
+		return nil, false, assert.AnError
+	}
+
+	return stub.run, stub.run != nil, nil
+}
+
+func (stub *workflowPanelInspector) List(
+	context.Context,
+	string,
+	int,
+) ([]database.WorkflowRunEntity, error) {
+	if stub.run == nil {
+		return []database.WorkflowRunEntity{}, nil
+	}
+
+	return []database.WorkflowRunEntity{*stub.run}, nil
+}
+
+func (stub *workflowPanelInspector) Events(
+	context.Context,
+	string,
+	int64,
+	int,
+) ([]database.TaskEventEntity, error) {
+	return []database.TaskEventEntity{}, nil
+}
+
+func (stub *workflowPanelInspector) AgentTasks(
+	context.Context,
+	string,
+) ([]database.WorkflowAgentTaskEntity, error) {
+	if stub.linksFail {
+		return nil, assert.AnError
+	}
+
+	return stub.links, nil
+}
+
+func (stub *workflowPanelInspector) AgentTask(
+	_ context.Context,
+	taskID string,
+) (*database.AgentTaskEntity, bool, error) {
+	task, found := stub.tasks[taskID]
+
+	return task, found, nil
+}
+
+func (stub *workflowPanelInspector) AgentTaskDetails(
+	_ context.Context,
+	runIDs []string,
+) ([]database.WorkflowAgentTaskDetail, error) {
+	stub.detailCalls = append(stub.detailCalls, append([]string(nil), runIDs...))
+	if stub.linksFail {
+		return nil, assert.AnError
+	}
+
+	details := make([]database.WorkflowAgentTaskDetail, 0, len(stub.links))
+	for index := range stub.links {
+		link := stub.links[index]
+
+		task, found := stub.tasks[link.AgentTaskID]
+		if !found {
+			continue
+		}
+
+		details = append(details, database.WorkflowAgentTaskDetail{AgentTask: *task, Link: link})
+	}
+
+	return details, nil
+}
+
+func (stub *workflowPanelInspector) Cancel(
+	_ context.Context,
+	ownerSessionID string,
+	runID string,
+) (bool, error) {
+	stub.cancelCall = &workflowCancelCall{ownerID: ownerSessionID, runID: runID}
+
+	return stub.cancelChanged, nil
+}
+
+func TestWorkflowItemsDescribeAgentProgress(t *testing.T) {
+	t.Parallel()
+
+	run := workflowSummaryRun("run-1", database.TaskRunning)
+	succeeded := behaviorAgentTask("agent-1", database.TaskSucceeded)
+	failed := behaviorAgentTask("agent-2", database.TaskFailed)
+	stub := newWorkflowPanelInspector()
+	stub.run = &run
+	stub.links = []database.WorkflowAgentTaskEntity{
+		workflowLink(run.Task.ID, succeeded.Task.ID, "", 0),
+		workflowLink(run.Task.ID, failed.Task.ID, "", 0),
+	}
+	stub.tasks = map[string]*database.AgentTaskEntity{
+		succeeded.Task.ID: &succeeded,
+		failed.Task.ID:    &failed,
+	}
+	app := newRenderTestApp(t)
+	app.sessionID = workflowTestSessionID
+	app.workflows = stub
+
+	items, err := app.workflowItems(t.Context())
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, workflowRunPrefix+run.Task.ID, items[0].Value)
+	assert.Contains(t, items[0].Title, "active review")
+	assert.Contains(t, items[0].Description, "2/2 agents")
+	assert.Contains(t, items[0].Description, "1 failed")
+	assert.Equal(
+		t,
+		workflowProgress{Total: 2, Succeeded: 1, Failed: 1, Running: 0},
+		app.workflowProgress[run.Task.ID],
+	)
+	assert.Equal(t, [][]string{{run.Task.ID}}, stub.detailCalls)
+}
+
+func TestWorkflowPanelNavigation(t *testing.T) {
+	t.Parallel()
+
+	run := workflowSummaryRun("run-1", database.TaskRunning)
+	child := behaviorAgentTask("agent-1", database.TaskRunning)
+	stub := newWorkflowPanelInspector()
+	stub.run = &run
+	stub.links = []database.WorkflowAgentTaskEntity{
+		workflowLink(run.Task.ID, child.Task.ID, "review", 2),
+	}
+	stub.tasks = map[string]*database.AgentTaskEntity{child.Task.ID: &child}
+	app := newRenderTestApp(t)
+	app.sessionID = workflowTestSessionID
+	app.workflows = stub
+
+	app.openWorkflowsPanel(t.Context())
+	require.Equal(t, panelWorkflows, app.selectedPanelKind)
+	require.Equal(t, "Workflows", app.panel.Title)
+
+	err := app.applyWorkflowSelection(t.Context(), workflowRunPrefix+run.Task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, run.Task.ID, app.workflowPanelRunID)
+	assert.Equal(t, "Workflow: active review", app.panel.Title)
+	items := app.panel.Items()
+	require.Len(t, items, 2)
+	assert.Equal(t, workflowTaskPrefix+child.Task.ID, items[1].Value)
+	assert.Contains(t, items[1].Title, "review[2]")
+
+	err = app.handlePanelKey(t.Context(), tcell.NewEventKey(tcell.KeyEscape, "", tcell.ModNone))
+	require.NoError(t, err)
+	assert.Equal(t, panelWorkflows, app.selectedPanelKind)
+	assert.Empty(t, app.workflowPanelRunID)
+	assert.Equal(t, "Workflows", app.panel.Title)
+}
+
+func TestWorkflowPanelCancellation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		detail bool
+	}{
+		{name: "selected run", detail: false},
+		{name: "expanded run", detail: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			run := workflowSummaryRun("run-1", database.TaskRunning)
+			stub := newWorkflowPanelInspector()
+			stub.run = &run
+			stub.cancelChanged = true
+			app := newRenderTestApp(t)
+			app.sessionID = workflowTestSessionID
+			app.workflows = stub
+			app.openWorkflowsPanel(t.Context())
+
+			if test.detail {
+				require.NoError(t, app.openWorkflowDetail(t.Context(), run.Task.ID))
+			}
+
+			handled, err := app.handleWorkflowsPanelKey(
+				t.Context(),
+				tcell.NewEventKey(tcell.KeyCtrlC, "", tcell.ModCtrl),
+			)
+			require.NoError(t, err)
+			assert.True(t, handled)
+			require.NotNil(t, stub.cancelCall)
+			assert.Equal(t, workflowTestSessionID, stub.cancelCall.ownerID)
+			assert.Equal(t, run.Task.ID, stub.cancelCall.runID)
+			assert.Contains(t, app.statusMessage, "workflow cancel requested")
+		})
+	}
+}
+
+func TestOpenWorkflowDetailRejectsInvalidRuns(t *testing.T) {
+	t.Parallel()
+
+	foreign := workflowSummaryRun("foreign", database.TaskRunning)
+	foreign.Task.OwnerSessionID = workflowTestForeignSession
+
+	tests := []struct {
+		name      string
+		workflows workflowInspector
+		wantError string
+	}{
+		{name: "runtime unavailable", workflows: nil, wantError: "not configured"},
+		{name: "load failure", workflows: inspectorWithGetError(), wantError: "load workflow"},
+		{name: "missing run", workflows: newWorkflowPanelInspector(), wantError: workflowNotFound},
+		{name: "foreign run", workflows: inspectorWithRun(&foreign), wantError: workflowNotFound},
+		{name: "links failure", workflows: inspectorWithLinksError(), wantError: "list workflow agent task details"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := newRenderTestApp(t)
+			app.sessionID = workflowTestSessionID
+			app.workflows = test.workflows
+
+			err := app.openWorkflowDetail(t.Context(), "run-1")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantError)
+		})
+	}
+}
+
+func workflowLink(runID, taskID, nodeKey string, invocationIndex int) database.WorkflowAgentTaskEntity {
+	return database.WorkflowAgentTaskEntity{
+		CreatedAt: time.Time{}, WorkflowTaskID: runID, AgentTaskID: taskID,
+		NodeKey: nodeKey, InvocationIndex: invocationIndex, Sequence: 0,
+	}
+}
+
+func inspectorWithGetError() *workflowPanelInspector {
+	stub := newWorkflowPanelInspector()
+	stub.getFails = true
+
+	return stub
+}
+
+func inspectorWithRun(run *database.WorkflowRunEntity) *workflowPanelInspector {
+	stub := newWorkflowPanelInspector()
+	stub.run = run
+
+	return stub
+}
+
+func inspectorWithLinksError() *workflowPanelInspector {
+	run := workflowSummaryRun("run-1", database.TaskRunning)
+	stub := inspectorWithRun(&run)
+	stub.linksFail = true
+
+	return stub
+}

--- a/internal/workflow/service.go
+++ b/internal/workflow/service.go
@@ -396,6 +396,20 @@ func (service *Service) AgentTasks(
 	return tasks, nil
 }
 
+// AgentTaskDetails returns complete child tasks for multiple workflows in one query.
+func (service *Service) AgentTaskDetails(
+	ctx context.Context,
+	runIDs []string,
+) ([]database.WorkflowAgentTaskDetail, error) {
+	details, err := service.runs.ListAgentTaskDetails(ctx, runIDs)
+	if err != nil {
+		return nil, oops.In("workflow").Code("list_agent_task_details").
+			Wrapf(err, "list workflow agent task details")
+	}
+
+	return details, nil
+}
+
 func (service *Service) createRun(
 	ctx context.Context,
 	request *ServiceRequest,

--- a/internal/workflow/service_internal_test.go
+++ b/internal/workflow/service_internal_test.go
@@ -184,6 +184,8 @@ func TestServiceRepositoryFailurePaths(t *testing.T) {
 	require.ErrorContains(t, err, "get workflow agent task")
 	_, err = service.AgentTasks(t.Context(), run.Task.ID)
 	require.ErrorContains(t, err, "list workflow agent tasks")
+	_, err = service.AgentTaskDetails(t.Context(), []string{run.Task.ID})
+	require.ErrorContains(t, err, "list workflow agent task details")
 	_, err = service.RecoverInterrupted(t.Context())
 	require.ErrorContains(t, err, "recover interrupted workflow runs")
 	_, err = service.Cancel(t.Context(), owner, run.Task.ID)


### PR DESCRIPTION
## Summary
- keep collapsed workflow summaries at their natural height, including while focused
- reserve detail rows only when workflow details are expanded
- use the shared pending-circle indicator for active workflows
- update workflow summary and layout regression tests

## Validation
- mise exec -- go test ./...
- mise exec -- task build
- mise exec -- task ci