### PR TITLE
refactor(database): share composite repository graph

### DIFF
--- a/internal/database/agent_task_repository.go
+++ b/internal/database/agent_task_repository.go
@@ -38,21 +38,39 @@ func NewAgentTaskRepository(connection *sql.DB) (*AgentTaskRepository, error) {
 		return nil, err
 	}
 
-	return NewAgentTaskRepositoryWithProvider(provider)
-}
-
-// NewAgentTaskRepositoryWithProvider creates an agent task repository with an explicit SQL provider.
-func NewAgentTaskRepositoryWithProvider(provider ksql.Provider) (*AgentTaskRepository, error) {
-	if isNilProvider(provider) {
-		return nil, nilProviderError()
-	}
-
 	tasks, err := NewTaskRepositoryWithProvider(provider)
 	if err != nil {
 		return nil, err
 	}
 
+	return NewAgentTaskRepositoryWithProvider(provider, tasks)
+}
+
+// NewAgentTaskRepositoryWithProvider creates an agent task repository with explicit shared dependencies.
+func NewAgentTaskRepositoryWithProvider(
+	provider ksql.Provider,
+	tasks *TaskRepository,
+) (*AgentTaskRepository, error) {
+	if isNilProvider(provider) {
+		return nil, nilProviderError()
+	}
+
+	if tasks == nil {
+		return nil, oops.In("database").Code("nil_task_repository").Errorf("task repository is required")
+	}
+
+	if !sameSQLProvider(provider, tasks.sql) {
+		return nil, oops.In("database").Code("repository_graph_mismatch").Errorf(
+			"task repository must share the SQL provider",
+		)
+	}
+
 	return &AgentTaskRepository{sql: provider, tasks: tasks}, nil
+}
+
+// Tasks returns the shared generic task repository.
+func (repository *AgentTaskRepository) Tasks() *TaskRepository {
+	return repository.tasks
 }
 
 // CreateWithChildSession atomically creates a child session and its queued agent task.

--- a/internal/database/repository_construction_internal_test.go
+++ b/internal/database/repository_construction_internal_test.go
@@ -218,18 +218,44 @@ func TestCompositeRepositoryConstructorsRejectInvalidGraph(t *testing.T) {
 	otherProvider, err := newSQLProvider(otherConnection)
 	require.NoError(t, err)
 
-	_, err = NewAgentTaskRepositoryWithProvider(provider, nil)
-	assertRepositoryOopsCode(t, err, "nil_task_repository")
-	_, err = NewAgentTaskRepositoryWithProvider(otherProvider, tasks)
-	assertRepositoryOopsCode(t, err, "repository_graph_mismatch")
-	_, err = NewWorkflowRepositoryWithProvider(provider, nil, agentTasks)
-	assertRepositoryOopsCode(t, err, "nil_task_repository")
-	_, err = NewWorkflowRepositoryWithProvider(provider, tasks, nil)
-	assertRepositoryOopsCode(t, err, "nil_agent_task_repository")
-	_, err = NewWorkflowRepositoryWithProvider(provider, otherTasks, agentTasks)
-	assertRepositoryOopsCode(t, err, "repository_graph_mismatch")
-	_, err = NewWorkflowRepositoryWithProvider(otherProvider, tasks, agentTasks)
-	assertRepositoryOopsCode(t, err, "repository_graph_mismatch")
+	const graphMismatch = "repository_graph_mismatch"
+
+	tests := map[string]struct {
+		err  error
+		code string
+	}{
+		"agent task with nil task repository": {
+			err:  agentTaskGraphConstructorError(provider, nil),
+			code: "nil_task_repository",
+		},
+		"agent task with mismatched provider": {
+			err:  agentTaskGraphConstructorError(otherProvider, tasks),
+			code: graphMismatch,
+		},
+		"workflow with nil task repository": {
+			err:  workflowGraphConstructorError(provider, nil, agentTasks),
+			code: "nil_task_repository",
+		},
+		"workflow with nil agent task repository": {
+			err:  workflowGraphConstructorError(provider, tasks, nil),
+			code: "nil_agent_task_repository",
+		},
+		"workflow with mismatched task repository": {
+			err:  workflowGraphConstructorError(provider, otherTasks, agentTasks),
+			code: graphMismatch,
+		},
+		"workflow with mismatched provider": {
+			err:  workflowGraphConstructorError(otherProvider, tasks, agentTasks),
+			code: graphMismatch,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assertRepositoryOopsCode(t, tt.err, tt.code)
+		})
+	}
 }
 
 func TestRepositoryMethodsRejectNilEntities(t *testing.T) {
@@ -330,6 +356,22 @@ func nilEntityCases(
 			return createErr
 		}, code: "nil_child_session_request"},
 	}
+}
+
+func agentTaskGraphConstructorError(provider ksql.Provider, tasks *TaskRepository) error {
+	_, err := NewAgentTaskRepositoryWithProvider(provider, tasks)
+
+	return err
+}
+
+func workflowGraphConstructorError(
+	provider ksql.Provider,
+	tasks *TaskRepository,
+	agentTasks *AgentTaskRepository,
+) error {
+	_, err := NewWorkflowRepositoryWithProvider(provider, tasks, agentTasks)
+
+	return err
 }
 
 func sessionConstructorError(connection *sql.DB) error {

--- a/internal/database/repository_construction_internal_test.go
+++ b/internal/database/repository_construction_internal_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/samber/oops"
 	"github.com/stretchr/testify/assert"
@@ -88,6 +89,147 @@ func TestRepositoryConstructorsRejectNilProviders(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestCompositeRepositoryConstructorsShareDependencies(t *testing.T) {
+	t.Parallel()
+
+	connection, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, connection.Close()) })
+
+	provider, err := newSQLProvider(connection)
+	require.NoError(t, err)
+	tasks, err := NewTaskRepositoryWithProvider(provider)
+	require.NoError(t, err)
+	agentTasks, err := NewAgentTaskRepositoryWithProvider(provider, tasks)
+	require.NoError(t, err)
+	workflows, err := NewWorkflowRepositoryWithProvider(provider, tasks, agentTasks)
+	require.NoError(t, err)
+
+	assert.Same(t, tasks, agentTasks.Tasks())
+	assert.Same(t, tasks, workflows.Tasks())
+	assert.Same(t, agentTasks, workflows.AgentTasks())
+
+	fixedNow := func() time.Time { return time.Unix(123, 0) }
+	tasks.now = fixedNow
+	assert.Equal(t, fixedNow(), agentTasks.Tasks().now())
+	assert.Equal(t, fixedNow(), workflows.Tasks().now())
+}
+
+func TestCompositeRepositoriesUseSharedClock(t *testing.T) {
+	t.Parallel()
+
+	connection, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	connection.SetMaxOpenConns(1)
+	t.Cleanup(func() { require.NoError(t, connection.Close()) })
+	require.NoError(t, Migrate(t.Context(), connection))
+
+	provider, err := newSQLProvider(connection)
+	require.NoError(t, err)
+	sessions, err := NewSessionRepositoryWithProvider(provider)
+	require.NoError(t, err)
+	tasks, err := NewTaskRepositoryWithProvider(provider)
+	require.NoError(t, err)
+	agentTasks, err := NewAgentTaskRepositoryWithProvider(provider, tasks)
+	require.NoError(t, err)
+	workflows, err := NewWorkflowRepositoryWithProvider(provider, tasks, agentTasks)
+	require.NoError(t, err)
+
+	fixedNow := time.Date(2026, time.August, 6, 12, 0, 0, 0, time.UTC)
+	tasks.now = func() time.Time { return fixedNow }
+
+	owner, err := sessions.CreateSession(t.Context(), t.TempDir(), "owner", "")
+	require.NoError(t, err)
+	child, err := sessions.CreateSession(t.Context(), owner.CWD, "child", owner.ID)
+	require.NoError(t, err)
+
+	createdTask, err := tasks.Create(t.Context(), newClockTestTask(owner.ID, "test"))
+	require.NoError(t, err)
+	createdAgentTask, err := agentTasks.Create(t.Context(), &AgentTaskEntity{
+		Task:           *newClockTestTask(owner.ID, ""),
+		ChildSessionID: child.ID,
+		AgentName:      "clock-agent",
+		Prompt:         "inspect",
+		Model:          "",
+		Provider:       "",
+		PolicyJSON:     "{}",
+		UsageJSON:      "{}",
+		Depth:          1,
+	})
+	require.NoError(t, err)
+	createdWorkflow, err := workflows.Create(t.Context(), &WorkflowRunEntity{
+		Task:          *newClockTestTask(owner.ID, ""),
+		Name:          "clock workflow",
+		Source:        "workflow source",
+		SourceHash:    "source hash",
+		SourceVersion: "1",
+		ArgumentsJSON: "{}",
+	})
+	require.NoError(t, err)
+
+	for _, created := range []*TaskEntity{createdTask, &createdAgentTask.Task, &createdWorkflow.Task} {
+		assert.Equal(t, fixedNow, created.CreatedAt)
+		assert.Equal(t, fixedNow, created.UpdatedAt)
+	}
+}
+
+func newClockTestTask(ownerSessionID, kind string) *TaskEntity {
+	return &TaskEntity{
+		CreatedAt:      time.Time{},
+		StartedAt:      nil,
+		FinishedAt:     nil,
+		UpdatedAt:      time.Time{},
+		LeaseExpiresAt: nil,
+		ID:             "",
+		Kind:           kind,
+		ParentTaskID:   "",
+		OwnerSessionID: ownerSessionID,
+		ConcurrencyKey: "",
+		LeaseOwner:     "",
+		State:          "",
+		Result:         "",
+		ErrorCode:      "",
+		ErrorMessage:   "",
+	}
+}
+
+func TestCompositeRepositoryConstructorsRejectInvalidGraph(t *testing.T) {
+	t.Parallel()
+
+	connection, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, connection.Close()) })
+
+	provider, err := newSQLProvider(connection)
+	require.NoError(t, err)
+	tasks, err := NewTaskRepositoryWithProvider(provider)
+	require.NoError(t, err)
+	otherTasks, err := NewTaskRepositoryWithProvider(provider)
+	require.NoError(t, err)
+	agentTasks, err := NewAgentTaskRepositoryWithProvider(provider, tasks)
+	require.NoError(t, err)
+
+	otherConnection, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, otherConnection.Close()) })
+
+	otherProvider, err := newSQLProvider(otherConnection)
+	require.NoError(t, err)
+
+	_, err = NewAgentTaskRepositoryWithProvider(provider, nil)
+	assertRepositoryOopsCode(t, err, "nil_task_repository")
+	_, err = NewAgentTaskRepositoryWithProvider(otherProvider, tasks)
+	assertRepositoryOopsCode(t, err, "repository_graph_mismatch")
+	_, err = NewWorkflowRepositoryWithProvider(provider, nil, agentTasks)
+	assertRepositoryOopsCode(t, err, "nil_task_repository")
+	_, err = NewWorkflowRepositoryWithProvider(provider, tasks, nil)
+	assertRepositoryOopsCode(t, err, "nil_agent_task_repository")
+	_, err = NewWorkflowRepositoryWithProvider(provider, otherTasks, agentTasks)
+	assertRepositoryOopsCode(t, err, "repository_graph_mismatch")
+	_, err = NewWorkflowRepositoryWithProvider(otherProvider, tasks, agentTasks)
+	assertRepositoryOopsCode(t, err, "repository_graph_mismatch")
 }
 
 func TestRepositoryMethodsRejectNilEntities(t *testing.T) {
@@ -239,13 +381,13 @@ func taskProviderConstructorError(provider ksql.Provider) error {
 }
 
 func agentTaskProviderConstructorError(provider ksql.Provider) error {
-	_, err := NewAgentTaskRepositoryWithProvider(provider)
+	_, err := NewAgentTaskRepositoryWithProvider(provider, nil)
 
 	return err
 }
 
 func workflowProviderConstructorError(provider ksql.Provider) error {
-	_, err := NewWorkflowRepositoryWithProvider(provider)
+	_, err := NewWorkflowRepositoryWithProvider(provider, nil, nil)
 
 	return err
 }

--- a/internal/database/sql_repository.go
+++ b/internal/database/sql_repository.go
@@ -27,6 +27,21 @@ func isNilProvider(provider ksql.Provider) bool {
 	return nilable && value.IsNil()
 }
 
+func sameSQLProvider(left, right ksql.Provider) bool {
+	if isNilProvider(left) || isNilProvider(right) {
+		return false
+	}
+
+	leftValue := reflect.ValueOf(left)
+	rightValue := reflect.ValueOf(right)
+
+	if leftValue.Type() != rightValue.Type() || !leftValue.Comparable() || !rightValue.Comparable() {
+		return false
+	}
+
+	return leftValue.Interface() == rightValue.Interface()
+}
+
 func newSQLProvider(connection *sql.DB) (ksql.DB, error) {
 	if connection == nil {
 		return ksql.DB{}, oops.In("database").Code("nil_sql_connection").Errorf("sql connection is required")

--- a/internal/database/task_test_helpers_test.go
+++ b/internal/database/task_test_helpers_test.go
@@ -37,11 +37,13 @@ func newTaskTestFixture(t *testing.T) *taskTestFixture {
 	connection := openTestSQLite(t, filepath.Join(t.TempDir(), "tasks.db"), 0)
 	require.NoError(t, database.Migrate(t.Context(), connection))
 
+	workflows := testutil.WorkflowRepository(t, connection)
+
 	return &taskTestFixture{
 		t:         t,
-		agents:    testutil.AgentTaskRepository(t, connection),
-		tasks:     testutil.TaskRepository(t, connection),
-		workflows: testutil.WorkflowRepository(t, connection),
+		agents:    workflows.AgentTasks(),
+		tasks:     workflows.Tasks(),
+		workflows: workflows,
 		sessions:  testutil.SessionRepository(t, connection),
 	}
 }

--- a/internal/database/workflow_repository.go
+++ b/internal/database/workflow_repository.go
@@ -56,23 +56,42 @@ func NewWorkflowRepository(connection *sql.DB) (*WorkflowRepository, error) {
 		return nil, err
 	}
 
-	return NewWorkflowRepositoryWithProvider(provider)
-}
-
-// NewWorkflowRepositoryWithProvider creates a workflow repository with an explicit SQL provider.
-func NewWorkflowRepositoryWithProvider(provider ksql.Provider) (*WorkflowRepository, error) {
-	if isNilProvider(provider) {
-		return nil, nilProviderError()
-	}
-
 	tasks, err := NewTaskRepositoryWithProvider(provider)
 	if err != nil {
 		return nil, err
 	}
 
-	agentTasks, err := NewAgentTaskRepositoryWithProvider(provider)
+	agentTasks, err := NewAgentTaskRepositoryWithProvider(provider, tasks)
 	if err != nil {
 		return nil, err
+	}
+
+	return NewWorkflowRepositoryWithProvider(provider, tasks, agentTasks)
+}
+
+// NewWorkflowRepositoryWithProvider creates a workflow repository with explicit shared dependencies.
+func NewWorkflowRepositoryWithProvider(
+	provider ksql.Provider,
+	tasks *TaskRepository,
+	agentTasks *AgentTaskRepository,
+) (*WorkflowRepository, error) {
+	if isNilProvider(provider) {
+		return nil, nilProviderError()
+	}
+
+	if tasks == nil {
+		return nil, oops.In("database").Code("nil_task_repository").Errorf("task repository is required")
+	}
+
+	if agentTasks == nil {
+		return nil, oops.In("database").Code("nil_agent_task_repository").Errorf("agent task repository is required")
+	}
+
+	if agentTasks.Tasks() != tasks || !sameSQLProvider(provider, tasks.sql) ||
+		!sameSQLProvider(provider, agentTasks.sql) {
+		return nil, oops.In("database").Code("repository_graph_mismatch").Errorf(
+			"workflow repositories must share dependencies and the SQL provider",
+		)
 	}
 
 	return &WorkflowRepository{sql: provider, tasks: tasks, agentTasks: agentTasks}, nil

--- a/internal/di/assistant_service_internal_test.go
+++ b/internal/di/assistant_service_internal_test.go
@@ -69,13 +69,15 @@ func newTestDatabaseService(t *testing.T) *DatabaseService {
 	connection.SetMaxOpenConns(1)
 	require.NoError(t, database.Migrate(context.Background(), connection))
 
+	workflows := testutil.WorkflowRepository(t, connection)
+
 	return &DatabaseService{
 		DB:         connection,
 		Sessions:   testutil.SessionRepository(t, connection),
 		Documents:  testutil.DocumentRepository(t, connection),
-		Tasks:      testutil.TaskRepository(t, connection),
-		AgentTasks: testutil.AgentTaskRepository(t, connection),
-		Workflows:  testutil.WorkflowRepository(t, connection),
+		Tasks:      workflows.Tasks(),
+		AgentTasks: workflows.AgentTasks(),
+		Workflows:  workflows,
 		path:       "",
 	}
 }

--- a/internal/di/database_service.go
+++ b/internal/di/database_service.go
@@ -73,12 +73,12 @@ func NewDatabaseService(injector do.Injector) (*DatabaseService, error) {
 		return nil, closeAfterRepositoryError(connection, "task", databasePath, err)
 	}
 
-	agentTasks, err := database.NewAgentTaskRepositoryWithProvider(sqlProvider)
+	agentTasks, err := database.NewAgentTaskRepositoryWithProvider(sqlProvider, tasks)
 	if err != nil {
 		return nil, closeAfterRepositoryError(connection, "agent_task", databasePath, err)
 	}
 
-	workflows, err := database.NewWorkflowRepositoryWithProvider(sqlProvider)
+	workflows, err := database.NewWorkflowRepositoryWithProvider(sqlProvider, tasks, agentTasks)
 	if err != nil {
 		return nil, closeAfterRepositoryError(connection, "workflow", databasePath, err)
 	}

--- a/internal/di/database_service_internal_test.go
+++ b/internal/di/database_service_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid/v5"
+	"github.com/samber/do/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -46,6 +47,24 @@ func TestOpenSQLiteDatabaseAppliesPragmasAndMigrations(t *testing.T) {
 	).Scan(&tableName)
 	require.NoError(t, err)
 	assert.Equal(t, "sessions", tableName)
+}
+
+func TestNewDatabaseServiceSharesCompositeRepositories(t *testing.T) {
+	t.Parallel()
+
+	cfg := testServiceConfig()
+	cfg.Database.Path = filepath.Join(t.TempDir(), "librecode.db")
+	cfg.Database.ApplyMigrations = true
+
+	injector := do.New()
+	do.ProvideValue(injector, &ConfigService{cfg: cfg, path: ""})
+	service, err := NewDatabaseService(injector)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Shutdown(context.Background())) })
+
+	assert.Same(t, service.Tasks, service.AgentTasks.Tasks())
+	assert.Same(t, service.Tasks, service.Workflows.Tasks())
+	assert.Same(t, service.AgentTasks, service.Workflows.AgentTasks())
 }
 
 func TestDatabaseServiceHealthCheckAndShutdown(t *testing.T) {


### PR DESCRIPTION
## Summary
- construct one shared task, agent-task, and workflow repository graph
- validate dependency and SQL provider identity across composite repositories
- add identity, mismatch, and shared-clock composition coverage

## Validation
- mise exec -- go test ./...
- mise exec -- task build
- mise exec -- task ci
- git diff --check