### PR TITLE
refactor(di): add explicit application bootstrap

### DIFF
--- a/cmd/librecode/chat.go
+++ b/cmd/librecode/chat.go
@@ -23,7 +23,7 @@ func newChatCmd() *cobra.Command {
 	var options chatRunOptions
 
 	cmd := &cobra.Command{
-		Use:   "chat",
+		Use:   chatUse,
 		Short: "Open the interactive chat UI",
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -50,43 +50,76 @@ func newChatCmd() *cobra.Command {
 	return cmd
 }
 
+type chatServices struct {
+	database  *di.DatabaseService
+	assistant *di.AssistantService
+	models    *di.ModelService
+	auth      *di.AuthService
+	extension *di.ExtensionService
+	config    *di.ConfigService
+	workflows *di.ChatWorkflowService
+}
+
+func resolveChatServices(container *di.Container) (*chatServices, error) {
+	runtimeServices, err := container.StartRuntime()
+	if err != nil {
+		return nil, cliError(err, "start runtime services")
+	}
+
+	return &chatServices{
+		database: runtimeServices.Database, assistant: runtimeServices.Assistant, models: runtimeServices.Models,
+		auth: runtimeServices.Auth, extension: runtimeServices.Extensions, config: runtimeServices.Config,
+		workflows: runtimeServices.ChatWorkflows,
+	}, nil
+}
+
+type terminalRunner func(context.Context, *terminal.RunOptions) error
+
 func runChat(cmd *cobra.Command, options chatRunOptions) error {
 	commandOptions := commandOptionsFromCommand(cmd)
 	commandOptions.interactive = true
 
 	return withContainer(cmd.Context(), commandOptions, func(container *di.Container) error {
-		databaseService := container.DatabaseService()
-		runtime := container.AssistantService().Runtime
-		modelRegistry := container.ModelService().Registry
-		authStorage := container.AuthService().Storage
-		extensionManager := container.ExtensionService().Manager
-		cfg := container.ConfigService().Get()
-		chatWorkflows := container.ChatWorkflowService()
+		return runChatWithContainer(cmd, container, options, terminal.Run)
+	})
+}
 
-		cwd, err := assistant.DefaultCWD("")
-		if err != nil {
-			return cliError(err, cliResolveWorkingDirectory)
-		}
+func runChatWithContainer(
+	cmd *cobra.Command,
+	container *di.Container,
+	options chatRunOptions,
+	runTerminal terminalRunner,
+) error {
+	services, err := resolveChatServices(container)
+	if err != nil {
+		return err
+	}
 
-		sessionID, err := resolveChatSessionID(cmd.Context(), runtime, cwd, options)
-		if err != nil {
-			return err
-		}
+	runtime := services.assistant.Runtime
 
-		resources := loadTerminalResources(cmd.Context(), cwd)
+	cwd, err := assistant.DefaultCWD("")
+	if err != nil {
+		return cliError(err, cliResolveWorkingDirectory)
+	}
 
-		return terminal.Run(cmd.Context(), &terminal.RunOptions{
-			Extensions: extensionManager,
-			Resources:  &resources,
-			Runtime:    runtime,
-			Workflows:  chatWorkflows.Runs,
-			Settings:   databaseService.Documents,
-			Models:     modelRegistry,
-			Auth:       authStorage,
-			Config:     cfg,
-			CWD:        cwd,
-			SessionID:  sessionID,
-		})
+	sessionID, err := resolveChatSessionID(cmd.Context(), runtime, cwd, options)
+	if err != nil {
+		return err
+	}
+
+	resources := loadTerminalResources(cmd.Context(), cwd)
+
+	return runTerminal(cmd.Context(), &terminal.RunOptions{
+		Extensions: services.extension.Manager,
+		Resources:  &resources,
+		Runtime:    runtime,
+		Workflows:  services.workflows.Runs,
+		Settings:   services.database.Documents,
+		Models:     services.models.Registry,
+		Auth:       services.auth.Storage,
+		Config:     services.config.Get(),
+		CWD:        cwd,
+		SessionID:  sessionID,
 	})
 }
 

--- a/cmd/librecode/constants.go
+++ b/cmd/librecode/constants.go
@@ -1,3 +1,10 @@
 package main
 
-const listUse = "list"
+const (
+	chatUse          = "chat"
+	configFlag       = "--config"
+	listUse          = "list"
+	modelUse         = "model"
+	noExtensionsFlag = "--no-extensions"
+	toolUse          = "tool"
+)

--- a/cmd/librecode/errors.go
+++ b/cmd/librecode/errors.go
@@ -2,7 +2,10 @@ package main
 
 import "github.com/samber/oops"
 
-const cliResolveWorkingDirectory = "resolve working directory"
+const (
+	cliResolveDatabaseService  = "resolve database service"
+	cliResolveWorkingDirectory = "resolve working directory"
+)
 
 func cliError(err error, action string) error {
 	if err == nil {

--- a/cmd/librecode/extension.go
+++ b/cmd/librecode/extension.go
@@ -33,7 +33,10 @@ func newExtensionListCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return withContainer(cmd.Context(), commandOptionsFromCommand(cmd), func(container *di.Container) error {
-				service := container.ExtensionService()
+				service, err := container.ExtensionService()
+				if err != nil {
+					return cliError(err, "resolve extension service")
+				}
 
 				loadedByPath := loadedExtensionsByPath(service.Manager.Extensions())
 				for index := range service.State.Configured {
@@ -56,9 +59,12 @@ func newExtensionRunCmd() *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return withContainer(cmd.Context(), commandOptionsFromCommand(cmd), func(container *di.Container) error {
-				manager := container.ExtensionService().Manager
+				service, err := container.ExtensionService()
+				if err != nil {
+					return cliError(err, "resolve extension service")
+				}
 
-				result, err := manager.ExecuteCommand(cmd.Context(), args[0], strings.Join(args[1:], " "))
+				result, err := service.Manager.ExecuteCommand(cmd.Context(), args[0], strings.Join(args[1:], " "))
 				if err != nil {
 					return cliError(err, "run extension command")
 				}

--- a/cmd/librecode/lifecycle_commands_internal_test.go
+++ b/cmd/librecode/lifecycle_commands_internal_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabaseCommandsUseApplicationLifecycle(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeLifecycleTestConfig(t)
+
+	newOutput := executeLifecycleCommand(t, configPath, "session", "new", "coverage session")
+	sessionID := strings.TrimSpace(newOutput)
+	require.NotEmpty(t, sessionID)
+
+	listOutput := executeLifecycleCommand(t, configPath, "session", listUse)
+	assert.Contains(t, listOutput, sessionID)
+	assert.Contains(t, listOutput, "coverage session")
+
+	showOutput := executeLifecycleCommand(t, configPath, "session", "show", sessionID)
+	assert.Empty(t, showOutput)
+
+	migrateOutput := executeLifecycleCommand(t, configPath, "migrate")
+	assert.Contains(t, migrateOutput, "migrations applied:")
+}
+
+func TestExtensionAndToolCommandsUseApplicationLifecycle(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeLifecycleTestConfig(t)
+
+	assert.Empty(t, executeLifecycleCommand(t, configPath, "extension", listUse))
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{configFlag, configPath, noExtensionsFlag, "extension", "run", "missing"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "run extension command")
+
+	toolOutput := executeLifecycleCommand(t, configPath, toolUse, listUse)
+	assert.Contains(t, toolOutput, "read\tread_only=true")
+}
+
+func writeLifecycleTestConfig(t *testing.T) string {
+	t.Helper()
+
+	databasePath := filepath.Join(t.TempDir(), "librecode.db")
+
+	return writeTestConfig(t, fmt.Sprintf(
+		"database:\n  path: %q\nmodels:\n  discovery:\n    enabled: false\nextensions:\n  use: []\n",
+		databasePath,
+	))
+}
+
+func executeLifecycleCommand(t *testing.T, configPath string, args ...string) string {
+	t.Helper()
+
+	cmd := newRootCmd()
+	output := new(bytes.Buffer)
+	cmd.SetOut(output)
+	cmd.SetArgs(append([]string{configFlag, configPath, noExtensionsFlag}, args...))
+	require.NoError(t, cmd.Execute())
+
+	return output.String()
+}

--- a/cmd/librecode/migrate.go
+++ b/cmd/librecode/migrate.go
@@ -15,7 +15,7 @@ func newMigrateCmd() *cobra.Command {
 			return withContainer(cmd.Context(), commandOptionsFromCommand(cmd), func(container *di.Container) error {
 				databaseService, err := container.DatabaseService()
 				if err != nil {
-					return cliError(err, "resolve database service")
+					return cliError(err, cliResolveDatabaseService)
 				}
 
 				return printLine(cmd.OutOrStdout(), "migrations applied: %s", databaseService.Path())

--- a/cmd/librecode/migrate.go
+++ b/cmd/librecode/migrate.go
@@ -13,7 +13,10 @@ func newMigrateCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return withContainer(cmd.Context(), commandOptionsFromCommand(cmd), func(container *di.Container) error {
-				databaseService := container.DatabaseService()
+				databaseService, err := container.DatabaseService()
+				if err != nil {
+					return cliError(err, "resolve database service")
+				}
 
 				return printLine(cmd.OutOrStdout(), "migrations applied: %s", databaseService.Path())
 			})

--- a/cmd/librecode/model.go
+++ b/cmd/librecode/model.go
@@ -17,7 +17,7 @@ import (
 
 func newModelCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "model",
+		Use:   modelUse,
 		Short: "Inspect available models",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return newModelListCmd().RunE(cmd, nil)
@@ -37,28 +37,19 @@ func newModelListCmd() *cobra.Command {
 		Short: "List models for authorized providers",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			options := commandOptionsFromCommand(cmd)
-
-			container, err := di.NewContainer(options.configFile, options.configOverrides())
-			if err != nil {
-				return cliError(err, "initialize model services")
-			}
-			defer func() {
-				if report := container.ShutdownWithContext(cmd.Context()); report != nil && !report.Succeed {
-					if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "shutdown failed: %v\n", report.Errors); err != nil {
-						return
-					}
+			return withContainer(cmd.Context(), commandOptionsFromCommand(cmd), func(container *di.Container) error {
+				service, err := container.ModelService()
+				if err != nil {
+					return cliError(err, "resolve model service")
 				}
-			}()
 
-			registry := container.ModelService().Registry
+				models := listedModels(service.Registry, all)
+				if len(args) == 1 {
+					models = filterModelList(models, args[0])
+				}
 
-			models := listedModels(registry, all)
-			if len(args) == 1 {
-				models = filterModelList(models, args[0])
-			}
-
-			return printModels(cmd.OutOrStdout(), models)
+				return printModels(cmd.OutOrStdout(), models)
+			})
 		},
 	}
 	cmd.Flags().BoolVar(&all, "all", false, "include models from unauthorized providers")

--- a/cmd/librecode/prompt.go
+++ b/cmd/librecode/prompt.go
@@ -87,14 +87,38 @@ func validatePromptRunOptions(options promptRunOptions) error {
 	return nil
 }
 
+type promptRunner func(*assistant.Runtime, *cobra.Command, promptRunOptions, string) error
+
 func runPromptWithContainer(
 	cmd *cobra.Command,
 	container *di.Container,
 	options promptRunOptions,
 	message string,
 ) error {
-	runtime := container.AssistantService().Runtime
+	return runPromptWithContainerAndRunner(cmd, container, options, message, runPromptRuntime)
+}
 
+func runPromptWithContainerAndRunner(
+	cmd *cobra.Command,
+	container *di.Container,
+	options promptRunOptions,
+	message string,
+	run promptRunner,
+) error {
+	runtimeServices, err := container.StartRuntime()
+	if err != nil {
+		return cliError(err, "start runtime services")
+	}
+
+	return run(runtimeServices.Assistant.Runtime, cmd, options, message)
+}
+
+func runPromptRuntime(
+	runtime *assistant.Runtime,
+	cmd *cobra.Command,
+	options promptRunOptions,
+	message string,
+) error {
 	cwd, err := assistant.DefaultCWD("")
 	if err != nil {
 		return cliError(err, cliResolveWorkingDirectory)

--- a/cmd/librecode/runtime.go
+++ b/cmd/librecode/runtime.go
@@ -3,36 +3,42 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
+	"time"
 
 	"github.com/samber/do/v2"
 
 	"github.com/omarluq/librecode/internal/di"
 )
 
-func withContainer(ctx context.Context, options commandOptions, handler func(*di.Container) error) error {
-	return withContainerOptions(ctx, options, handler)
-}
+const shutdownTimeout = 10 * time.Second
 
-func withContainerOptions(ctx context.Context, options commandOptions, handler func(*di.Container) error) error {
-	container, err := di.NewContainer(options.configFile, options.configOverrides())
+func withContainer(
+	ctx context.Context,
+	options commandOptions,
+	handler func(*di.Container) error,
+) (runErr error) {
+	container, err := di.NewContainer(ctx, options.configFile, options.configOverrides())
 	if err != nil {
 		return cliError(err, "initialize services")
 	}
 
-	runErr := handler(container)
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
 
-	return finishContainerRun(runErr, container.ShutdownWithContext(ctx))
+		runErr = finishContainerRun(runErr, container.ShutdownWithContext(shutdownCtx))
+	}()
+
+	return handler(container)
 }
 
 func finishContainerRun(runErr error, shutdownReport *do.ShutdownReport) error {
 	if shutdownReport != nil && !shutdownReport.Succeed && shutdownReport.Error() != "" {
-		shutdownErr := fmt.Errorf("%w", shutdownReport)
 		if runErr != nil {
-			return errors.Join(runErr, shutdownErr)
+			return errors.Join(runErr, shutdownReport)
 		}
 
-		return shutdownErr
+		return shutdownReport
 	}
 
 	return runErr

--- a/cmd/librecode/runtime_composition_internal_test.go
+++ b/cmd/librecode/runtime_composition_internal_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/assistant"
+	"github.com/omarluq/librecode/internal/di"
+	"github.com/omarluq/librecode/internal/terminal"
+)
+
+func TestChatCompositionStartsRuntimeAndInvokesTerminal(t *testing.T) {
+	t.Parallel()
+
+	container := newRuntimeTestContainer(t, true)
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+
+	called := false
+	chatOptions := chatRunOptions{SessionID: "", ResumeID: "", Resume: false}
+	err := runChatWithContainer(cmd, container, chatOptions, func(
+		ctx context.Context,
+		options *terminal.RunOptions,
+	) error {
+		called = true
+
+		assert.Same(t, cmd.Context(), ctx)
+		require.NotNil(t, options)
+		require.NotNil(t, options.Runtime)
+		require.NotNil(t, options.Workflows)
+		require.NotNil(t, options.Settings)
+		require.NotNil(t, options.Models)
+		require.NotNil(t, options.Auth)
+		assert.NotNil(t, options.Config)
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestPromptCompositionStartsRuntimeAndInvokesRunner(t *testing.T) {
+	t.Parallel()
+
+	container := newRuntimeTestContainer(t, false)
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+
+	called := false
+	promptOptions := promptRunOptions{
+		SessionID: "", SessionName: "", ToolStrategy: "", MetricsJSON: "", Resume: false,
+	}
+	err := runPromptWithContainerAndRunner(
+		cmd,
+		container,
+		promptOptions,
+		"hello",
+		func(runtime *assistant.Runtime, gotCmd *cobra.Command, options promptRunOptions, message string) error {
+			called = true
+
+			require.NotNil(t, runtime)
+			assert.Same(t, cmd, gotCmd)
+			assert.Equal(t, "hello", message)
+			assert.Equal(t, promptOptions, options)
+
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func newRuntimeTestContainer(t *testing.T, interactive bool) *di.Container {
+	t.Helper()
+
+	databasePath := filepath.Join(t.TempDir(), "librecode.db")
+	config := fmt.Sprintf(
+		"database:\n  path: %q\nmodels:\n  discovery:\n    enabled: false\nextensions:\n  use: []\n",
+		databasePath,
+	)
+	container, err := di.NewContainer(
+		t.Context(),
+		writeTestConfig(t, config),
+		di.ConfigOverrides{DisableExtensions: true, Interactive: interactive},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		report := container.ShutdownWithContext(context.Background())
+		assert.True(t, report.Succeed, report.Error())
+	})
+
+	return container
+}

--- a/cmd/librecode/runtime_composition_internal_test.go
+++ b/cmd/librecode/runtime_composition_internal_test.go
@@ -46,6 +46,25 @@ func TestChatCompositionStartsRuntimeAndInvokesTerminal(t *testing.T) {
 	assert.True(t, called)
 }
 
+func TestChatCompositionPropagatesTerminalError(t *testing.T) {
+	t.Parallel()
+
+	container := newRuntimeTestContainer(t, true)
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+
+	expectedErr := assert.AnError
+
+	err := runChatWithContainer(cmd, container, chatRunOptions{SessionID: "", ResumeID: "", Resume: false}, func(
+		context.Context,
+		*terminal.RunOptions,
+	) error {
+		return expectedErr
+	})
+
+	assert.ErrorIs(t, err, expectedErr)
+}
+
 func TestPromptCompositionStartsRuntimeAndInvokesRunner(t *testing.T) {
 	t.Parallel()
 
@@ -76,6 +95,67 @@ func TestPromptCompositionStartsRuntimeAndInvokesRunner(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, called)
+}
+
+func TestPromptCompositionPropagatesRunnerError(t *testing.T) {
+	t.Parallel()
+
+	container := newRuntimeTestContainer(t, false)
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+
+	expectedErr := assert.AnError
+
+	err := runPromptWithContainerAndRunner(
+		cmd,
+		container,
+		promptRunOptions{SessionID: "", SessionName: "", ToolStrategy: "", MetricsJSON: "", Resume: false},
+		"hello",
+		func(*assistant.Runtime, *cobra.Command, promptRunOptions, string) error {
+			return expectedErr
+		},
+	)
+
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestRuntimeCompositionRejectsClosedContainer(t *testing.T) {
+	t.Parallel()
+
+	container := newRuntimeTestContainer(t, false)
+	assert.True(t, container.ShutdownWithContext(context.Background()).Succeed)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+
+	chatCalled := false
+	err := runChatWithContainer(cmd, container, chatRunOptions{SessionID: "", ResumeID: "", Resume: false}, func(
+		context.Context,
+		*terminal.RunOptions,
+	) error {
+		chatCalled = true
+
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "start runtime services")
+	assert.False(t, chatCalled)
+
+	promptCalled := false
+	err = runPromptWithContainerAndRunner(
+		cmd,
+		container,
+		promptRunOptions{SessionID: "", SessionName: "", ToolStrategy: "", MetricsJSON: "", Resume: false},
+		"hello",
+		func(*assistant.Runtime, *cobra.Command, promptRunOptions, string) error {
+			promptCalled = true
+
+			return nil
+		},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "start runtime services")
+	assert.False(t, promptCalled)
 }
 
 func newRuntimeTestContainer(t *testing.T, interactive bool) *di.Container {

--- a/cmd/librecode/runtime_internal_test.go
+++ b/cmd/librecode/runtime_internal_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/samber/do/v2"
@@ -22,17 +24,41 @@ func TestWithContainerRunsHandler(t *testing.T) {
 	}
 
 	called := false
-	err := withContainerOptions(context.Background(), options, func(container *di.Container) error {
+	err := withContainer(context.Background(), options, func(container *di.Container) error {
 		called = true
 
 		require.NotNil(t, container)
-		assert.True(t, container.ConfigService().Interactive())
+		configService, resolveErr := container.ConfigService()
+		require.NoError(t, resolveErr)
+		assert.True(t, configService.Interactive())
 
 		return nil
 	})
 
 	require.NoError(t, err)
 	assert.True(t, called)
+}
+
+func TestWithContainerUsesFreshShutdownContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	options := commandOptions{
+		configFile:        writeTestConfig(t, "extensions:\n  use: []\n"),
+		disableExtensions: true,
+		interactive:       false,
+	}
+
+	err := withContainer(ctx, options, func(container *di.Container) error {
+		_, resolveErr := container.DatabaseService()
+		require.NoError(t, resolveErr)
+		cancel()
+
+		return context.Canceled
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NotContains(t, err.Error(), "shutdown database")
 }
 
 func TestWithContainerReturnsHandlerError(t *testing.T) {
@@ -45,7 +71,7 @@ func TestWithContainerReturnsHandlerError(t *testing.T) {
 	}
 
 	expectedErr := errors.New("handler failed")
-	err := withContainerOptions(context.Background(), options, func(*di.Container) error {
+	err := withContainer(context.Background(), options, func(*di.Container) error {
 		return expectedErr
 	})
 
@@ -132,12 +158,77 @@ func TestWithContainerReturnsConfigError(t *testing.T) {
 		interactive:       false,
 	}
 
-	err := withContainerOptions(context.Background(), options, func(*di.Container) error {
+	err := withContainer(context.Background(), options, func(*di.Container) error {
 		return nil
 	})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "database.busy_timeout cannot be negative")
+}
+
+func TestCommandsReturnBootstrapErrors(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeTestConfig(t, "database:\n  busy_timeout: -1s\nextensions:\n  use: []\n")
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: chatUse, args: []string{chatUse}},
+		{name: "prompt", args: []string{"prompt", "hello"}},
+		{name: "model list", args: []string{modelUse, listUse}},
+		{name: "tool list", args: []string{toolUse, listUse}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := newRootCmd()
+			cmd.SetArgs(append([]string{configFlag, configPath, noExtensionsFlag}, test.args...))
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "database.busy_timeout cannot be negative")
+		})
+	}
+}
+
+func TestModelAndToolCommandsUseApplicationLifecycle(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeTestConfig(t, "models:\n  discovery:\n    enabled: false\nextensions:\n  use: []\n")
+
+	t.Run("model list", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := newRootCmd()
+		output := new(bytes.Buffer)
+		cmd.SetOut(output)
+		cmd.SetArgs([]string{configFlag, configPath, noExtensionsFlag, modelUse, listUse, "--all"})
+
+		require.NoError(t, cmd.Execute())
+		assert.Contains(t, output.String(), "provider")
+	})
+
+	t.Run("read tool", func(t *testing.T) {
+		t.Parallel()
+
+		cwd := t.TempDir()
+		path := filepath.Join(cwd, "hello.txt")
+		writeCLIFile(t, path, "hello")
+
+		cmd := newRootCmd()
+		output := new(bytes.Buffer)
+		cmd.SetOut(output)
+		cmd.SetArgs([]string{
+			configFlag, configPath, noExtensionsFlag, toolUse, "run", "--cwd", cwd,
+			"read", `{"path":"hello.txt"}`,
+		})
+
+		require.NoError(t, cmd.Execute())
+		assert.Contains(t, output.String(), "hello")
+	})
 }
 
 func failedShutdownReport(err error) *do.ShutdownReport {

--- a/cmd/librecode/runtime_internal_test.go
+++ b/cmd/librecode/runtime_internal_test.go
@@ -43,6 +43,8 @@ func TestWithContainerUsesFreshShutdownContext(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	options := commandOptions{
 		configFile:        writeTestConfig(t, "extensions:\n  use: []\n"),
 		disableExtensions: true,

--- a/cmd/librecode/session.go
+++ b/cmd/librecode/session.go
@@ -37,7 +37,12 @@ func newSessionNewCmd() *cobra.Command {
 			name := strings.TrimSpace(strings.Join(args, " "))
 
 			return withContainer(cmd.Context(), commandOptionsFromCommand(cmd), func(container *di.Container) error {
-				repository := container.DatabaseService().Sessions
+				service, err := container.DatabaseService()
+				if err != nil {
+					return cliError(err, "resolve database service")
+				}
+
+				repository := service.Sessions
 
 				cwd, err := assistant.DefaultCWD("")
 				if err != nil {
@@ -60,30 +65,35 @@ func newSessionListCmd() *cobra.Command {
 		Use:   listUse,
 		Short: "List sessions for the current working directory",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return withContainer(cmd.Context(), commandOptionsFromCommand(cmd), func(container *di.Container) error {
-				repository := container.DatabaseService().Sessions
-
-				cwd, err := assistant.DefaultCWD("")
-				if err != nil {
-					return cliError(err, cliResolveWorkingDirectory)
-				}
-
-				sessions, err := repository.ListSessions(cmd.Context(), cwd)
-				if err != nil {
-					return cliError(err, "list sessions")
-				}
-
-				for index := range sessions {
-					if err := printSessionSummary(cmd, &sessions[index]); err != nil {
-						return err
-					}
-				}
-
-				return nil
-			})
-		},
+		RunE:  runSessionList,
 	}
+}
+
+func runSessionList(cmd *cobra.Command, _ []string) error {
+	return withContainer(cmd.Context(), commandOptionsFromCommand(cmd), func(container *di.Container) error {
+		service, err := container.DatabaseService()
+		if err != nil {
+			return cliError(err, "resolve database service")
+		}
+
+		cwd, err := assistant.DefaultCWD("")
+		if err != nil {
+			return cliError(err, cliResolveWorkingDirectory)
+		}
+
+		sessions, err := service.Sessions.ListSessions(cmd.Context(), cwd)
+		if err != nil {
+			return cliError(err, "list sessions")
+		}
+
+		for index := range sessions {
+			if err := printSessionSummary(cmd, &sessions[index]); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 }
 
 func newSessionShowCmd() *cobra.Command {
@@ -93,7 +103,12 @@ func newSessionShowCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return withContainer(cmd.Context(), commandOptionsFromCommand(cmd), func(container *di.Container) error {
-				repository := container.DatabaseService().Sessions
+				service, err := container.DatabaseService()
+				if err != nil {
+					return cliError(err, "resolve database service")
+				}
+
+				repository := service.Sessions
 
 				entries, err := repository.Entries(cmd.Context(), args[0])
 				if err != nil {

--- a/cmd/librecode/session.go
+++ b/cmd/librecode/session.go
@@ -39,7 +39,7 @@ func newSessionNewCmd() *cobra.Command {
 			return withContainer(cmd.Context(), commandOptionsFromCommand(cmd), func(container *di.Container) error {
 				service, err := container.DatabaseService()
 				if err != nil {
-					return cliError(err, "resolve database service")
+					return cliError(err, cliResolveDatabaseService)
 				}
 
 				repository := service.Sessions
@@ -73,7 +73,7 @@ func runSessionList(cmd *cobra.Command, _ []string) error {
 	return withContainer(cmd.Context(), commandOptionsFromCommand(cmd), func(container *di.Container) error {
 		service, err := container.DatabaseService()
 		if err != nil {
-			return cliError(err, "resolve database service")
+			return cliError(err, cliResolveDatabaseService)
 		}
 
 		cwd, err := assistant.DefaultCWD("")
@@ -105,7 +105,7 @@ func newSessionShowCmd() *cobra.Command {
 			return withContainer(cmd.Context(), commandOptionsFromCommand(cmd), func(container *di.Container) error {
 				service, err := container.DatabaseService()
 				if err != nil {
-					return cliError(err, "resolve database service")
+					return cliError(err, cliResolveDatabaseService)
 				}
 
 				repository := service.Sessions

--- a/cmd/librecode/tool.go
+++ b/cmd/librecode/tool.go
@@ -16,7 +16,7 @@ const toolJSONStdinLimitBytes int64 = 1 << 20
 
 func newToolCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "tool",
+		Use:   toolUse,
 		Short: "Run librecode-style built-in coding tools",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
@@ -40,9 +40,12 @@ func newToolListCmd() *cobra.Command {
 
 func runToolList(cmd *cobra.Command, _ []string) error {
 	return withContainer(cmd.Context(), commandOptionsFromCommand(cmd), func(container *di.Container) error {
-		registry := container.ToolService().Registry
+		service, err := container.ToolService()
+		if err != nil {
+			return cliError(err, "resolve tool service")
+		}
 
-		definitions := registry.Definitions()
+		definitions := service.Registry.Definitions()
 		for index := range definitions {
 			if err := printToolDefinition(cmd, &definitions[index]); err != nil {
 				return err
@@ -67,7 +70,10 @@ func newToolRunCmd() *cobra.Command {
 			}
 
 			return withContainer(cmd.Context(), commandOptionsFromCommand(cmd), func(container *di.Container) error {
-				service := container.ToolService()
+				service, err := container.ToolService()
+				if err != nil {
+					return cliError(err, "resolve tool service")
+				}
 
 				registry, err := toolRegistryForCWD(service, cwd)
 				if err != nil {

--- a/internal/di/agent_task_service.go
+++ b/internal/di/agent_task_service.go
@@ -2,7 +2,6 @@ package di
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/samber/do/v2"
 
@@ -11,18 +10,29 @@ import (
 
 // AgentTaskService owns durable background agent execution.
 type AgentTaskService struct {
-	Tasks *agenttask.Service
+	Tasks     *agenttask.Service
+	assistant *AssistantService
+	options   *agenttask.Options
 }
 
 // NewAgentTaskService wires the assistant runtime into the durable task scheduler.
 func NewAgentTaskService(injector do.Injector) (*AgentTaskService, error) {
-	databaseService := do.MustInvoke[*DatabaseService](injector)
-	assistantService := do.MustInvoke[*AssistantService](injector)
-
-	var logger *slog.Logger
-	if loggerService, loggerErr := do.Invoke[*LoggerService](injector); loggerErr == nil {
-		logger = loggerService.SlogLogger
+	databaseService, err := do.Invoke[*DatabaseService](injector)
+	if err != nil {
+		return nil, serviceError(err, "resolve database service")
 	}
+
+	assistantService, err := do.Invoke[*AssistantService](injector)
+	if err != nil {
+		return nil, serviceError(err, "resolve assistant service")
+	}
+
+	loggerService, err := do.Invoke[*LoggerService](injector)
+	if err != nil {
+		return nil, serviceError(err, "resolve logger service")
+	}
+
+	logger := loggerService.SlogLogger
 
 	runner, err := agenttask.NewRuntimeRunner(
 		assistantService.Runtime,
@@ -33,21 +43,39 @@ func NewAgentTaskService(injector do.Injector) (*AgentTaskService, error) {
 		return nil, serviceError(err, "create agent task runner")
 	}
 
-	tasks, err := agenttask.New(context.Background(), &agenttask.Options{
-		Tasks: databaseService.Tasks, AgentTasks: databaseService.AgentTasks, Workflows: databaseService.Workflows,
-		Runner: runner, Concurrency: 0, SessionConcurrency: 0, QueueCapacity: 0, Timeout: 0,
-		Logger: logger,
-	})
-	if err != nil {
-		return nil, serviceError(err, "create agent task service")
+	return &AgentTaskService{
+		Tasks:     nil,
+		assistant: assistantService,
+		options: &agenttask.Options{
+			Tasks: databaseService.Tasks, AgentTasks: databaseService.AgentTasks, Workflows: databaseService.Workflows,
+			Runner: runner, Concurrency: 0, SessionConcurrency: 0, QueueCapacity: 0, Timeout: 0,
+			Logger: logger,
+		},
+	}, nil
+}
+
+// Start recovers durable tasks and starts scheduler workers.
+func (service *AgentTaskService) Start(ctx context.Context) error {
+	if service.Tasks != nil {
+		return nil
 	}
 
-	assistantService.Runtime.SetAgentTaskController(tasks)
+	tasks, err := agenttask.New(ctx, service.options)
+	if err != nil {
+		return serviceError(err, "create agent task service")
+	}
 
-	return &AgentTaskService{Tasks: tasks}, nil
+	service.Tasks = tasks
+	service.assistant.Runtime.SetAgentTaskController(tasks)
+
+	return nil
 }
 
 // Shutdown stops workers before the database service is closed.
 func (service *AgentTaskService) Shutdown(ctx context.Context) error {
+	if service.Tasks == nil {
+		return nil
+	}
+
 	return serviceError(service.Tasks.Shutdown(ctx), "shutdown agent task service")
 }

--- a/internal/di/assistant_service.go
+++ b/internal/di/assistant_service.go
@@ -17,13 +17,40 @@ type AssistantService struct {
 
 // NewAssistantService wires the assistant runtime.
 func NewAssistantService(injector do.Injector) (*AssistantService, error) {
-	cfg := do.MustInvoke[*ConfigService](injector).Get()
-	databaseService := do.MustInvoke[*DatabaseService](injector)
-	extensionService := do.MustInvoke[*ExtensionService](injector)
-	cache := do.MustInvoke[*CacheService](injector)
-	models := do.MustInvoke[*ModelService](injector)
-	logger := do.MustInvoke[*LoggerService](injector).SlogLogger
-	skills := do.MustInvoke[*SkillsService](injector)
+	configService, err := do.Invoke[*ConfigService](injector)
+	if err != nil {
+		return nil, err
+	}
+
+	databaseService, err := do.Invoke[*DatabaseService](injector)
+	if err != nil {
+		return nil, err
+	}
+
+	extensionService, err := do.Invoke[*ExtensionService](injector)
+	if err != nil {
+		return nil, err
+	}
+
+	cache, err := do.Invoke[*CacheService](injector)
+	if err != nil {
+		return nil, err
+	}
+
+	models, err := do.Invoke[*ModelService](injector)
+	if err != nil {
+		return nil, err
+	}
+
+	loggerService, err := do.Invoke[*LoggerService](injector)
+	if err != nil {
+		return nil, err
+	}
+
+	skills, err := do.Invoke[*SkillsService](injector)
+	if err != nil {
+		return nil, err
+	}
 
 	cwd, err := filepath.Abs(".")
 	if err != nil {
@@ -34,13 +61,13 @@ func NewAssistantService(injector do.Injector) (*AssistantService, error) {
 
 	return &AssistantService{
 		Runtime: assistant.NewRuntime(&assistant.RuntimeOptions{
-			Config:      cfg,
+			Config:      configService.Get(),
 			Sessions:    databaseService.Sessions,
 			Extensions:  extensionService.Manager,
 			Cache:       cache.Responses,
 			Models:      models.Registry,
 			Client:      nil,
-			Logger:      logger,
+			Logger:      loggerService.SlogLogger,
 			SkillsCache: skills.Cache,
 			Agents:      agents,
 		}),

--- a/internal/di/auth_service.go
+++ b/internal/di/auth_service.go
@@ -1,7 +1,6 @@
 package di
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 
@@ -18,13 +17,18 @@ type AuthService struct {
 }
 
 // NewAuthService wires librecode-style auth.json credential storage.
-func NewAuthService(_ do.Injector) (*AuthService, error) {
+func NewAuthService(injector do.Injector) (*AuthService, error) {
 	authPath, err := resolveAuthPath()
 	if err != nil {
 		return nil, err
 	}
 
-	storage, err := auth.NewStorage(context.Background(), auth.NewFileBackend(authPath))
+	ctx, err := applicationContext(injector)
+	if err != nil {
+		return nil, err
+	}
+
+	storage, err := auth.NewStorage(ctx, auth.NewFileBackend(authPath))
 	if err != nil {
 		return nil, oops.In("auth").Code("load").Wrapf(err, "load auth storage")
 	}

--- a/internal/di/cache_service.go
+++ b/internal/di/cache_service.go
@@ -13,7 +13,12 @@ type CacheService struct {
 
 // NewCacheService creates response caches from config.
 func NewCacheService(injector do.Injector) (*CacheService, error) {
-	cfg := do.MustInvoke[*ConfigService](injector).Get()
+	configService, err := do.Invoke[*ConfigService](injector)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := configService.Get()
 
 	return &CacheService{
 		Responses: assistant.NewResponseCache(cfg.Cache.Enabled, cfg.Cache.Capacity, cfg.Cache.TTL),

--- a/internal/di/chat_workflow_service.go
+++ b/internal/di/chat_workflow_service.go
@@ -13,33 +13,66 @@ import (
 type ChatWorkflowService struct {
 	Runs       *workflow.Service
 	Dispatcher *workflow.Dispatcher
+	workflows  *WorkflowService
+	database   *DatabaseService
+	assistant  *AssistantService
+	logger     *slog.Logger
 }
 
 // NewChatWorkflowService enables model-authored workflows for interactive chat.
 func NewChatWorkflowService(injector do.Injector) (*ChatWorkflowService, error) {
-	workflows := do.MustInvoke[*WorkflowService](injector)
-	databaseService := do.MustInvoke[*DatabaseService](injector)
-	assistantService := do.MustInvoke[*AssistantService](injector)
-
-	var logger *slog.Logger
-	if loggerService, err := do.Invoke[*LoggerService](injector); err == nil {
-		logger = loggerService.SlogLogger
+	workflows, err := do.Invoke[*WorkflowService](injector)
+	if err != nil {
+		return nil, serviceError(err, "resolve workflow service")
 	}
 
-	dispatcher, err := workflow.NewDispatcher(context.Background(), workflow.DispatcherOptions{
-		Service: workflows.Runs, Tasks: databaseService.Tasks, Logger: logger,
+	databaseService, err := do.Invoke[*DatabaseService](injector)
+	if err != nil {
+		return nil, serviceError(err, "resolve database service")
+	}
+
+	assistantService, err := do.Invoke[*AssistantService](injector)
+	if err != nil {
+		return nil, serviceError(err, "resolve assistant service")
+	}
+
+	loggerService, err := do.Invoke[*LoggerService](injector)
+	if err != nil {
+		return nil, serviceError(err, "resolve logger service")
+	}
+
+	return &ChatWorkflowService{
+		Runs: nil, Dispatcher: nil, workflows: workflows, database: databaseService,
+		assistant: assistantService, logger: loggerService.SlogLogger,
+	}, nil
+}
+
+// Start starts the in-process workflow dispatcher.
+func (service *ChatWorkflowService) Start(ctx context.Context) error {
+	if service.Dispatcher != nil {
+		return nil
+	}
+
+	dispatcher, err := workflow.NewDispatcher(ctx, workflow.DispatcherOptions{
+		Service: service.workflows.Runs, Tasks: service.database.Tasks, Logger: service.logger,
 		Concurrency: 0, Buffer: 0, Interval: 0,
 	})
 	if err != nil {
-		return nil, serviceError(err, "create chat workflow dispatcher")
+		return serviceError(err, "create chat workflow dispatcher")
 	}
 
-	assistantService.Runtime.SetWorkflowSubmitter(dispatcher)
+	service.Runs = service.workflows.Runs
+	service.Dispatcher = dispatcher
+	service.assistant.Runtime.SetWorkflowSubmitter(dispatcher)
 
-	return &ChatWorkflowService{Runs: workflows.Runs, Dispatcher: dispatcher}, nil
+	return nil
 }
 
 // Shutdown stops workflow workers before their dependencies are closed.
 func (service *ChatWorkflowService) Shutdown(ctx context.Context) error {
+	if service.Dispatcher == nil {
+		return nil
+	}
+
 	return serviceError(service.Dispatcher.Shutdown(ctx), "shutdown chat workflow dispatcher")
 }

--- a/internal/di/config_service.go
+++ b/internal/di/config_service.go
@@ -27,7 +27,10 @@ type ConfigService struct {
 
 // NewConfigService loads configuration from the injector's configured path.
 func NewConfigService(injector do.Injector) (*ConfigService, error) {
-	path := do.MustInvokeNamed[string](injector, ConfigPathKey)
+	path, err := do.InvokeNamed[string](injector, ConfigPathKey)
+	if err != nil {
+		return nil, err
+	}
 
 	loaded, err := config.LoadResolved(path)
 	if err != nil {
@@ -36,7 +39,11 @@ func NewConfigService(injector do.Injector) (*ConfigService, error) {
 
 	cfg := loaded.Config
 
-	overrides := do.MustInvokeNamed[ConfigOverrides](injector, ConfigOverridesKey)
+	overrides, err := do.InvokeNamed[ConfigOverrides](injector, ConfigOverridesKey)
+	if err != nil {
+		return nil, err
+	}
+
 	if overrides.DisableExtensions {
 		cfg.Extensions.Enabled = false
 	}

--- a/internal/di/config_service_test.go
+++ b/internal/di/config_service_test.go
@@ -1,6 +1,7 @@
 package di_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,11 +18,17 @@ func TestNewContainer_DisableExtensionsOverride(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
 	require.NoError(t, os.WriteFile(configPath, []byte("extensions:\n  enabled: true\n"), 0o600))
 
-	container, err := di.NewContainer(configPath, di.ConfigOverrides{DisableExtensions: true, Interactive: false})
+	container, err := di.NewContainer(context.Background(), configPath, di.ConfigOverrides{
+		DisableExtensions: true,
+		Interactive:       false,
+	})
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.True(t, container.ShutdownWithContext(t.Context()).Succeed) })
 
-	cfg := container.ConfigService().Get()
+	configService, err := container.ConfigService()
+	require.NoError(t, err)
+
+	cfg := configService.Get()
 	assert.False(t, cfg.Extensions.Enabled)
 }
 
@@ -43,14 +50,15 @@ func TestConfigServiceTracksLoadedPathAndInteractiveOverride(t *testing.T) {
 			configPath := filepath.Join(t.TempDir(), "config.yaml")
 			require.NoError(t, os.WriteFile(configPath, []byte("app:\n  env: test\n"), 0o600))
 
-			container, err := di.NewContainer(configPath, di.ConfigOverrides{
+			container, err := di.NewContainer(context.Background(), configPath, di.ConfigOverrides{
 				DisableExtensions: false,
 				Interactive:       test.interactive,
 			})
 			require.NoError(t, err)
 			t.Cleanup(func() { assert.True(t, container.ShutdownWithContext(t.Context()).Succeed) })
 
-			configService := container.ConfigService()
+			configService, err := container.ConfigService()
+			require.NoError(t, err)
 			assert.Equal(t, configPath, configService.Path())
 			assert.Equal(t, test.interactive, configService.Interactive())
 		})

--- a/internal/di/container.go
+++ b/internal/di/container.go
@@ -3,92 +3,350 @@ package di
 
 import (
 	"context"
+	"errors"
+	"sync"
+	"time"
 
 	"github.com/samber/do/v2"
 	"github.com/samber/oops"
 )
 
+const (
+	applicationContextKey = "application.context"
+	startupCleanupTimeout = 10 * time.Second
+)
+
 // Container wraps the root injector used by the CLI runtime.
 type Container struct {
-	injector *do.RootScope
+	injector     *do.RootScope
+	runtime      *RuntimeServices
+	buildRuntime func(context.Context) (*RuntimeServices, error)
+	lifecycle    sync.Mutex
+	closed       bool
+	started      bool
+}
+
+// RuntimeServices is the fully constructed and started application runtime.
+type RuntimeServices struct {
+	Config        *ConfigService
+	Database      *DatabaseService
+	Auth          *AuthService
+	Models        *ModelService
+	Extensions    *ExtensionService
+	Assistant     *AssistantService
+	AgentTasks    *AgentTaskService
+	Workflows     *WorkflowService
+	ChatWorkflows *ChatWorkflowService
 }
 
 // NewContainer builds the root injector for the CLI runtime.
-func NewContainer(configPath string, overrides ConfigOverrides) (*Container, error) {
+func NewContainer(ctx context.Context, configPath string, overrides ConfigOverrides) (*Container, error) {
+	if ctx == nil {
+		return nil, oops.In("di").Code("nil_application_context").Errorf("application context is required")
+	}
+
 	injector := do.New()
+	do.ProvideNamedValue(injector, applicationContextKey, ctx)
 	do.ProvideNamedValue(injector, ConfigPathKey, configPath)
 	do.ProvideNamedValue(injector, ConfigOverridesKey, overrides)
 	RegisterServices(injector)
 
+	container := &Container{
+		injector:     injector,
+		runtime:      nil,
+		buildRuntime: nil,
+		lifecycle:    sync.Mutex{},
+		closed:       false,
+		started:      false,
+	}
+	container.buildRuntime = container.constructRuntime
+
 	if _, err := do.Invoke[*ConfigService](injector); err != nil {
-		return nil, oops.
-			In("di").
-			Code("container_init").
-			Wrapf(err, "initialize container")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), startupCleanupTimeout)
+		defer cancel()
+
+		wrapped := oops.In("di").Code("container_init").Wrapf(err, "initialize container")
+
+		return nil, joinShutdownError(wrapped, injector.ShutdownWithContext(shutdownCtx))
 	}
 
-	return &Container{injector: injector}, nil
+	return container, nil
+}
+
+func applicationContext(injector do.Injector) (context.Context, error) {
+	return do.InvokeNamed[context.Context](injector, applicationContextKey)
 }
 
 // ShutdownWithContext stops all registered services using the given context.
 func (c *Container) ShutdownWithContext(ctx context.Context) *do.ShutdownReport {
+	c.lifecycle.Lock()
+	defer c.lifecycle.Unlock()
+
+	return c.shutdownLocked(ctx)
+}
+
+func (c *Container) shutdownLocked(ctx context.Context) *do.ShutdownReport {
+	if c.closed {
+		return &do.ShutdownReport{Succeed: true}
+	}
+
+	c.closed = true
+
 	return c.injector.ShutdownWithContext(ctx)
 }
 
+// StartRuntime constructs the complete runtime and starts its durable workers.
+func (c *Container) StartRuntime() (*RuntimeServices, error) {
+	c.lifecycle.Lock()
+	defer c.lifecycle.Unlock()
+
+	if c.closed {
+		return nil, oops.In("di").Code("container_closed").Errorf("start runtime services: container is closed")
+	}
+
+	if c.started {
+		return c.runtime, nil
+	}
+
+	ctx, resolveErr := applicationContext(c.injector)
+	if resolveErr != nil {
+		return nil, c.runtimeStartErrorLocked(resolveErr)
+	}
+
+	if contextErr := ctx.Err(); contextErr != nil {
+		return nil, c.runtimeStartErrorLocked(contextErr)
+	}
+
+	runtimeServices, err := c.buildRuntime(ctx)
+	if err != nil {
+		return nil, c.runtimeStartErrorLocked(err)
+	}
+
+	if contextErr := ctx.Err(); contextErr != nil {
+		return nil, c.runtimeStartErrorLocked(contextErr)
+	}
+
+	c.runtime = runtimeServices
+	c.started = true
+
+	return runtimeServices, nil
+}
+
+func (c *Container) constructRuntime(ctx context.Context) (*RuntimeServices, error) {
+	services, err := c.resolveRuntimeServices()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := services.AgentTasks.Start(ctx); err != nil {
+		return nil, err
+	}
+
+	if err := services.Workflows.Start(ctx); err != nil {
+		return nil, err
+	}
+
+	if err := services.ChatWorkflows.Start(ctx); err != nil {
+		return nil, err
+	}
+
+	return services, nil
+}
+
+func (c *Container) resolveRuntimeServices() (*RuntimeServices, error) {
+	configService, err := do.Invoke[*ConfigService](c.injector)
+	if err != nil {
+		return nil, err
+	}
+
+	databaseService, err := do.Invoke[*DatabaseService](c.injector)
+	if err != nil {
+		return nil, err
+	}
+
+	authService, err := do.Invoke[*AuthService](c.injector)
+	if err != nil {
+		return nil, err
+	}
+
+	modelService, err := do.Invoke[*ModelService](c.injector)
+	if err != nil {
+		return nil, err
+	}
+
+	extensionService, err := do.Invoke[*ExtensionService](c.injector)
+	if err != nil {
+		return nil, err
+	}
+
+	assistantService, err := do.Invoke[*AssistantService](c.injector)
+	if err != nil {
+		return nil, err
+	}
+
+	agentTasks, err := do.Invoke[*AgentTaskService](c.injector)
+	if err != nil {
+		return nil, err
+	}
+
+	workflows, err := do.Invoke[*WorkflowService](c.injector)
+	if err != nil {
+		return nil, err
+	}
+
+	chatWorkflows, err := do.Invoke[*ChatWorkflowService](c.injector)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RuntimeServices{
+		Config:        configService,
+		Database:      databaseService,
+		Auth:          authService,
+		Models:        modelService,
+		Extensions:    extensionService,
+		Assistant:     assistantService,
+		AgentTasks:    agentTasks,
+		Workflows:     workflows,
+		ChatWorkflows: chatWorkflows,
+	}, nil
+}
+
+func (c *Container) runtimeStartErrorLocked(startErr error) error {
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), startupCleanupTimeout)
+	defer cancel()
+
+	wrapped := oops.In("di").Code("runtime_start").Wrapf(startErr, "start runtime services")
+
+	return joinShutdownError(wrapped, c.shutdownLocked(shutdownCtx))
+}
+
+func joinShutdownError(base error, report *do.ShutdownReport) error {
+	if report == nil || report.Succeed || report.Error() == "" {
+		return base
+	}
+
+	return errors.Join(base, report)
+}
+
+func (c *Container) lockForResolution() error {
+	c.lifecycle.Lock()
+
+	if c.closed {
+		c.lifecycle.Unlock()
+
+		return oops.In("di").Code("container_closed").Errorf("resolve service: container is closed")
+	}
+
+	return nil
+}
+
 // ConfigService resolves the configuration service.
-func (c *Container) ConfigService() *ConfigService {
-	return do.MustInvoke[*ConfigService](c.injector)
+func (c *Container) ConfigService() (*ConfigService, error) {
+	if err := c.lockForResolution(); err != nil {
+		return nil, err
+	}
+	defer c.lifecycle.Unlock()
+
+	return do.Invoke[*ConfigService](c.injector)
 }
 
 // AuthService resolves the auth service.
-func (c *Container) AuthService() *AuthService {
-	return do.MustInvoke[*AuthService](c.injector)
+func (c *Container) AuthService() (*AuthService, error) {
+	if err := c.lockForResolution(); err != nil {
+		return nil, err
+	}
+	defer c.lifecycle.Unlock()
+
+	return do.Invoke[*AuthService](c.injector)
 }
 
 // DatabaseService resolves the database service.
-func (c *Container) DatabaseService() *DatabaseService {
-	return do.MustInvoke[*DatabaseService](c.injector)
+func (c *Container) DatabaseService() (*DatabaseService, error) {
+	if err := c.lockForResolution(); err != nil {
+		return nil, err
+	}
+	defer c.lifecycle.Unlock()
+
+	return do.Invoke[*DatabaseService](c.injector)
 }
 
 // ExtensionService resolves the extension service.
-func (c *Container) ExtensionService() *ExtensionService {
-	return do.MustInvoke[*ExtensionService](c.injector)
+func (c *Container) ExtensionService() (*ExtensionService, error) {
+	if err := c.lockForResolution(); err != nil {
+		return nil, err
+	}
+	defer c.lifecycle.Unlock()
+
+	return do.Invoke[*ExtensionService](c.injector)
 }
 
 // ModelService resolves the model service.
-func (c *Container) ModelService() *ModelService {
-	return do.MustInvoke[*ModelService](c.injector)
+func (c *Container) ModelService() (*ModelService, error) {
+	if err := c.lockForResolution(); err != nil {
+		return nil, err
+	}
+	defer c.lifecycle.Unlock()
+
+	return do.Invoke[*ModelService](c.injector)
 }
 
-// AssistantService resolves the assistant runtime and initializes background agents.
-func (c *Container) AssistantService() *AssistantService {
-	service := do.MustInvoke[*AssistantService](c.injector)
-	do.MustInvoke[*AgentTaskService](c.injector)
+// AssistantService resolves the assistant runtime without starting workers.
+func (c *Container) AssistantService() (*AssistantService, error) {
+	if err := c.lockForResolution(); err != nil {
+		return nil, err
+	}
+	defer c.lifecycle.Unlock()
 
-	return service
+	return do.Invoke[*AssistantService](c.injector)
 }
 
-// AgentTaskService resolves the durable background agent service.
-func (c *Container) AgentTaskService() *AgentTaskService {
-	return do.MustInvoke[*AgentTaskService](c.injector)
+// AgentTaskService resolves the inert durable background agent service.
+func (c *Container) AgentTaskService() (*AgentTaskService, error) {
+	if err := c.lockForResolution(); err != nil {
+		return nil, err
+	}
+	defer c.lifecycle.Unlock()
+
+	return do.Invoke[*AgentTaskService](c.injector)
 }
 
-// WorkflowService resolves script-driven durable agent orchestration.
-func (c *Container) WorkflowService() *WorkflowService {
-	return do.MustInvoke[*WorkflowService](c.injector)
+// WorkflowService resolves inert script-driven durable agent orchestration.
+func (c *Container) WorkflowService() (*WorkflowService, error) {
+	if err := c.lockForResolution(); err != nil {
+		return nil, err
+	}
+	defer c.lifecycle.Unlock()
+
+	return do.Invoke[*WorkflowService](c.injector)
 }
 
-// ChatWorkflowService resolves the interactive workflow dispatcher.
-func (c *Container) ChatWorkflowService() *ChatWorkflowService {
-	return do.MustInvoke[*ChatWorkflowService](c.injector)
+// ChatWorkflowService resolves the inert interactive workflow dispatcher.
+func (c *Container) ChatWorkflowService() (*ChatWorkflowService, error) {
+	if err := c.lockForResolution(); err != nil {
+		return nil, err
+	}
+	defer c.lifecycle.Unlock()
+
+	return do.Invoke[*ChatWorkflowService](c.injector)
 }
 
 // ToolService resolves the tool service.
-func (c *Container) ToolService() *ToolService {
-	return do.MustInvoke[*ToolService](c.injector)
+func (c *Container) ToolService() (*ToolService, error) {
+	if err := c.lockForResolution(); err != nil {
+		return nil, err
+	}
+	defer c.lifecycle.Unlock()
+
+	return do.Invoke[*ToolService](c.injector)
 }
 
 // SkillsService resolves the skills cache service.
-func (c *Container) SkillsService() *SkillsService {
-	return do.MustInvoke[*SkillsService](c.injector)
+func (c *Container) SkillsService() (*SkillsService, error) {
+	if err := c.lockForResolution(); err != nil {
+		return nil, err
+	}
+	defer c.lifecycle.Unlock()
+
+	return do.Invoke[*SkillsService](c.injector)
 }

--- a/internal/di/database_service.go
+++ b/internal/di/database_service.go
@@ -36,7 +36,19 @@ type DatabaseService struct {
 
 // NewDatabaseService opens the session database and applies embedded migrations.
 func NewDatabaseService(injector do.Injector) (*DatabaseService, error) {
-	cfg := do.MustInvoke[*ConfigService](injector).Get()
+	cfg, err := databaseConfig(injector)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, err := applicationContext(injector)
+	if err != nil {
+		return nil, err
+	}
+
+	if contextErr := ctx.Err(); contextErr != nil {
+		return nil, oops.In("database").Code("startup_canceled").Wrapf(contextErr, "initialize database")
+	}
 
 	databasePath, err := resolveDatabasePath(cfg)
 	if err != nil {
@@ -48,11 +60,20 @@ func NewDatabaseService(injector do.Injector) (*DatabaseService, error) {
 		return nil, oops.In("database").Code("mkdir").With("path", databasePath).Wrapf(mkdirErr, "create database dir")
 	}
 
-	connection, err := openSQLiteDatabase(databasePath, cfg.Database)
+	connection, err := openSQLiteDatabase(ctx, databasePath, cfg.Database)
 	if err != nil {
 		return nil, err
 	}
 
+	service, err := newDatabaseRepositories(connection, databasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return service, nil
+}
+
+func newDatabaseRepositories(connection *sql.DB, databasePath string) (*DatabaseService, error) {
 	sqlProvider, err := ksqlite.NewFromSQLDB(connection)
 	if err != nil {
 		return nil, closeAfterSetupError(connection, "close_after_sql_provider", "sql_provider", databasePath, err)
@@ -84,14 +105,18 @@ func NewDatabaseService(injector do.Injector) (*DatabaseService, error) {
 	}
 
 	return &DatabaseService{
-		DB:         connection,
-		Sessions:   sessions,
-		Documents:  documents,
-		Tasks:      tasks,
-		AgentTasks: agentTasks,
-		Workflows:  workflows,
-		path:       databasePath,
+		DB: connection, Sessions: sessions, Documents: documents, Tasks: tasks,
+		AgentTasks: agentTasks, Workflows: workflows, path: databasePath,
 	}, nil
+}
+
+func databaseConfig(injector do.Injector) (*config.Config, error) {
+	configService, err := do.Invoke[*ConfigService](injector)
+	if err != nil {
+		return nil, err
+	}
+
+	return configService.Get(), nil
 }
 
 // Path returns the resolved session database path.
@@ -118,7 +143,7 @@ func (service *DatabaseService) Shutdown(ctx context.Context) error {
 	}
 }
 
-func openSQLiteDatabase(databasePath string, cfg config.DatabaseConfig) (*sql.DB, error) {
+func openSQLiteDatabase(ctx context.Context, databasePath string, cfg config.DatabaseConfig) (*sql.DB, error) {
 	dsn := database.SQLiteDSN(databasePath, database.SQLiteOptions{BusyTimeout: cfg.BusyTimeout})
 
 	connection, err := sql.Open(sqliteDriverName, dsn)
@@ -130,8 +155,7 @@ func openSQLiteDatabase(databasePath string, cfg config.DatabaseConfig) (*sql.DB
 	connection.SetMaxIdleConns(cfg.MaxIdleConns)
 	connection.SetConnMaxLifetime(cfg.ConnMaxLifetime)
 
-	setupCtx := context.Background()
-	if err := setupSQLiteDatabase(setupCtx, connection, databasePath, cfg); err != nil {
+	if err := setupSQLiteDatabase(ctx, connection, databasePath, cfg); err != nil {
 		return nil, err
 	}
 

--- a/internal/di/database_service_internal_test.go
+++ b/internal/di/database_service_internal_test.go
@@ -23,7 +23,7 @@ func TestOpenSQLiteDatabaseAppliesPragmasAndMigrations(t *testing.T) {
 	t.Parallel()
 
 	databasePath := filepath.Join(t.TempDir(), "librecode.db")
-	connection, err := openSQLiteDatabase(databasePath, config.DatabaseConfig{
+	connection, err := openSQLiteDatabase(context.Background(), databasePath, config.DatabaseConfig{
 		Path:            "",
 		ApplyMigrations: true,
 		MaxOpenConns:    1,
@@ -57,6 +57,7 @@ func TestNewDatabaseServiceSharesCompositeRepositories(t *testing.T) {
 	cfg.Database.ApplyMigrations = true
 
 	injector := do.New()
+	provideTestApplicationContext(injector)
 	do.ProvideValue(injector, &ConfigService{cfg: cfg, path: "", interactive: false})
 	service, err := NewDatabaseService(injector)
 	require.NoError(t, err)
@@ -65,6 +66,24 @@ func TestNewDatabaseServiceSharesCompositeRepositories(t *testing.T) {
 	assert.Same(t, service.Tasks, service.AgentTasks.Tasks())
 	assert.Same(t, service.Tasks, service.Workflows.Tasks())
 	assert.Same(t, service.AgentTasks, service.Workflows.AgentTasks())
+}
+
+func TestNewDatabaseServiceHonorsCanceledApplicationContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := testServiceConfig()
+	cfg.Database.Path = filepath.Join(t.TempDir(), "librecode.db")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	injector := do.New()
+	do.ProvideNamedValue(injector, applicationContextKey, ctx)
+	do.ProvideValue(injector, &ConfigService{cfg: cfg, path: "", interactive: false})
+
+	service, err := NewDatabaseService(injector)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, service)
 }
 
 func TestDatabaseServiceHealthCheckAndShutdown(t *testing.T) {

--- a/internal/di/extension_service.go
+++ b/internal/di/extension_service.go
@@ -1,7 +1,6 @@
 package di
 
 import (
-	"context"
 	"path/filepath"
 
 	"github.com/samber/do/v2"
@@ -19,10 +18,19 @@ type ExtensionService struct {
 
 // NewExtensionService loads configured Lua extensions.
 func NewExtensionService(injector do.Injector) (*ExtensionService, error) {
-	configService := do.MustInvoke[*ConfigService](injector)
+	configService, err := do.Invoke[*ConfigService](injector)
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := configService.Get()
-	logger := do.MustInvoke[*LoggerService](injector).SlogLogger
-	manager := extension.NewManager(logger)
+
+	loggerService, err := do.Invoke[*LoggerService](injector)
+	if err != nil {
+		return nil, err
+	}
+
+	manager := extension.NewManager(loggerService.SlogLogger)
 	state := extension.ManagerState{Configured: []extension.ResolvedSource{}, Loaded: []extension.LoadedExtension{}}
 
 	if cfg.Extensions.Enabled {
@@ -34,7 +42,17 @@ func NewExtensionService(injector do.Injector) (*ExtensionService, error) {
 		state.Configured = resolvedSources
 
 		paths := extensionLoadPaths(resolvedSources)
-		if err := manager.LoadPaths(context.Background(), paths); err != nil {
+
+		ctx, err := applicationContext(injector)
+		if err != nil {
+			manager.Shutdown()
+
+			return nil, err
+		}
+
+		if err := manager.LoadPaths(ctx, paths); err != nil {
+			manager.Shutdown()
+
 			return nil, oops.In("extension").Code("load_extensions").Wrapf(err, "load lua extensions")
 		}
 

--- a/internal/di/extension_service_behavior_internal_test.go
+++ b/internal/di/extension_service_behavior_internal_test.go
@@ -27,14 +27,20 @@ func TestExtensionServiceUsesProjectLockfile(t *testing.T) {
 
 	writeDIFile(t, projectLock, []byte("extensions:\n  github:owner/repo:\n    version: v9.9.9\n"))
 
-	container, err := NewContainer("", ConfigOverrides{DisableExtensions: false, Interactive: false})
+	container, err := NewContainer(context.Background(), "", ConfigOverrides{
+		DisableExtensions: false,
+		Interactive:       false,
+	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		report := container.ShutdownWithContext(context.Background())
 		assert.True(t, report.Succeed, report.Error())
 	})
 
-	state := container.ExtensionService().State
+	service, err := container.ExtensionService()
+	require.NoError(t, err)
+
+	state := service.State
 	require.Len(t, state.Configured, 1)
 	assert.Equal(t, "v9.9.9", state.Configured[0].Lock.Version)
 }

--- a/internal/di/home_paths_test.go
+++ b/internal/di/home_paths_test.go
@@ -36,13 +36,14 @@ func TestAuthServicePrefersProjectLibrecodeAuth(t *testing.T) {
 		Interactive:       false,
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.True(t, container.ShutdownWithContext(context.Background()).Succeed)
+	})
 
 	authService, err := container.AuthService()
 	require.NoError(t, err)
 
 	storage := authService.Storage
-
-	t.Cleanup(func() { require.True(t, container.ShutdownWithContext(t.Context()).Succeed) })
 
 	assert.True(t, storage.HasStored("project-provider"))
 	assert.False(t, storage.HasStored("global-provider"))
@@ -64,11 +65,12 @@ func TestDatabaseServicePrefersProjectLibrecodeDatabase(t *testing.T) {
 		Interactive:       false,
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.True(t, container.ShutdownWithContext(context.Background()).Succeed)
+	})
 
 	databaseService, err := container.DatabaseService()
 	require.NoError(t, err)
-
-	t.Cleanup(func() { _ = container.ShutdownWithContext(t.Context()).Succeed })
 
 	assert.Equal(t, projectPath, databaseService.Path())
 }

--- a/internal/di/home_paths_test.go
+++ b/internal/di/home_paths_test.go
@@ -1,6 +1,7 @@
 package di_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,10 +31,16 @@ func TestAuthServicePrefersProjectLibrecodeAuth(t *testing.T) {
 	require.NoError(t, os.WriteFile(projectAuthPath, projectAuth, 0o600))
 	require.NoError(t, os.WriteFile(globalAuthPath, globalAuth, 0o600))
 
-	container, err := di.NewContainer("", di.ConfigOverrides{DisableExtensions: false, Interactive: false})
+	container, err := di.NewContainer(context.Background(), "", di.ConfigOverrides{
+		DisableExtensions: false,
+		Interactive:       false,
+	})
 	require.NoError(t, err)
 
-	storage := container.AuthService().Storage
+	authService, err := container.AuthService()
+	require.NoError(t, err)
+
+	storage := authService.Storage
 
 	t.Cleanup(func() { require.True(t, container.ShutdownWithContext(t.Context()).Succeed) })
 
@@ -52,10 +59,14 @@ func TestDatabaseServicePrefersProjectLibrecodeDatabase(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Dir(projectPath), 0o700))
 	require.NoError(t, os.WriteFile(projectPath, nil, 0o600))
 
-	container, err := di.NewContainer("", di.ConfigOverrides{DisableExtensions: false, Interactive: false})
+	container, err := di.NewContainer(context.Background(), "", di.ConfigOverrides{
+		DisableExtensions: false,
+		Interactive:       false,
+	})
 	require.NoError(t, err)
 
-	databaseService := container.DatabaseService()
+	databaseService, err := container.DatabaseService()
+	require.NoError(t, err)
 
 	t.Cleanup(func() { _ = container.ShutdownWithContext(t.Context()).Succeed })
 

--- a/internal/di/logger_service.go
+++ b/internal/di/logger_service.go
@@ -20,7 +20,11 @@ type LoggerService struct {
 
 // NewLoggerService configures application logging from the resolved config.
 func NewLoggerService(injector do.Injector) (*LoggerService, error) {
-	configService := do.MustInvoke[*ConfigService](injector)
+	configService, err := do.Invoke[*ConfigService](injector)
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := configService.Get()
 	zerologLogger := newZerologLogger(cfg, loggerWriter(configService))
 

--- a/internal/di/model_service.go
+++ b/internal/di/model_service.go
@@ -17,12 +17,29 @@ type ModelService struct {
 
 // NewModelService wires librecode-style model registry loading.
 func NewModelService(injector do.Injector) (*ModelService, error) {
-	configService := do.MustInvoke[*ConfigService](injector)
-	databaseService := do.MustInvoke[*DatabaseService](injector)
-	authStorage := do.MustInvoke[*AuthService](injector).Storage
-	registry := model.NewRegistry(&model.RegistryOptions{
+	configService, err := do.Invoke[*ConfigService](injector)
+	if err != nil {
+		return nil, err
+	}
+
+	databaseService, err := do.Invoke[*DatabaseService](injector)
+	if err != nil {
+		return nil, err
+	}
+
+	authService, err := do.Invoke[*AuthService](injector)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, err := applicationContext(injector)
+	if err != nil {
+		return nil, err
+	}
+
+	registry := model.NewRegistryContext(ctx, &model.RegistryOptions{
 		ConfigReader: database.NewDocumentSource(databaseService.Documents, "model", "models"),
-		Auth:         authStorage,
+		Auth:         authService.Storage,
 		ModelsPath:   "",
 		BuiltIns:     nil,
 		Discovery: model.DiscoveryOptions{
@@ -34,6 +51,9 @@ func NewModelService(injector do.Injector) (*ModelService, error) {
 			Enabled:      configService.Get().Models.Discovery.Enabled,
 		},
 	})
+	if err := registry.Error(); err != nil {
+		return nil, serviceError(err, "load model registry")
+	}
 
 	return &ModelService{Registry: registry}, nil
 }

--- a/internal/di/model_service.go
+++ b/internal/di/model_service.go
@@ -51,7 +51,7 @@ func NewModelService(injector do.Injector) (*ModelService, error) {
 			Enabled:      configService.Get().Models.Discovery.Enabled,
 		},
 	})
-	if err := registry.Error(); err != nil {
+	if err := registry.ConfigError(); err != nil {
 		return nil, serviceError(err, "load model registry")
 	}
 

--- a/internal/di/model_service_internal_test.go
+++ b/internal/di/model_service_internal_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/omarluq/librecode/internal/testutil"
 )
 
-func TestNewModelServiceWiresRegistryDiscovery(t *testing.T) {
+func TestNewModelServiceKeepsRegistryAvailableWhenDiscoveryFails(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("LIBRECODE_HOME", home)
 	db := newModelServiceTestDB(t)
@@ -26,10 +26,10 @@ func TestNewModelServiceWiresRegistryDiscovery(t *testing.T) {
 
 	cfg := config.Load("").MustGet()
 	cfg.Models.Discovery = config.ModelDiscoveryConfig{
-		SourceURL:    "https://models.invalid/api.json",
+		SourceURL:    "",
 		CacheTTL:     0,
 		FetchTimeout: 0,
-		Enabled:      false,
+		Enabled:      true,
 	}
 	injector := do.New()
 	provideTestApplicationContext(injector)
@@ -48,6 +48,8 @@ func TestNewModelServiceWiresRegistryDiscovery(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, service.Registry)
 	assert.NotEmpty(t, service.Registry.All())
+	require.NoError(t, service.Registry.ConfigError())
+	require.Error(t, service.Registry.DiscoveryError())
 	assert.Equal(t, filepath.Join(home, "models-dev.json"), modelDiscoveryCachePath())
 
 	discovery := service.Registry.DiscoveryOptions()

--- a/internal/di/model_service_internal_test.go
+++ b/internal/di/model_service_internal_test.go
@@ -32,6 +32,7 @@ func TestNewModelServiceWiresRegistryDiscovery(t *testing.T) {
 		Enabled:      false,
 	}
 	injector := do.New()
+	provideTestApplicationContext(injector)
 	do.ProvideValue(injector, &ConfigService{cfg: cfg, path: "", interactive: false})
 	do.ProvideValue(injector, &DatabaseService{
 		DB:         nil,

--- a/internal/di/service_constructors_internal_test.go
+++ b/internal/di/service_constructors_internal_test.go
@@ -117,6 +117,16 @@ func newTestAssistantService(t *testing.T, injector do.Injector) *AssistantServi
 	return service
 }
 
+func TestNewContainerRejectsNilContext(t *testing.T) {
+	t.Parallel()
+
+	var ctx context.Context
+
+	container, err := NewContainer(ctx, "", ConfigOverrides{DisableExtensions: false, Interactive: false})
+	assert.Nil(t, container)
+	assert.ErrorContains(t, err, "application context is required")
+}
+
 func TestContainerAccessorReturnsConstructionError(t *testing.T) {
 	homeFile := filepath.Join(t.TempDir(), "home-file")
 	require.NoError(t, os.WriteFile(homeFile, []byte("not a directory"), 0o600))
@@ -317,6 +327,10 @@ func TestStartRuntimeStartsWorkersExplicitly(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, runtimeServices)
 
+	repeatedServices, err := container.StartRuntime()
+	require.NoError(t, err)
+	assert.Same(t, runtimeServices, repeatedServices)
+
 	agentTasks, err := container.AgentTaskService()
 	require.NoError(t, err)
 	require.NotNil(t, agentTasks.Tasks)
@@ -328,6 +342,29 @@ func TestStartRuntimeStartsWorkersExplicitly(t *testing.T) {
 	chatWorkflows, err := container.ChatWorkflowService()
 	require.NoError(t, err)
 	require.NotNil(t, chatWorkflows.Dispatcher)
+}
+
+func TestContainerRejectsResolutionAfterShutdown(t *testing.T) {
+	t.Parallel()
+
+	container, err := NewContainer(context.Background(), "", ConfigOverrides{
+		DisableExtensions: true,
+		Interactive:       false,
+	})
+	require.NoError(t, err)
+	assert.True(t, container.ShutdownWithContext(context.Background()).Succeed)
+	assert.True(t, container.ShutdownWithContext(context.Background()).Succeed)
+
+	runtimeServices, err := container.StartRuntime()
+	assert.Nil(t, runtimeServices)
+	require.ErrorContains(t, err, "container is closed")
+
+	services := containerServiceAccessors(container)
+	for _, resolve := range services {
+		service, resolveErr := resolve()
+		assert.Nil(t, service)
+		assert.ErrorContains(t, resolveErr, "container is closed")
+	}
 }
 
 func TestContainerServiceAccessors(t *testing.T) {
@@ -343,7 +380,16 @@ func TestContainerServiceAccessors(t *testing.T) {
 		assert.Empty(t, report.Errors)
 	})
 
-	services := []func() (any, error){
+	services := containerServiceAccessors(container)
+	for _, resolve := range services {
+		service, resolveErr := resolve()
+		require.NoError(t, resolveErr)
+		require.NotNil(t, service)
+	}
+}
+
+func containerServiceAccessors(container *Container) []func() (any, error) {
+	return []func() (any, error){
 		func() (any, error) { return container.ConfigService() },
 		func() (any, error) { return container.AuthService() },
 		func() (any, error) { return container.DatabaseService() },
@@ -355,10 +401,5 @@ func TestContainerServiceAccessors(t *testing.T) {
 		func() (any, error) { return container.ChatWorkflowService() },
 		func() (any, error) { return container.ToolService() },
 		func() (any, error) { return container.SkillsService() },
-	}
-	for _, resolve := range services {
-		service, resolveErr := resolve()
-		require.NoError(t, resolveErr)
-		require.NotNil(t, service)
 	}
 }

--- a/internal/di/service_constructors_internal_test.go
+++ b/internal/di/service_constructors_internal_test.go
@@ -278,6 +278,8 @@ func TestStartRuntimeDoesNotPublishAfterCancellation(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	container, err := NewContainer(ctx, "", ConfigOverrides{
 		DisableExtensions: true,
 		Interactive:       false,

--- a/internal/di/service_constructors_internal_test.go
+++ b/internal/di/service_constructors_internal_test.go
@@ -2,16 +2,25 @@ package di
 
 import (
 	"context"
+	"errors"
+	"os"
 	"path/filepath"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/samber/do/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/omarluq/librecode/internal/config"
 )
+
+func provideTestApplicationContext(injector do.Injector) {
+	do.ProvideNamedValue(injector, applicationContextKey, context.Background())
+}
 
 func TestNewCacheServiceUsesConfiguredCache(t *testing.T) {
 	t.Parallel()
@@ -50,10 +59,13 @@ func TestNewAgentTaskServiceRejectsIncompleteWiring(t *testing.T) {
 	t.Parallel()
 
 	injector := do.New()
+	provideTestApplicationContext(injector)
 	do.ProvideValue(injector, &DatabaseService{
 		DB: nil, Sessions: nil, Documents: nil, Tasks: nil, AgentTasks: nil, Workflows: nil, path: "",
 	})
 	do.ProvideValue(injector, &AssistantService{Runtime: nil, Agents: nil})
+
+	do.ProvideValue(injector, &LoggerService{SlogLogger: nil, ZerologLogger: zerolog.Logger{}})
 
 	service, err := NewAgentTaskService(injector)
 	require.ErrorContains(t, err, "create agent task runner")
@@ -64,26 +76,33 @@ func TestNewAgentTaskServiceWrapsSchedulerError(t *testing.T) {
 	t.Parallel()
 
 	injector := do.New()
+	provideTestApplicationContext(injector)
+
 	databaseService := newTestDatabaseService(t)
 	databaseService.Tasks = nil
 	do.ProvideValue(injector, databaseService)
 	do.ProvideValue(injector, newTestAssistantService(t, injector))
 
 	service, err := NewAgentTaskService(injector)
+	require.NoError(t, err)
+
+	err = service.Start(t.Context())
 	require.ErrorContains(t, err, "create agent task service")
-	assert.Nil(t, service)
 }
 
 func TestAgentTaskServiceWiresAndShutsDown(t *testing.T) {
 	t.Parallel()
 
 	injector := do.New()
+	provideTestApplicationContext(injector)
 	do.ProvideValue(injector, newTestDatabaseService(t))
 	assistant := newTestAssistantService(t, injector)
 	do.ProvideValue(injector, assistant)
 
 	service, err := NewAgentTaskService(injector)
 	require.NoError(t, err)
+	require.Nil(t, service.Tasks)
+	require.NoError(t, service.Start(t.Context()))
 	require.NotNil(t, service.Tasks)
 	require.NoError(t, service.Shutdown(context.Background()))
 }
@@ -98,25 +117,246 @@ func newTestAssistantService(t *testing.T, injector do.Injector) *AssistantServi
 	return service
 }
 
-func TestContainerServiceAccessors(t *testing.T) {
-	t.Parallel()
+func TestContainerAccessorReturnsConstructionError(t *testing.T) {
+	homeFile := filepath.Join(t.TempDir(), "home-file")
+	require.NoError(t, os.WriteFile(homeFile, []byte("not a directory"), 0o600))
+	t.Setenv("LIBRECODE_HOME", homeFile)
 
-	container, err := NewContainer("", ConfigOverrides{DisableExtensions: false, Interactive: false})
+	container, err := NewContainer(context.Background(), "", ConfigOverrides{
+		DisableExtensions: true,
+		Interactive:       false,
+	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		report := container.ShutdownWithContext(context.Background())
 		assert.Empty(t, report.Errors)
 	})
 
-	require.NotNil(t, container.ConfigService())
-	require.NotNil(t, container.AuthService())
-	require.NotNil(t, container.DatabaseService())
-	require.NotNil(t, container.ExtensionService())
-	require.NotNil(t, container.ModelService())
-	require.NotNil(t, container.AssistantService())
-	require.NotNil(t, container.AgentTaskService())
-	require.NotNil(t, container.WorkflowService())
-	require.NotNil(t, container.ChatWorkflowService())
-	require.NotNil(t, container.ToolService())
-	require.NotNil(t, container.SkillsService())
+	service, err := container.DatabaseService()
+	require.Error(t, err)
+	assert.Nil(t, service)
+	assert.Contains(t, err.Error(), "create database dir")
+}
+
+func TestStartRuntimeRejectsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	container, err := NewContainer(ctx, "", ConfigOverrides{
+		DisableExtensions: true,
+		Interactive:       false,
+	})
+	require.NoError(t, err)
+
+	services, err := container.StartRuntime()
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, services)
+}
+
+func TestAssistantServiceAccessorDoesNotStartWorkers(t *testing.T) {
+	t.Parallel()
+
+	container, err := NewContainer(context.Background(), "", ConfigOverrides{
+		DisableExtensions: true,
+		Interactive:       false,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		report := container.ShutdownWithContext(context.Background())
+		assert.Empty(t, report.Errors)
+	})
+
+	_, err = container.AssistantService()
+	require.NoError(t, err)
+
+	agentTasks, err := container.AgentTaskService()
+	require.NoError(t, err)
+	assert.Nil(t, agentTasks.Tasks)
+
+	workflows, err := container.WorkflowService()
+	require.NoError(t, err)
+	assert.Nil(t, workflows.Runs)
+
+	chatWorkflows, err := container.ChatWorkflowService()
+	require.NoError(t, err)
+	assert.Nil(t, chatWorkflows.Dispatcher)
+}
+
+func TestStartRuntimeCleansUpPartialConstruction(t *testing.T) {
+	t.Parallel()
+
+	container, err := NewContainer(context.Background(), "", ConfigOverrides{
+		DisableExtensions: true,
+		Interactive:       false,
+	})
+	require.NoError(t, err)
+
+	recorder := new(shutdownRecorder)
+	do.ProvideValue(container.injector, recorder)
+	do.Provide(container.injector, newBootstrapParent)
+	do.Provide(container.injector, newBootstrapChild)
+
+	expectedErr := errors.New("runtime construction failed")
+	container.buildRuntime = func(context.Context) (*RuntimeServices, error) {
+		if _, resolveErr := do.Invoke[*bootstrapChild](container.injector); resolveErr != nil {
+			return nil, resolveErr
+		}
+
+		return nil, expectedErr
+	}
+
+	runtimeServices, err := container.StartRuntime()
+	require.ErrorIs(t, err, expectedErr)
+	assert.Nil(t, runtimeServices)
+	assert.Equal(t, []string{"child", "parent"}, recorder.snapshot())
+
+	_, err = container.DatabaseService()
+	assert.Error(t, err)
+}
+
+// shutdownRecorder records lifecycle order without relying on timing or goroutine counts.
+type shutdownRecorder struct {
+	events []string
+	mu     sync.Mutex
+}
+
+func (recorder *shutdownRecorder) append(event string) {
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+
+	recorder.events = append(recorder.events, event)
+}
+
+func (recorder *shutdownRecorder) snapshot() []string {
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+
+	return slices.Clone(recorder.events)
+}
+
+type bootstrapParent struct {
+	recorder *shutdownRecorder
+}
+
+func newBootstrapParent(injector do.Injector) (*bootstrapParent, error) {
+	recorder, err := do.Invoke[*shutdownRecorder](injector)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bootstrapParent{recorder: recorder}, nil
+}
+
+func (resource *bootstrapParent) Shutdown(context.Context) error {
+	resource.recorder.append("parent")
+
+	return nil
+}
+
+type bootstrapChild struct {
+	recorder *shutdownRecorder
+}
+
+func newBootstrapChild(injector do.Injector) (*bootstrapChild, error) {
+	parent, err := do.Invoke[*bootstrapParent](injector)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bootstrapChild{recorder: parent.recorder}, nil
+}
+
+func (resource *bootstrapChild) Shutdown(context.Context) error {
+	resource.recorder.append("child")
+
+	return nil
+}
+
+func TestStartRuntimeDoesNotPublishAfterCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	container, err := NewContainer(ctx, "", ConfigOverrides{
+		DisableExtensions: true,
+		Interactive:       false,
+	})
+	require.NoError(t, err)
+
+	container.buildRuntime = func(context.Context) (*RuntimeServices, error) {
+		cancel()
+
+		return new(RuntimeServices), nil
+	}
+
+	runtimeServices, err := container.StartRuntime()
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, runtimeServices)
+
+	_, err = container.ConfigService()
+	assert.Error(t, err)
+}
+
+func TestStartRuntimeStartsWorkersExplicitly(t *testing.T) {
+	t.Parallel()
+
+	container, err := NewContainer(context.Background(), "", ConfigOverrides{
+		DisableExtensions: true,
+		Interactive:       false,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		report := container.ShutdownWithContext(context.Background())
+		assert.Empty(t, report.Errors)
+	})
+
+	runtimeServices, err := container.StartRuntime()
+	require.NoError(t, err)
+	require.NotNil(t, runtimeServices)
+
+	agentTasks, err := container.AgentTaskService()
+	require.NoError(t, err)
+	require.NotNil(t, agentTasks.Tasks)
+
+	workflows, err := container.WorkflowService()
+	require.NoError(t, err)
+	require.NotNil(t, workflows.Runs)
+
+	chatWorkflows, err := container.ChatWorkflowService()
+	require.NoError(t, err)
+	require.NotNil(t, chatWorkflows.Dispatcher)
+}
+
+func TestContainerServiceAccessors(t *testing.T) {
+	t.Parallel()
+
+	container, err := NewContainer(context.Background(), "", ConfigOverrides{
+		DisableExtensions: false,
+		Interactive:       false,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		report := container.ShutdownWithContext(context.Background())
+		assert.Empty(t, report.Errors)
+	})
+
+	services := []func() (any, error){
+		func() (any, error) { return container.ConfigService() },
+		func() (any, error) { return container.AuthService() },
+		func() (any, error) { return container.DatabaseService() },
+		func() (any, error) { return container.ExtensionService() },
+		func() (any, error) { return container.ModelService() },
+		func() (any, error) { return container.AssistantService() },
+		func() (any, error) { return container.AgentTaskService() },
+		func() (any, error) { return container.WorkflowService() },
+		func() (any, error) { return container.ChatWorkflowService() },
+		func() (any, error) { return container.ToolService() },
+		func() (any, error) { return container.SkillsService() },
+	}
+	for _, resolve := range services {
+		service, resolveErr := resolve()
+		require.NoError(t, resolveErr)
+		require.NotNil(t, service)
+	}
 }

--- a/internal/di/workflow_service.go
+++ b/internal/di/workflow_service.go
@@ -11,46 +11,74 @@ import (
 
 // WorkflowService owns script-driven durable agent orchestration.
 type WorkflowService struct {
-	Runner *workflow.Runner
-	Runs   *workflow.Service
+	Runner     *workflow.Runner
+	Runs       *workflow.Service
+	database   *DatabaseService
+	assistant  *AssistantService
+	agentTasks *AgentTaskService
 }
 
 // NewWorkflowService wires workflow execution to the durable agent scheduler.
 func NewWorkflowService(injector do.Injector) (*WorkflowService, error) {
-	databaseService := do.MustInvoke[*DatabaseService](injector)
-	assistantService := do.MustInvoke[*AssistantService](injector)
-	agentTaskService := do.MustInvoke[*AgentTaskService](injector)
+	databaseService, err := do.Invoke[*DatabaseService](injector)
+	if err != nil {
+		return nil, serviceError(err, "resolve database service")
+	}
+
+	assistantService, err := do.Invoke[*AssistantService](injector)
+	if err != nil {
+		return nil, serviceError(err, "resolve assistant service")
+	}
+
+	agentTaskService, err := do.Invoke[*AgentTaskService](injector)
+	if err != nil {
+		return nil, serviceError(err, "resolve agent task service")
+	}
+
+	return &WorkflowService{
+		Runner: nil, Runs: nil, database: databaseService, assistant: assistantService, agentTasks: agentTaskService,
+	}, nil
+}
+
+// Start constructs workflow orchestration and recovers interrupted runs.
+func (service *WorkflowService) Start(ctx context.Context) error {
+	if service.Runs != nil {
+		return nil
+	}
 
 	submitter, err := assistant.NewAgentSubmitter(
-		agentTaskService.Tasks,
-		assistantService.Agents,
+		service.agentTasks.Tasks,
+		service.assistant.Agents,
 	)
 	if err != nil {
-		return nil, serviceError(err, "create workflow agent submitter")
+		return serviceError(err, "create workflow agent submitter")
 	}
 
 	controller, err := assistant.NewWorkflowController(
 		submitter,
-		agentTaskService.Tasks,
-		databaseService.Sessions,
+		service.agentTasks.Tasks,
+		service.database.Sessions,
 	)
 	if err != nil {
-		return nil, serviceError(err, "create workflow controller")
+		return serviceError(err, "create workflow controller")
 	}
 
 	runner, err := workflow.NewRunner(controller)
 	if err != nil {
-		return nil, serviceError(err, "create workflow runner")
+		return serviceError(err, "create workflow runner")
 	}
 
-	runs, err := workflow.NewService(databaseService.Workflows, runner)
+	runs, err := workflow.NewService(service.database.Workflows, runner)
 	if err != nil {
-		return nil, serviceError(err, "create durable workflow service")
+		return serviceError(err, "create durable workflow service")
 	}
 
-	if _, recoverErr := runs.RecoverInterrupted(context.Background()); recoverErr != nil {
-		return nil, serviceError(recoverErr, "recover interrupted workflows")
+	if _, recoverErr := runs.RecoverInterrupted(ctx); recoverErr != nil {
+		return serviceError(recoverErr, "recover interrupted workflows")
 	}
 
-	return &WorkflowService{Runner: runner, Runs: runs}, nil
+	service.Runner = runner
+	service.Runs = runs
+
+	return nil
 }

--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -44,6 +44,11 @@ type providerRequestConfig struct {
 
 // NewRegistry creates and refreshes a registry.
 func NewRegistry(options *RegistryOptions) *Registry {
+	return NewRegistryContext(context.Background(), options)
+}
+
+// NewRegistryContext creates and refreshes a registry using ctx for discovery.
+func NewRegistryContext(ctx context.Context, options *RegistryOptions) *Registry {
 	resolvedOptions := registryOptions(options)
 	registry := &Registry{
 		configSource:    resolvedOptions.ConfigReader,
@@ -56,7 +61,7 @@ func NewRegistry(options *RegistryOptions) *Registry {
 		lock:            sync.RWMutex{},
 		loadError:       nil,
 	}
-	registry.Refresh()
+	registry.RefreshContext(ctx)
 
 	return registry
 }

--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -25,7 +25,8 @@ type RegistryOptions struct {
 
 // Registry loads built-in and custom models and resolves provider request auth.
 type Registry struct {
-	loadError       error
+	configError     error
+	discoveryError  error
 	configSource    ConfigReader
 	auth            *auth.Storage
 	providerConfigs map[string]providerRequestConfig
@@ -59,7 +60,8 @@ func NewRegistryContext(ctx context.Context, options *RegistryOptions) *Registry
 		builtIns:        cloneModels(resolvedOptions.BuiltIns),
 		discovery:       resolvedOptions.Discovery,
 		lock:            sync.RWMutex{},
-		loadError:       nil,
+		configError:     nil,
+		discoveryError:  nil,
 	}
 	registry.RefreshContext(ctx)
 
@@ -81,16 +83,33 @@ func (registry *Registry) RefreshContext(ctx context.Context) {
 	registry.lock.Lock()
 	registry.models = models
 	registry.providerConfigs = customResult.ProviderConfigs
-	registry.loadError = firstRegistryError(customResult.Err, discoveryErr)
+	registry.configError = customResult.Err
+	registry.discoveryError = discoveryErr
 	registry.lock.Unlock()
 }
 
-// Error returns the latest models.json load error.
+// Error returns the latest model configuration or discovery error.
 func (registry *Registry) Error() error {
 	registry.lock.RLock()
 	defer registry.lock.RUnlock()
 
-	return registry.loadError
+	return firstRegistryError(registry.configError, registry.discoveryError)
+}
+
+// ConfigError returns the latest custom model configuration error.
+func (registry *Registry) ConfigError() error {
+	registry.lock.RLock()
+	defer registry.lock.RUnlock()
+
+	return registry.configError
+}
+
+// DiscoveryError returns the latest model discovery error.
+func (registry *Registry) DiscoveryError() error {
+	registry.lock.RLock()
+	defer registry.lock.RUnlock()
+
+	return registry.discoveryError
 }
 
 // All returns all known models.

--- a/internal/model/registry_internal_test.go
+++ b/internal/model/registry_internal_test.go
@@ -135,6 +135,34 @@ func TestRegistryRequestAuthContextReturnsAuthErrors(t *testing.T) {
 	assert.False(t, resolved.OK)
 }
 
+func TestRegistrySeparatesConfigurationAndDiscoveryErrors(t *testing.T) {
+	t.Parallel()
+
+	builtIn := emptyModel()
+	builtIn.Provider = "test"
+	builtIn.ID = "built-in"
+
+	registry := NewRegistryContext(t.Context(), &RegistryOptions{
+		ConfigReader: nil,
+		Auth:         nil,
+		ModelsPath:   "",
+		BuiltIns:     []Model{builtIn},
+		Discovery: DiscoveryOptions{
+			Client:       nil,
+			CachePath:    "",
+			SourceURL:    "",
+			CacheTTL:     0,
+			FetchTimeout: 0,
+			Enabled:      true,
+		},
+	})
+
+	require.NoError(t, registry.ConfigError())
+	require.Error(t, registry.DiscoveryError())
+	require.Error(t, registry.Error())
+	assert.Len(t, registry.All(), 1)
+}
+
 func TestRegistryOptionsAndFirstRegistryError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/terminal/app.go
+++ b/internal/terminal/app.go
@@ -439,6 +439,8 @@ func (app *App) runLoopStep(
 	dirty bool,
 ) (shouldQuit, nextDirty bool) {
 	select {
+	case <-ctx.Done():
+		return true, false
 	case event := <-app.screen.EventQ():
 		return app.handleLoopEvent(ctx, event)
 	case <-app.workTick(workTicker):

--- a/internal/terminal/app.go
+++ b/internal/terminal/app.go
@@ -438,6 +438,10 @@ func (app *App) runLoopStep(
 	messageWarmTimer *time.Timer,
 	dirty bool,
 ) (shouldQuit, nextDirty bool) {
+	if ctx.Err() != nil {
+		return true, false
+	}
+
 	select {
 	case <-ctx.Done():
 		return true, false

--- a/internal/terminal/render_internal_test.go
+++ b/internal/terminal/render_internal_test.go
@@ -795,6 +795,8 @@ func TestRunLoopStepStopsOnContextCancellation(t *testing.T) {
 	t.Parallel()
 
 	app := newScrollableRenderTestApp(t)
+	app.screen.EventQ() <- tcell.NewEventKey(tcell.KeyRune, "x", tcell.ModNone)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -802,6 +804,7 @@ func TestRunLoopStepStopsOnContextCancellation(t *testing.T) {
 
 	assert.True(t, shouldQuit)
 	assert.False(t, dirty)
+	assert.Empty(t, app.composerBuffer.TextValue())
 }
 
 func runLoopStepWithDormantTimers(t *testing.T, app *App) (shouldQuit, dirty bool) {

--- a/internal/terminal/render_internal_test.go
+++ b/internal/terminal/render_internal_test.go
@@ -791,7 +791,30 @@ func TestRunLoopStepHandlesQueuedEvents(t *testing.T) {
 	}
 }
 
+func TestRunLoopStepStopsOnContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	app := newScrollableRenderTestApp(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	shouldQuit, dirty := runLoopStepWithContextAndDormantTimers(ctx, t, app)
+
+	assert.True(t, shouldQuit)
+	assert.False(t, dirty)
+}
+
 func runLoopStepWithDormantTimers(t *testing.T, app *App) (shouldQuit, dirty bool) {
+	t.Helper()
+
+	return runLoopStepWithContextAndDormantTimers(context.Background(), t, app)
+}
+
+func runLoopStepWithContextAndDormantTimers(
+	ctx context.Context,
+	t *testing.T,
+	app *App,
+) (shouldQuit, dirty bool) {
 	t.Helper()
 
 	workTicker := time.NewTicker(time.Hour)
@@ -807,7 +830,7 @@ func runLoopStepWithDormantTimers(t *testing.T, app *App) (shouldQuit, dirty boo
 	})
 
 	return app.runLoopStep(
-		context.Background(),
+		ctx,
 		workTicker,
 		frameTicker,
 		extensionTimer,


### PR DESCRIPTION
## Summary
- add an explicit, error-returning runtime bootstrap with atomic service publication
- propagate root cancellation through startup and use bounded, idempotent cleanup
- separate worker construction from scheduler, recovery, and dispatcher startup
- add CLI composition and lifecycle regression coverage

## Validation
- mise exec -- go test ./...
- mise exec -- task build
- mise exec -- task ci
- git diff --check