### PR TITLE
refactor(assistant): wire runtime capabilities atomically

### DIFF
--- a/cmd/librecode/chat.go
+++ b/cmd/librecode/chat.go
@@ -113,7 +113,7 @@ func runChatWithContainer(
 		Extensions: services.extension.Manager,
 		Resources:  &resources,
 		Runtime:    runtime,
-		Workflows:  services.workflows.Runs,
+		Workflows:  services.workflows.Runs(),
 		Settings:   services.database.Documents,
 		Models:     services.models.Registry,
 		Auth:       services.auth.Storage,

--- a/cmd/librecode/constants.go
+++ b/cmd/librecode/constants.go
@@ -6,5 +6,6 @@ const (
 	listUse          = "list"
 	modelUse         = "model"
 	noExtensionsFlag = "--no-extensions"
+	promptUse        = "prompt"
 	toolUse          = "tool"
 )

--- a/cmd/librecode/prompt_internal_test.go
+++ b/cmd/librecode/prompt_internal_test.go
@@ -18,8 +18,6 @@ const testSessionName = "named"
 func TestValidatePromptRunOptions(t *testing.T) {
 	t.Parallel()
 
-	const testSessionID = "session-1"
-
 	tests := []struct {
 		wantErr string
 		name    string

--- a/cmd/librecode/runtime_composition_internal_test.go
+++ b/cmd/librecode/runtime_composition_internal_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -23,7 +22,7 @@ func TestChatCompositionStartsRuntimeAndInvokesTerminal(t *testing.T) {
 	cmd.SetContext(t.Context())
 
 	called := false
-	chatOptions := chatRunOptions{SessionID: "", ResumeID: "", Resume: false}
+	chatOptions := chatRunOptions{SessionID: testSessionID, ResumeID: "", Resume: false}
 	err := runChatWithContainer(cmd, container, chatOptions, func(
 		ctx context.Context,
 		options *terminal.RunOptions,
@@ -38,6 +37,12 @@ func TestChatCompositionStartsRuntimeAndInvokesTerminal(t *testing.T) {
 		require.NotNil(t, options.Models)
 		require.NotNil(t, options.Auth)
 		assert.NotNil(t, options.Config)
+		assert.True(t, filepath.IsAbs(options.CWD))
+		assert.Equal(t, chatOptions.SessionID, options.SessionID)
+
+		tasks, err := options.Runtime.AgentTasks(ctx, "missing", 1)
+		require.NoError(t, err)
+		assert.Empty(t, tasks)
 
 		return nil
 	})
@@ -89,6 +94,10 @@ func TestPromptCompositionStartsRuntimeAndInvokesRunner(t *testing.T) {
 			assert.Equal(t, "hello", message)
 			assert.Equal(t, promptOptions, options)
 
+			tasks, err := runtime.AgentTasks(gotCmd.Context(), "missing", 1)
+			require.NoError(t, err)
+			assert.Empty(t, tasks)
+
 			return nil
 		},
 	)
@@ -122,53 +131,70 @@ func TestPromptCompositionPropagatesRunnerError(t *testing.T) {
 func TestRuntimeCompositionRejectsClosedContainer(t *testing.T) {
 	t.Parallel()
 
-	container := newRuntimeTestContainer(t, false)
-	assert.True(t, container.ShutdownWithContext(context.Background()).Succeed)
+	tests := []struct {
+		run  func(*cobra.Command, *di.Container, *bool) error
+		name string
+	}{
+		{
+			name: "chat",
+			run: func(cmd *cobra.Command, container *di.Container, called *bool) error {
+				return runChatWithContainer(
+					cmd,
+					container,
+					chatRunOptions{SessionID: "", ResumeID: "", Resume: false},
+					func(context.Context, *terminal.RunOptions) error {
+						*called = true
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(t.Context())
-
-	chatCalled := false
-	err := runChatWithContainer(cmd, container, chatRunOptions{SessionID: "", ResumeID: "", Resume: false}, func(
-		context.Context,
-		*terminal.RunOptions,
-	) error {
-		chatCalled = true
-
-		return nil
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "start runtime services")
-	assert.False(t, chatCalled)
-
-	promptCalled := false
-	err = runPromptWithContainerAndRunner(
-		cmd,
-		container,
-		promptRunOptions{SessionID: "", SessionName: "", ToolStrategy: "", MetricsJSON: "", Resume: false},
-		"hello",
-		func(*assistant.Runtime, *cobra.Command, promptRunOptions, string) error {
-			promptCalled = true
-
-			return nil
+						return nil
+					},
+				)
+			},
 		},
-	)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "start runtime services")
-	assert.False(t, promptCalled)
+		{
+			name: promptUse,
+			run: func(cmd *cobra.Command, container *di.Container, called *bool) error {
+				return runPromptWithContainerAndRunner(
+					cmd,
+					container,
+					promptRunOptions{
+						SessionID: "", SessionName: "", ToolStrategy: "", MetricsJSON: "", Resume: false,
+					},
+					"hello",
+					func(*assistant.Runtime, *cobra.Command, promptRunOptions, string) error {
+						*called = true
+
+						return nil
+					},
+				)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			container := newRuntimeTestContainer(t, false)
+			require.True(t, container.ShutdownWithContext(context.Background()).Succeed)
+
+			cmd := &cobra.Command{}
+			cmd.SetContext(t.Context())
+
+			called := false
+			err := test.run(cmd, container, &called)
+
+			require.ErrorContains(t, err, "start runtime services")
+			assert.False(t, called)
+		})
+	}
 }
 
 func newRuntimeTestContainer(t *testing.T, interactive bool) *di.Container {
 	t.Helper()
 
-	databasePath := filepath.Join(t.TempDir(), "librecode.db")
-	config := fmt.Sprintf(
-		"database:\n  path: %q\nmodels:\n  discovery:\n    enabled: false\nextensions:\n  use: []\n",
-		databasePath,
-	)
 	container, err := di.NewContainer(
 		t.Context(),
-		writeTestConfig(t, config),
+		writeLifecycleTestConfig(t),
 		di.ConfigOverrides{DisableExtensions: true, Interactive: interactive},
 	)
 	require.NoError(t, err)

--- a/cmd/librecode/runtime_internal_test.go
+++ b/cmd/librecode/runtime_internal_test.go
@@ -178,7 +178,7 @@ func TestCommandsReturnBootstrapErrors(t *testing.T) {
 		args []string
 	}{
 		{name: chatUse, args: []string{chatUse}},
-		{name: "prompt", args: []string{"prompt", "hello"}},
+		{name: promptUse, args: []string{promptUse, "hello"}},
 		{name: "model list", args: []string{modelUse, listUse}},
 		{name: "tool list", args: []string{toolUse, listUse}},
 	}

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,6 @@ github.com/samber/slog-common v0.21.0 h1:Wo2hTly1Br5RjYqX/BTWJJeDnTE85oWk/7vqlpZ
 github.com/samber/slog-common v0.21.0/go.mod h1:d/6OaSlzdkl9PFpfRLgn8FwY1OW6EFmPtBpsHX4MrU0=
 github.com/samber/slog-zerolog/v2 v2.9.2 h1:DIFzfzDTxHeRyGlfg/D7b2by7VVzcsBTybRPrzjWF4c=
 github.com/samber/slog-zerolog/v2 v2.9.2/go.mod h1:2q6cYK2OcN6YfQE/WyCnUtigc+yYf3ozqGsGmRwZR6I=
-github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
-github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 h1:1EYB5IzjZawrrnELUi78f9fPu57HuXjmddZPjrls/28=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.3/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sebdah/goldie/v2 v2.8.0 h1:dZb9wR8q5++oplmEiJT+U/5KyotVD+HNGCAc5gNr8rc=

--- a/internal/agenttask/service.go
+++ b/internal/agenttask/service.go
@@ -184,6 +184,10 @@ func NewStopped(ctx context.Context, options *Options) (*Service, error) {
 
 // Start launches workers and queues recovered tasks.
 func (service *Service) Start(ctx context.Context) error {
+	if ctx == nil {
+		return oops.In("agenttask").Code("nil_start_context").Errorf("start context is required")
+	}
+
 	service.lifecycle.Lock()
 	defer service.lifecycle.Unlock()
 

--- a/internal/agenttask/service.go
+++ b/internal/agenttask/service.go
@@ -93,7 +93,6 @@ type Service struct {
 	runner                     Runner
 	getTaskFn                  func(context.Context, string) (*database.TaskEntity, bool, error)
 	renewLeaseFn               func(context.Context, string, string, time.Time) (bool, error)
-	ctx                        context.Context
 	active                     map[string]context.CancelFunc
 	subscribers                map[string]map[uint64]chan database.TaskEventEntity
 	sessionSlots               map[string]chan struct{}
@@ -156,19 +155,15 @@ func NewStopped(ctx context.Context, options *Options) (*Service, error) {
 		logger = slog.Default()
 	}
 
-	serviceCtx, cancel := context.WithCancel(ctx)
-
 	leaseOwner, err := newLeaseOwner()
 	if err != nil {
-		cancel()
-
 		return nil, oops.In("agenttask").Code("worker_identity").Wrapf(err, "create worker identity")
 	}
 
 	service := &Service{
-		runner: options.Runner, done: serviceCtx.Done(), tasks: options.Tasks,
+		runner: options.Runner, tasks: options.Tasks,
 		agentTasks: options.AgentTasks, workflows: options.Workflows, queue: make(chan string, queueCapacity),
-		cancel: cancel, active: make(map[string]context.CancelFunc),
+		cancel: nil, done: nil, active: make(map[string]context.CancelFunc),
 		sessionSlots:   make(map[string]chan struct{}),
 		subscribers:    make(map[string]map[uint64]chan database.TaskEventEntity),
 		nextSubscriber: 0, wg: sync.WaitGroup{}, timeout: timeout,
@@ -178,11 +173,9 @@ func NewStopped(ctx context.Context, options *Options) (*Service, error) {
 		leaseRenewalRetryInterval:  leaseRenewalRetryInterval,
 		leaseRenewalAttemptTimeout: leaseRenewalAttemptTimeout,
 		leaseRenewalAttempts:       leaseRenewalAttempts, mu: sync.Mutex{},
-		lifecycle: sync.Mutex{}, ctx: serviceCtx, started: false, closed: false,
+		lifecycle: sync.Mutex{}, started: false, closed: false,
 	}
 	if err := service.recoverInterrupted(ctx); err != nil {
-		cancel()
-
 		return nil, err
 	}
 
@@ -202,12 +195,16 @@ func (service *Service) Start(ctx context.Context) error {
 		return nil
 	}
 
+	workerCtx, cancel := context.WithCancel(ctx)
+	service.cancel = cancel
+	service.done = workerCtx.Done()
+
 	for range service.concurrency {
 		service.wg.Add(1)
-		go service.worker(service.ctx)
+		go service.worker(workerCtx)
 	}
 
-	if err := service.enqueueRecovered(ctx, service.ctx); err != nil {
+	if err := service.enqueueRecovered(ctx); err != nil {
 		service.cancel()
 		service.wg.Wait()
 		service.closed = true
@@ -408,7 +405,9 @@ func (service *Service) Subscribe(taskID string) Subscription {
 	channel := make(chan database.TaskEventEntity)
 	close(channel)
 
-	return Subscription{Events: channel, Cancel: func() {}}
+	return Subscription{Events: channel, Cancel: func() {
+		// The failed subscription owns no resources, so cancellation is a no-op.
+	}}
 }
 
 func (service *Service) subscribe(taskID string) (Subscription, error) {
@@ -570,7 +569,10 @@ func (service *Service) Shutdown(ctx context.Context) error {
 	}
 
 	service.closed = true
-	service.cancel()
+	if service.cancel != nil {
+		service.cancel()
+	}
+
 	service.closeSubscriptions()
 	service.lifecycle.Unlock()
 
@@ -1071,7 +1073,7 @@ func (service *Service) recoverInterrupted(ctx context.Context) error {
 	return nil
 }
 
-func (service *Service) enqueueRecovered(ctx, serviceCtx context.Context) error {
+func (service *Service) enqueueRecovered(ctx context.Context) error {
 	queued, err := service.tasks.ListByStates(ctx, database.TaskKindAgent, []database.TaskState{database.TaskQueued}, 0)
 	if err != nil {
 		return oops.In("agenttask").Code("recover_tasks").Wrapf(err, "list queued tasks")
@@ -1082,8 +1084,8 @@ func (service *Service) enqueueRecovered(ctx, serviceCtx context.Context) error 
 		case service.queue <- queued[index].ID:
 		case <-ctx.Done():
 			return oops.In("agenttask").Code("recover_canceled").Wrapf(ctx.Err(), "enqueue recovered tasks")
-		case <-serviceCtx.Done():
-			return oops.In("agenttask").Code("service_stopped").Wrapf(serviceCtx.Err(), "enqueue recovered tasks")
+		case <-service.done:
+			return oops.In("agenttask").Code("service_stopped").Errorf("enqueue recovered tasks: service stopped")
 		}
 	}
 

--- a/internal/agenttask/service.go
+++ b/internal/agenttask/service.go
@@ -93,27 +93,32 @@ type Service struct {
 	runner                     Runner
 	getTaskFn                  func(context.Context, string) (*database.TaskEntity, bool, error)
 	renewLeaseFn               func(context.Context, string, string, time.Time) (bool, error)
+	ctx                        context.Context
 	active                     map[string]context.CancelFunc
 	subscribers                map[string]map[uint64]chan database.TaskEventEntity
+	sessionSlots               map[string]chan struct{}
 	agentTasks                 *database.AgentTaskRepository
 	workflows                  *database.WorkflowRepository
+	tasks                      *database.TaskRepository
 	queue                      chan string
 	cancel                     context.CancelFunc
 	done                       <-chan struct{}
-	sessionSlots               map[string]chan struct{}
-	tasks                      *database.TaskRepository
 	logger                     *slog.Logger
 	leaseOwner                 string
 	wg                         sync.WaitGroup
+	mu                         sync.Mutex
+	lifecycle                  sync.Mutex
 	nextSubscriber             uint64
 	timeout                    time.Duration
-	sessionConcurrency         int
 	leaseDuration              time.Duration
 	leaseHeartbeatInterval     time.Duration
 	leaseRenewalRetryInterval  time.Duration
 	leaseRenewalAttemptTimeout time.Duration
 	leaseRenewalAttempts       int
-	mu                         sync.Mutex
+	concurrency                int
+	sessionConcurrency         int
+	started                    bool
+	closed                     bool
 }
 
 func invalidOptions(options *Options) bool {
@@ -122,6 +127,20 @@ func invalidOptions(options *Options) bool {
 
 // New creates and starts a task service.
 func New(ctx context.Context, options *Options) (*Service, error) {
+	service, err := NewStopped(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := service.Start(ctx); err != nil {
+		return nil, err
+	}
+
+	return service, nil
+}
+
+// NewStopped creates a task service without starting its workers.
+func NewStopped(ctx context.Context, options *Options) (*Service, error) {
 	if invalidOptions(options) {
 		return nil, errors.New("agenttask: tasks, agent tasks, and runner are required")
 	}
@@ -153,12 +172,13 @@ func New(ctx context.Context, options *Options) (*Service, error) {
 		sessionSlots:   make(map[string]chan struct{}),
 		subscribers:    make(map[string]map[uint64]chan database.TaskEventEntity),
 		nextSubscriber: 0, wg: sync.WaitGroup{}, timeout: timeout,
-		sessionConcurrency: sessionConcurrency, logger: logger, leaseOwner: leaseOwner,
+		concurrency: concurrency, sessionConcurrency: sessionConcurrency, logger: logger, leaseOwner: leaseOwner,
 		getTaskFn: options.Tasks.Get, renewLeaseFn: options.Tasks.RenewLease, leaseDuration: leaseDuration,
 		leaseHeartbeatInterval:     leaseHeartbeatInterval,
 		leaseRenewalRetryInterval:  leaseRenewalRetryInterval,
 		leaseRenewalAttemptTimeout: leaseRenewalAttemptTimeout,
 		leaseRenewalAttempts:       leaseRenewalAttempts, mu: sync.Mutex{},
+		lifecycle: sync.Mutex{}, ctx: serviceCtx, started: false, closed: false,
 	}
 	if err := service.recoverInterrupted(ctx); err != nil {
 		cancel()
@@ -166,19 +186,39 @@ func New(ctx context.Context, options *Options) (*Service, error) {
 		return nil, err
 	}
 
-	for range concurrency {
-		service.wg.Add(1)
-		go service.worker(serviceCtx)
-	}
-
-	if err := service.enqueueRecovered(ctx, serviceCtx); err != nil {
-		cancel()
-		service.wg.Wait()
-
-		return nil, err
-	}
-
 	return service, nil
+}
+
+// Start launches workers and queues recovered tasks.
+func (service *Service) Start(ctx context.Context) error {
+	service.lifecycle.Lock()
+	defer service.lifecycle.Unlock()
+
+	if service.closed {
+		return oops.In("agenttask").Code("service_stopped").Errorf("task service is stopped")
+	}
+
+	if service.started {
+		return nil
+	}
+
+	for range service.concurrency {
+		service.wg.Add(1)
+		go service.worker(service.ctx)
+	}
+
+	if err := service.enqueueRecovered(ctx, service.ctx); err != nil {
+		service.cancel()
+		service.wg.Wait()
+		service.closed = true
+		service.closeSubscriptions()
+
+		return err
+	}
+
+	service.started = true
+
+	return nil
 }
 
 func optionDefaults(options *Options) (
@@ -360,6 +400,25 @@ func (service *Service) Events(
 // Subscribe follows newly persisted events for a task. Delivery is bounded and
 // best-effort; callers recover gaps using Events and the event sequence.
 func (service *Service) Subscribe(taskID string) Subscription {
+	subscription, err := service.subscribe(taskID)
+	if err == nil {
+		return subscription
+	}
+
+	channel := make(chan database.TaskEventEntity)
+	close(channel)
+
+	return Subscription{Events: channel, Cancel: func() {}}
+}
+
+func (service *Service) subscribe(taskID string) (Subscription, error) {
+	service.lifecycle.Lock()
+	defer service.lifecycle.Unlock()
+
+	if service.closed {
+		return Subscription{}, oops.In("agenttask").Code("service_stopped").Errorf("task service is stopped")
+	}
+
 	channel := make(chan database.TaskEventEntity, eventBuffer)
 
 	service.mu.Lock()
@@ -391,16 +450,19 @@ func (service *Service) Subscribe(taskID string) Subscription {
 			}
 			service.mu.Unlock()
 		})
-	}}
+	}}, nil
 }
 
 // SubscribeAgentTask exposes task completion notifications through the assistant boundary.
 func (service *Service) SubscribeAgentTask(
 	taskID string,
-) (events <-chan database.TaskEventEntity, cancel func()) {
-	subscription := service.Subscribe(taskID)
+) (events <-chan database.TaskEventEntity, cancel func(), err error) {
+	subscription, err := service.subscribe(taskID)
+	if err != nil {
+		return nil, nil, err
+	}
 
-	return subscription.Events, subscription.Cancel
+	return subscription.Events, subscription.Cancel, nil
 }
 
 // Cancel requests cancellation without allowing terminal states to change.
@@ -500,8 +562,17 @@ func (service *Service) Await(ctx context.Context, taskID string) (*database.Age
 
 // Shutdown cancels active work and waits for all workers.
 func (service *Service) Shutdown(ctx context.Context) error {
+	service.lifecycle.Lock()
+	if service.closed {
+		service.lifecycle.Unlock()
+
+		return nil
+	}
+
+	service.closed = true
 	service.cancel()
 	service.closeSubscriptions()
+	service.lifecycle.Unlock()
 
 	done := make(chan struct{})
 

--- a/internal/agenttask/service_internal_test.go
+++ b/internal/agenttask/service_internal_test.go
@@ -32,7 +32,8 @@ func emptyService() *Service {
 		cancel: nil, done: nil, sessionSlots: nil, tasks: nil, logger: nil, leaseOwner: "", wg: sync.WaitGroup{},
 		nextSubscriber: 0, timeout: 0, sessionConcurrency: 0, leaseDuration: 0,
 		leaseHeartbeatInterval: 0, leaseRenewalRetryInterval: 0, leaseRenewalAttemptTimeout: 0,
-		leaseRenewalAttempts: 0, mu: sync.Mutex{},
+		leaseRenewalAttempts: 0, mu: sync.Mutex{}, lifecycle: sync.Mutex{}, ctx: nil,
+		concurrency: 0, started: false, closed: false,
 	}
 }
 
@@ -705,6 +706,28 @@ func TestServiceInternalExecuteSkipsUnavailableTask(t *testing.T) {
 			assert.NotContains(t, service.active, "task")
 		})
 	}
+}
+
+func TestStartFailureClosesExistingSubscriptions(t *testing.T) {
+	t.Parallel()
+
+	service := emptyService()
+	service.ctx, service.cancel = context.WithCancel(t.Context())
+	service.done = service.ctx.Done()
+	service.queue = make(chan string)
+	service.subscribers = make(map[string]map[uint64]chan database.TaskEventEntity)
+	closedService := serviceWithClosedRepositories(t)
+	service.tasks = closedService.tasks
+	service.agentTasks = closedService.agentTasks
+
+	subscription, err := service.subscribe("task")
+	require.NoError(t, err)
+
+	err = service.Start(t.Context())
+	require.ErrorContains(t, err, "list queued tasks")
+
+	_, open := <-subscription.Events
+	assert.False(t, open)
 }
 
 func TestServiceInternalShutdownCancellation(t *testing.T) {

--- a/internal/agenttask/service_internal_test.go
+++ b/internal/agenttask/service_internal_test.go
@@ -32,7 +32,7 @@ func emptyService() *Service {
 		cancel: nil, done: nil, sessionSlots: nil, tasks: nil, logger: nil, leaseOwner: "", wg: sync.WaitGroup{},
 		nextSubscriber: 0, timeout: 0, sessionConcurrency: 0, leaseDuration: 0,
 		leaseHeartbeatInterval: 0, leaseRenewalRetryInterval: 0, leaseRenewalAttemptTimeout: 0,
-		leaseRenewalAttempts: 0, mu: sync.Mutex{}, lifecycle: sync.Mutex{}, ctx: nil,
+		leaseRenewalAttempts: 0, mu: sync.Mutex{}, lifecycle: sync.Mutex{},
 		concurrency: 0, started: false, closed: false,
 	}
 }
@@ -303,7 +303,7 @@ func repositoryWriteErrorCases(service *Service) []repositoryErrorCase {
 		{name: "enqueue recovered tasks", wantError: "list queued tasks", run: func(t *testing.T) error {
 			t.Helper()
 
-			return service.enqueueRecovered(t.Context(), t.Context())
+			return service.enqueueRecovered(t.Context())
 		}},
 	}
 }
@@ -533,7 +533,9 @@ func testQueuedTaskCancellation(
 	serviceCtx, cancelRecovery := context.WithCancel(t.Context())
 	cancelRecovery()
 
-	err = service.enqueueRecovered(t.Context(), serviceCtx)
+	service.done = serviceCtx.Done()
+
+	err = service.enqueueRecovered(t.Context())
 	require.ErrorContains(t, err, "enqueue recovered tasks")
 
 	testCancelingTaskFinalization(t, service, tasks, agentTasks, sessions, owner.ID)
@@ -712,8 +714,6 @@ func TestStartFailureClosesExistingSubscriptions(t *testing.T) {
 	t.Parallel()
 
 	service := emptyService()
-	service.ctx, service.cancel = context.WithCancel(t.Context())
-	service.done = service.ctx.Done()
 	service.queue = make(chan string)
 	service.subscribers = make(map[string]map[uint64]chan database.TaskEventEntity)
 	closedService := serviceWithClosedRepositories(t)

--- a/internal/agenttask/service_test.go
+++ b/internal/agenttask/service_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/oops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite" // Register the SQLite database/sql driver used by test repositories.
@@ -405,6 +406,16 @@ func TestStoppedServiceDoesNotRunQueuedTasksUntilStarted(t *testing.T) {
 		Concurrency: 1, SessionConcurrency: 1, QueueCapacity: 1, Timeout: time.Minute,
 	})
 	require.NoError(t, err)
+
+	var (
+		nilContext context.Context
+		coded      oops.OopsError
+	)
+
+	err = service.Start(nilContext)
+	require.ErrorAs(t, err, &coded)
+	assert.Equal(t, "nil_start_context", coded.Code())
+
 	t.Cleanup(func() {
 		runner.unblock()
 		require.NoError(t, service.Shutdown(context.Background()))

--- a/internal/agenttask/service_test.go
+++ b/internal/agenttask/service_test.go
@@ -114,7 +114,8 @@ func TestServiceAgentTaskAdaptersAndSubscriptionCancellation(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	events, cancel := service.SubscribeAgentTask(created.Task.ID)
+	events, cancel, err := service.SubscribeAgentTask(created.Task.ID)
+	require.NoError(t, err)
 	cancel()
 	cancel() // Cancellation is intentionally idempotent.
 	requireChannelClosed(t, events)
@@ -122,6 +123,23 @@ func TestServiceAgentTaskAdaptersAndSubscriptionCancellation(t *testing.T) {
 	completed, err := service.Await(t.Context(), created.Task.ID)
 	require.NoError(t, err)
 	assert.Equal(t, database.TaskSucceeded, completed.Task.State)
+}
+
+func TestServiceRejectsSubscriptionsAfterShutdown(t *testing.T) {
+	t.Parallel()
+
+	tasks, agentTasks, _ := repositories(t)
+	service := newService(t, tasks, agentTasks, new(fakeRunner))
+	require.NoError(t, service.Shutdown(t.Context()))
+
+	events, cancel, err := service.SubscribeAgentTask("task")
+	require.ErrorContains(t, err, "task service is stopped")
+	assert.Nil(t, events)
+	assert.Nil(t, cancel)
+
+	subscription := service.Subscribe("task")
+	requireChannelClosed(t, subscription.Events)
+	subscription.Cancel()
 }
 
 func TestServiceRejectsWorkflowSubmissionWithoutRepository(t *testing.T) {
@@ -358,6 +376,49 @@ func TestSecondServiceDoesNotInterruptLiveTask(t *testing.T) {
 	completed, err := first.Await(t.Context(), created.Task.ID)
 	require.NoError(t, err)
 	assert.Equal(t, database.TaskSucceeded, completed.Task.State)
+}
+
+func TestStoppedServiceDoesNotRunQueuedTasksUntilStarted(t *testing.T) {
+	t.Parallel()
+
+	tasks, agentTasks, sessions := repositories(t)
+	parent := createSession(t, sessions, "parent", "")
+	child := createSession(t, sessions, "child", parent.ID)
+	created, err := agentTasks.Create(t.Context(), &database.AgentTaskEntity{
+		Task: database.TaskEntity{
+			ID: "", Kind: database.TaskKindAgent, ParentTaskID: "", OwnerSessionID: parent.ID,
+			ConcurrencyKey: parent.ID, State: database.TaskQueued, Result: "", ErrorCode: "", ErrorMessage: "",
+			LeaseOwner: "", CreatedAt: time.Time{}, StartedAt: nil, FinishedAt: nil, UpdatedAt: time.Time{},
+			LeaseExpiresAt: nil,
+		},
+		ChildSessionID: child.ID, AgentName: "general", Prompt: "queued", Model: "", Provider: "",
+		PolicyJSON: "{}", UsageJSON: "{}", Depth: 1,
+	})
+	require.NoError(t, err)
+
+	runner := &fakeRunner{
+		result: agenttask.Result{Text: completedResult, UsageJSON: `{}`}, err: nil,
+		started: make(chan string, 1), release: make(chan struct{}), eventRelease: nil, once: sync.Once{},
+	}
+	service, err := agenttask.NewStopped(t.Context(), &agenttask.Options{
+		Tasks: tasks, AgentTasks: agentTasks, Workflows: nil, Runner: runner, Logger: nil,
+		Concurrency: 1, SessionConcurrency: 1, QueueCapacity: 1, Timeout: time.Minute,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		runner.unblock()
+		require.NoError(t, service.Shutdown(context.Background()))
+	})
+
+	select {
+	case <-runner.started:
+		t.Fatal("stopped service ran queued task before start")
+	default:
+	}
+
+	require.NoError(t, service.Start(t.Context()))
+	require.Equal(t, created.Task.ID, awaitStarted(t, runner.started))
+	require.NoError(t, service.Start(t.Context()))
 }
 
 func TestServiceEnforcesSessionConcurrency(t *testing.T) {

--- a/internal/assistant/agent_runtime_wrappers_internal_test.go
+++ b/internal/assistant/agent_runtime_wrappers_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/samber/oops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -14,6 +15,14 @@ import (
 	"github.com/omarluq/librecode/internal/extension"
 	"github.com/omarluq/librecode/internal/tool"
 )
+
+func requireRuntimeOopsCode(t *testing.T, err error, code string) {
+	t.Helper()
+
+	coded, ok := oops.AsOops(err)
+	require.True(t, ok)
+	require.Equal(t, code, coded.Code())
+}
 
 type testToolProvider struct {
 	tools []extension.Tool
@@ -59,33 +68,34 @@ func TestRuntimeAgentWrappersWithoutController(t *testing.T) {
 			assert.Nil(t, runtime.AgentDefinitions())
 			assert.Nil(t, runtime.AgentDiagnostics())
 			tasks, err := runtime.AgentTasks(t.Context(), "owner", 10)
-			require.NoError(t, err)
+			requireRuntimeOopsCode(t, err, "agent_task_service_unavailable")
 			assert.Nil(t, tasks)
 			task, found, err := runtime.AgentTask(t.Context(), "id")
-			require.NoError(t, err)
+			requireRuntimeOopsCode(t, err, "agent_task_service_unavailable")
 			assert.Nil(t, task)
 			assert.False(t, found)
 			canceled, found, err := runtime.CancelAgentTask(t.Context(), "owner", "id")
-			require.NoError(t, err)
+			requireRuntimeOopsCode(t, err, "agent_task_service_unavailable")
 			assert.Nil(t, canceled)
 			assert.False(t, found)
 
-			events, cancel := runtime.SubscribeAgentTask("id")
-			cancel()
-
-			_, open := <-events
-			assert.False(t, open)
+			events, cancel, err := runtime.SubscribeAgentTask("id")
+			requireRuntimeOopsCode(t, err, "agent_task_service_unavailable")
+			assert.Nil(t, events)
+			assert.Nil(t, cancel)
 		})
 	}
 }
 
-func TestRuntimeAgentControllerSetterAndSubscriptionDelegate(t *testing.T) {
+func TestRuntimeAgentControllerOptionAndSubscriptionDelegate(t *testing.T) {
 	t.Parallel()
 
 	stub := new(agentControllerStub)
-	runtime := new(Runtime)
-	runtime.SetAgentTaskController(stub)
-	events, cancel := runtime.SubscribeAgentTask("task")
+	runtime := NewRuntimeForTest(func(options *RuntimeTestOptions) {
+		options.AgentTasks = stub
+	})
+	events, cancel, err := runtime.SubscribeAgentTask("task")
+	require.NoError(t, err)
 	cancel()
 
 	_, open := <-events
@@ -93,40 +103,86 @@ func TestRuntimeAgentControllerSetterAndSubscriptionDelegate(t *testing.T) {
 	assert.Equal(t, 1, stub.subscriptions)
 }
 
-func TestRuntimeAgentWrappersDelegateAndWrapErrors(t *testing.T) {
+func TestRuntimeAgentWrappersDelegate(t *testing.T) {
 	t.Parallel()
 
 	stub := new(agentControllerStub)
 	stub.task = agentToolTask("id", "owner", database.TaskQueued)
 	stub.listed = []database.AgentTaskEntity{}
 	stub.found = true
-	runtime := new(Runtime)
-	runtime.agentTasks = stub
-	runtime.agents = agent.Load(t.TempDir())
-	assert.NotEmpty(t, runtime.AgentDefinitions())
-	assert.Empty(t, runtime.AgentDiagnostics())
+	runtime := NewRuntimeForTest(func(options *RuntimeTestOptions) {
+		options.AgentTasks = stub
+	})
+
 	_, err := runtime.AgentTasks(t.Context(), "owner", 7)
 	require.NoError(t, err)
 	assert.Equal(t, 7, stub.lastLimit)
+
 	task, found, err := runtime.AgentTask(t.Context(), "id")
 	require.NoError(t, err)
 	assert.True(t, found)
 	assert.Equal(t, "id", task.Task.ID)
+
 	_, found, err = runtime.CancelAgentTask(t.Context(), "owner", "id")
 	require.NoError(t, err)
 	assert.True(t, found)
+}
 
-	stub.listErr = errors.New("list failed")
-	_, err = runtime.AgentTasks(t.Context(), "owner", 1)
-	require.ErrorContains(t, err, "list agent tasks")
+func TestRuntimeAgentWrappersWrapErrors(t *testing.T) {
+	t.Parallel()
 
-	stub.getErr = errors.New("get failed")
-	_, _, err = runtime.AgentTask(t.Context(), "id")
-	require.ErrorContains(t, err, "get agent task")
+	tests := []struct {
+		name      string
+		configure func(*agentControllerStub)
+		call      func(*Runtime) error
+		want      string
+	}{
+		{
+			name:      "list",
+			configure: func(stub *agentControllerStub) { stub.listErr = errors.New("list failed") },
+			call: func(runtime *Runtime) error {
+				_, err := runtime.AgentTasks(t.Context(), "owner", 1)
 
-	stub.cancelErr = errors.New("cancel failed")
-	_, _, err = runtime.CancelAgentTask(t.Context(), "owner", "id")
-	require.ErrorContains(t, err, "cancel agent task")
+				return err
+			},
+			want: "list agent tasks",
+		},
+		{
+			name:      "get",
+			configure: func(stub *agentControllerStub) { stub.getErr = errors.New("get failed") },
+			call: func(runtime *Runtime) error {
+				_, _, err := runtime.AgentTask(t.Context(), "id")
+
+				return err
+			},
+			want: "get agent task",
+		},
+		{
+			name:      "cancel",
+			configure: func(stub *agentControllerStub) { stub.cancelErr = errors.New("cancel failed") },
+			call: func(runtime *Runtime) error {
+				_, _, err := runtime.CancelAgentTask(t.Context(), "owner", "id")
+
+				return err
+			},
+			want: "cancel agent task",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			stub := new(agentControllerStub)
+			test.configure(stub)
+
+			runtime := NewRuntimeForTest(func(options *RuntimeTestOptions) {
+				options.AgentTasks = stub
+			})
+
+			require.ErrorContains(t, test.call(runtime), test.want)
+		})
+	}
 }
 
 func TestAsyncAgentPromptAndToolRegistries(t *testing.T) {
@@ -282,9 +338,7 @@ func TestPromptRegistryHonorsDisabledExtensions(t *testing.T) {
 	registry, err := runtime.promptToolRegistry(t.Context(), t.TempDir(), "owner")
 	require.NoError(t, err)
 
-	for _, definition := range registry.Definitions() {
-		assert.NotEqual(t, tool.Name("custom"), definition.Name)
-	}
+	assert.False(t, registry.Has("custom"))
 }
 
 func TestWithExecutionProfileClonesToolsAndDependencies(t *testing.T) {

--- a/internal/assistant/agent_runtime_wrappers_internal_test.go
+++ b/internal/assistant/agent_runtime_wrappers_internal_test.go
@@ -145,7 +145,7 @@ func TestRuntimeAgentWrappersWrapErrors(t *testing.T) {
 
 				return err
 			},
-			want: "list agent tasks",
+			want: "list_agent_tasks",
 		},
 		{
 			name:      "get",
@@ -155,7 +155,7 @@ func TestRuntimeAgentWrappersWrapErrors(t *testing.T) {
 
 				return err
 			},
-			want: "get agent task",
+			want: "get_agent_task",
 		},
 		{
 			name:      "cancel",
@@ -165,7 +165,17 @@ func TestRuntimeAgentWrappersWrapErrors(t *testing.T) {
 
 				return err
 			},
-			want: "cancel agent task",
+			want: "cancel_agent_task",
+		},
+		{
+			name:      "subscribe",
+			configure: func(stub *agentControllerStub) { stub.subscribeErr = errors.New("subscribe failed") },
+			call: func(runtime *Runtime) error {
+				_, _, err := runtime.SubscribeAgentTask("id")
+
+				return err
+			},
+			want: "subscribe_agent_task",
 		},
 	}
 
@@ -180,7 +190,7 @@ func TestRuntimeAgentWrappersWrapErrors(t *testing.T) {
 				options.AgentTasks = stub
 			})
 
-			require.ErrorContains(t, test.call(runtime), test.want)
+			requireRuntimeOopsCode(t, test.call(runtime), test.want)
 		})
 	}
 }

--- a/internal/assistant/agent_tool.go
+++ b/internal/assistant/agent_tool.go
@@ -51,7 +51,7 @@ type AgentTaskController interface {
 	List(context.Context, string, int) ([]database.AgentTaskEntity, error)
 	Cancel(context.Context, string, string) (*database.TaskEntity, bool, error)
 	Await(context.Context, string) (*database.AgentTaskEntity, error)
-	SubscribeAgentTask(string) (events <-chan database.TaskEventEntity, cancel func())
+	SubscribeAgentTask(string) (events <-chan database.TaskEventEntity, cancel func(), err error)
 }
 
 type agentToolExecutor struct {

--- a/internal/assistant/agent_tool_internal_test.go
+++ b/internal/assistant/agent_tool_internal_test.go
@@ -76,12 +76,12 @@ func (stub *agentControllerStub) Await(context.Context, string) (*database.Agent
 }
 func (stub *agentControllerStub) SubscribeAgentTask(
 	string,
-) (events <-chan database.TaskEventEntity, cancel func()) {
+) (events <-chan database.TaskEventEntity, cancel func(), err error) {
 	stub.subscriptions++
 	channel := make(chan database.TaskEventEntity)
 	close(channel)
 
-	return channel, func() {}
+	return channel, func() {}, nil
 }
 
 func TestAgentToolDefinitionsAndDispatch(t *testing.T) {

--- a/internal/assistant/agent_tool_internal_test.go
+++ b/internal/assistant/agent_tool_internal_test.go
@@ -23,6 +23,7 @@ type agentControllerStub struct {
 	getErr        error
 	cancelErr     error
 	listErr       error
+	subscribeErr  error
 	getFunc       func(int) (*database.AgentTaskEntity, bool, error)
 	submitFunc    func() (*database.AgentTaskEntity, error)
 	cancelFound   *bool
@@ -78,6 +79,10 @@ func (stub *agentControllerStub) SubscribeAgentTask(
 	string,
 ) (events <-chan database.TaskEventEntity, cancel func(), err error) {
 	stub.subscriptions++
+	if stub.subscribeErr != nil {
+		return nil, nil, stub.subscribeErr
+	}
+
 	channel := make(chan database.TaskEventEntity)
 	close(channel)
 

--- a/internal/assistant/runtime.go
+++ b/internal/assistant/runtime.go
@@ -39,7 +39,7 @@ type Runtime struct {
 	toolSchemaCache   *toolSchemaCache
 	agents            *agent.Catalog
 	agentTasks        AgentTaskController
-	workflowSubmitter workflowSubmitter
+	workflowSubmitter WorkflowSubmitter
 	operations        *sessionOperationCoordinator
 	newCompactionUUID func() (uuid.UUID, error)
 	profile           ExecutionProfile
@@ -139,15 +139,17 @@ type responseBundle struct {
 
 // RuntimeOptions contains dependencies for an assistant runtime.
 type RuntimeOptions struct {
-	Config      *config.Config
-	Sessions    *database.SessionRepository
-	Extensions  runtimeExtensions
-	Cache       *ResponseCache
-	Models      *model.Registry
-	Client      Completer
-	Logger      *slog.Logger
-	SkillsCache *core.SkillsCache
-	Agents      *agent.Catalog
+	Config            *config.Config
+	Sessions          *database.SessionRepository
+	Extensions        runtimeExtensions
+	Cache             *ResponseCache
+	Models            *model.Registry
+	Client            Completer
+	Logger            *slog.Logger
+	SkillsCache       *core.SkillsCache
+	Agents            *agent.Catalog
+	AgentTasks        AgentTaskController
+	WorkflowSubmitter WorkflowSubmitter
 }
 
 // NewRuntime creates an assistant runtime.
@@ -172,8 +174,8 @@ func NewRuntime(options *RuntimeOptions) *Runtime {
 		skillsCache:       options.SkillsCache,
 		toolSchemaCache:   newToolSchemaCache(),
 		agents:            options.Agents,
-		agentTasks:        nil,
-		workflowSubmitter: nil,
+		agentTasks:        options.AgentTasks,
+		workflowSubmitter: options.WorkflowSubmitter,
 		operations:        newSessionOperationCoordinator(),
 		newCompactionUUID: uuid.NewV7,
 		profile:           topLevelExecutionProfile(),
@@ -187,18 +189,6 @@ func (runtime *Runtime) acquirePromptOperation(ctx context.Context, sessionID st
 	}
 
 	return release, nil
-}
-
-// SetAgentTaskController enables asynchronous subagent tools.
-// It must be called during application startup, before Prompt is used.
-func (runtime *Runtime) SetAgentTaskController(controller AgentTaskController) {
-	runtime.agentTasks = controller
-}
-
-// SetWorkflowSubmitter enables model-authored durable workflows.
-// It must be called during application startup, before Prompt is used.
-func (runtime *Runtime) SetWorkflowSubmitter(submitter workflowSubmitter) {
-	runtime.workflowSubmitter = submitter
 }
 
 // Prompt appends a user prompt and an assistant response to the selected session.
@@ -377,7 +367,8 @@ func (runtime *Runtime) AgentTasks(
 	limit int,
 ) ([]database.AgentTaskEntity, error) {
 	if runtime == nil || runtime.agentTasks == nil {
-		return nil, nil
+		return nil, oops.In("assistant").Code("agent_task_service_unavailable").
+			Errorf("agent task service is unavailable")
 	}
 
 	tasks, err := runtime.agentTasks.List(ctx, ownerSessionID, limit)
@@ -394,7 +385,8 @@ func (runtime *Runtime) AgentTask(
 	taskID string,
 ) (*database.AgentTaskEntity, bool, error) {
 	if runtime == nil || runtime.agentTasks == nil {
-		return nil, false, nil
+		return nil, false, oops.In("assistant").Code("agent_task_service_unavailable").
+			Errorf("agent task service is unavailable")
 	}
 
 	task, found, err := runtime.agentTasks.Get(ctx, taskID)
@@ -417,12 +409,14 @@ func (runtime *Runtime) AgentTaskEvents(
 	limit int,
 ) ([]database.TaskEventEntity, error) {
 	if runtime == nil || runtime.agentTasks == nil {
-		return nil, nil
+		return nil, oops.In("assistant").Code("agent_task_service_unavailable").
+			Errorf("agent task service is unavailable")
 	}
 
 	reader, ok := runtime.agentTasks.(agentTaskEventReader)
 	if !ok {
-		return nil, nil
+		return nil, oops.In("assistant").Code("agent_task_events_unavailable").
+			Errorf("agent task events are unavailable")
 	}
 
 	events, err := reader.Events(ctx, taskID, after, limit)
@@ -437,17 +431,18 @@ func (runtime *Runtime) AgentTaskEvents(
 // SubscribeAgentTask follows persisted events for one agent task.
 func (runtime *Runtime) SubscribeAgentTask(
 	taskID string,
-) (events <-chan database.TaskEventEntity, cancel func()) {
+) (events <-chan database.TaskEventEntity, cancel func(), err error) {
 	if runtime == nil || runtime.agentTasks == nil {
-		channel := make(chan database.TaskEventEntity)
-		close(channel)
-
-		return channel, func() {
-			// The closed channel has no live subscription to cancel.
-		}
+		return nil, nil, oops.In("assistant").Code("agent_task_service_unavailable").
+			Errorf("agent task service is unavailable")
 	}
 
-	return runtime.agentTasks.SubscribeAgentTask(taskID)
+	events, cancel, err = runtime.agentTasks.SubscribeAgentTask(taskID)
+	if err != nil {
+		return nil, nil, oops.In("assistant").Code("subscribe_agent_task").Wrapf(err, "subscribe agent task")
+	}
+
+	return events, cancel, nil
 }
 
 // CancelAgentTask requests cancellation of one durable agent task.
@@ -457,7 +452,8 @@ func (runtime *Runtime) CancelAgentTask(
 	taskID string,
 ) (*database.TaskEntity, bool, error) {
 	if runtime == nil || runtime.agentTasks == nil {
-		return nil, false, nil
+		return nil, false, oops.In("assistant").Code("agent_task_service_unavailable").
+			Errorf("agent task service is unavailable")
 	}
 
 	task, found, err := runtime.agentTasks.Cancel(ctx, ownerSessionID, taskID)

--- a/internal/assistant/runtime.go
+++ b/internal/assistant/runtime.go
@@ -360,6 +360,8 @@ func (runtime *Runtime) AgentDefinitions() []agent.Definition {
 	return runtime.agents.Definitions()
 }
 
+const agentTaskServiceUnavailable = "agent task service is unavailable"
+
 // AgentTasks returns durable agent tasks owned by a session.
 func (runtime *Runtime) AgentTasks(
 	ctx context.Context,
@@ -368,7 +370,7 @@ func (runtime *Runtime) AgentTasks(
 ) ([]database.AgentTaskEntity, error) {
 	if runtime == nil || runtime.agentTasks == nil {
 		return nil, oops.In("assistant").Code("agent_task_service_unavailable").
-			Errorf("agent task service is unavailable")
+			Errorf(agentTaskServiceUnavailable)
 	}
 
 	tasks, err := runtime.agentTasks.List(ctx, ownerSessionID, limit)
@@ -386,7 +388,7 @@ func (runtime *Runtime) AgentTask(
 ) (*database.AgentTaskEntity, bool, error) {
 	if runtime == nil || runtime.agentTasks == nil {
 		return nil, false, oops.In("assistant").Code("agent_task_service_unavailable").
-			Errorf("agent task service is unavailable")
+			Errorf(agentTaskServiceUnavailable)
 	}
 
 	task, found, err := runtime.agentTasks.Get(ctx, taskID)
@@ -410,7 +412,7 @@ func (runtime *Runtime) AgentTaskEvents(
 ) ([]database.TaskEventEntity, error) {
 	if runtime == nil || runtime.agentTasks == nil {
 		return nil, oops.In("assistant").Code("agent_task_service_unavailable").
-			Errorf("agent task service is unavailable")
+			Errorf(agentTaskServiceUnavailable)
 	}
 
 	reader, ok := runtime.agentTasks.(agentTaskEventReader)
@@ -434,7 +436,7 @@ func (runtime *Runtime) SubscribeAgentTask(
 ) (events <-chan database.TaskEventEntity, cancel func(), err error) {
 	if runtime == nil || runtime.agentTasks == nil {
 		return nil, nil, oops.In("assistant").Code("agent_task_service_unavailable").
-			Errorf("agent task service is unavailable")
+			Errorf(agentTaskServiceUnavailable)
 	}
 
 	events, cancel, err = runtime.agentTasks.SubscribeAgentTask(taskID)
@@ -453,7 +455,7 @@ func (runtime *Runtime) CancelAgentTask(
 ) (*database.TaskEntity, bool, error) {
 	if runtime == nil || runtime.agentTasks == nil {
 		return nil, false, oops.In("assistant").Code("agent_task_service_unavailable").
-			Errorf("agent task service is unavailable")
+			Errorf(agentTaskServiceUnavailable)
 	}
 
 	task, found, err := runtime.agentTasks.Cancel(ctx, ownerSessionID, taskID)

--- a/internal/assistant/testing.go
+++ b/internal/assistant/testing.go
@@ -12,15 +12,17 @@ import (
 
 // RuntimeTestOptions holds optional Runtime dependencies for test factories.
 type RuntimeTestOptions struct {
-	Config      *config.Config
-	Sessions    *database.SessionRepository
-	Extensions  runtimeExtensions
-	Cache       *ResponseCache
-	Models      *model.Registry
-	Client      Completer
-	Logger      *slog.Logger
-	SkillsCache *core.SkillsCache
-	Agents      *agent.Catalog
+	Config            *config.Config
+	Sessions          *database.SessionRepository
+	Extensions        runtimeExtensions
+	Cache             *ResponseCache
+	Models            *model.Registry
+	Client            Completer
+	Logger            *slog.Logger
+	SkillsCache       *core.SkillsCache
+	Agents            *agent.Catalog
+	AgentTasks        AgentTaskController
+	WorkflowSubmitter WorkflowSubmitter
 }
 
 // NewRuntimeForTest builds a Runtime from the given setup closure, setting every
@@ -29,29 +31,33 @@ type RuntimeTestOptions struct {
 // warnings when exhaustruct forces every field to be listed).
 func NewRuntimeForTest(setup func(*RuntimeTestOptions)) *Runtime {
 	opts := &RuntimeTestOptions{
-		Config:      nil,
-		Sessions:    nil,
-		Extensions:  nil,
-		Cache:       nil,
-		Models:      nil,
-		Client:      nil,
-		Logger:      nil,
-		SkillsCache: nil,
-		Agents:      nil,
+		Config:            nil,
+		Sessions:          nil,
+		Extensions:        nil,
+		Cache:             nil,
+		Models:            nil,
+		Client:            nil,
+		Logger:            nil,
+		SkillsCache:       nil,
+		Agents:            nil,
+		AgentTasks:        nil,
+		WorkflowSubmitter: nil,
 	}
 	if setup != nil {
 		setup(opts)
 	}
 
 	return NewRuntime(&RuntimeOptions{
-		Config:      opts.Config,
-		Sessions:    opts.Sessions,
-		Extensions:  opts.Extensions,
-		Cache:       opts.Cache,
-		Models:      opts.Models,
-		Client:      opts.Client,
-		Logger:      opts.Logger,
-		SkillsCache: opts.SkillsCache,
-		Agents:      opts.Agents,
+		Config:            opts.Config,
+		Sessions:          opts.Sessions,
+		Extensions:        opts.Extensions,
+		Cache:             opts.Cache,
+		Models:            opts.Models,
+		Client:            opts.Client,
+		Logger:            opts.Logger,
+		SkillsCache:       opts.SkillsCache,
+		Agents:            opts.Agents,
+		AgentTasks:        opts.AgentTasks,
+		WorkflowSubmitter: opts.WorkflowSubmitter,
 	})
 }

--- a/internal/assistant/workflow_controller_internal_test.go
+++ b/internal/assistant/workflow_controller_internal_test.go
@@ -68,11 +68,11 @@ func (stub *workflowControllerTaskStub) Await(
 
 func (*workflowControllerTaskStub) SubscribeAgentTask(
 	string,
-) (events <-chan database.TaskEventEntity, unsubscribe func()) {
+) (events <-chan database.TaskEventEntity, unsubscribe func(), err error) {
 	eventChannel := make(chan database.TaskEventEntity)
 	close(eventChannel)
 
-	return eventChannel, func() {}
+	return eventChannel, func() {}, nil
 }
 
 func TestNewWorkflowControllerValidatesDependencies(t *testing.T) {

--- a/internal/assistant/workflow_tool.go
+++ b/internal/assistant/workflow_tool.go
@@ -18,12 +18,13 @@ const workflowToolName tool.Name = "workflow"
 
 const workflowTaskIDKey = "workflow_task_id"
 
-type workflowSubmitter interface {
+// WorkflowSubmitter is the runtime-facing boundary for durable workflows.
+type WorkflowSubmitter interface {
 	Submit(context.Context, *workflow.ServiceRequest) (*database.WorkflowRunEntity, error)
 }
 
 type workflowToolExecutor struct {
-	submitter      workflowSubmitter
+	submitter      WorkflowSubmitter
 	ownerSessionID string
 }
 

--- a/internal/assistant/workflow_tool_internal_test.go
+++ b/internal/assistant/workflow_tool_internal_test.go
@@ -158,18 +158,26 @@ func TestWorkflowResultDetailsHandlesNil(t *testing.T) {
 	assert.Empty(t, workflowResultDetails(nil))
 }
 
+func TestWorkflowToolDistinguishesUnavailableService(t *testing.T) {
+	t.Parallel()
+
+	executor := &workflowToolExecutor{submitter: nil, ownerSessionID: "owner"}
+	_, err := executor.Execute(t.Context(), tool.Arguments{})
+	requireRuntimeOopsCode(t, err, "workflow_service_unavailable")
+}
+
 func TestPromptRegistryIncludesWorkflowWhenConfigured(t *testing.T) {
 	t.Parallel()
 
-	runtime := new(Runtime)
-	runtime.profile = topLevelExecutionProfile()
-	runtime.SetWorkflowSubmitter(&workflowSubmitterStub{request: nil, run: nil, err: nil})
+	runtime := NewRuntimeForTest(func(options *RuntimeTestOptions) {
+		options.WorkflowSubmitter = &workflowSubmitterStub{request: nil, run: nil, err: nil}
+	})
 
 	registry, err := runtime.promptToolRegistry(t.Context(), t.TempDir(), "owner")
 	require.NoError(t, err)
 	assert.True(t, registry.Has(workflowToolName))
 
-	runtime.SetWorkflowSubmitter(nil)
+	runtime = NewRuntimeForTest(nil)
 	registry, err = runtime.promptToolRegistry(t.Context(), t.TempDir(), "owner")
 	require.NoError(t, err)
 	assert.False(t, registry.Has(workflowToolName))

--- a/internal/di/agent_task_service.go
+++ b/internal/di/agent_task_service.go
@@ -2,17 +2,19 @@ package di
 
 import (
 	"context"
+	"sync"
 
 	"github.com/samber/do/v2"
+	"github.com/samber/oops"
 
 	"github.com/omarluq/librecode/internal/agenttask"
 )
 
 // AgentTaskService owns durable background agent execution.
 type AgentTaskService struct {
-	Tasks     *agenttask.Service
-	assistant *AssistantService
+	tasks     *agenttask.Service
 	options   *agenttask.Options
+	lifecycle sync.Mutex
 }
 
 // NewAgentTaskService wires the assistant runtime into the durable task scheduler.
@@ -44,38 +46,64 @@ func NewAgentTaskService(injector do.Injector) (*AgentTaskService, error) {
 	}
 
 	return &AgentTaskService{
-		Tasks:     nil,
-		assistant: assistantService,
+		tasks: nil,
 		options: &agenttask.Options{
 			Tasks: databaseService.Tasks, AgentTasks: databaseService.AgentTasks, Workflows: databaseService.Workflows,
 			Runner: runner, Concurrency: 0, SessionConcurrency: 0, QueueCapacity: 0, Timeout: 0,
 			Logger: logger,
 		},
+		lifecycle: sync.Mutex{},
 	}, nil
 }
 
-// Start recovers durable tasks and starts scheduler workers.
+// Tasks returns the constructed durable task scheduler, if startup reached that stage.
+func (service *AgentTaskService) Tasks() *agenttask.Service {
+	service.lifecycle.Lock()
+	defer service.lifecycle.Unlock()
+
+	return service.tasks
+}
+
+// Start constructs the durable task scheduler without starting workers.
 func (service *AgentTaskService) Start(ctx context.Context) error {
-	if service.Tasks != nil {
+	service.lifecycle.Lock()
+	defer service.lifecycle.Unlock()
+
+	if service.tasks != nil {
 		return nil
 	}
 
-	tasks, err := agenttask.New(ctx, service.options)
+	tasks, err := agenttask.NewStopped(ctx, service.options)
 	if err != nil {
 		return serviceError(err, "create agent task service")
 	}
 
-	service.Tasks = tasks
-	service.assistant.Runtime.SetAgentTaskController(tasks)
+	service.tasks = tasks
 
 	return nil
 }
 
+// StartWorkers starts scheduler workers after runtime capabilities are published.
+func (service *AgentTaskService) StartWorkers(ctx context.Context) error {
+	service.lifecycle.Lock()
+	defer service.lifecycle.Unlock()
+
+	if service.tasks == nil {
+		return oops.In("di").Code("agent_task_service_not_constructed").
+			Errorf("agent task service is not constructed")
+	}
+
+	return serviceError(service.tasks.Start(ctx), "start agent task workers")
+}
+
 // Shutdown stops workers before the database service is closed.
 func (service *AgentTaskService) Shutdown(ctx context.Context) error {
-	if service.Tasks == nil {
+	service.lifecycle.Lock()
+	defer service.lifecycle.Unlock()
+
+	if service.tasks == nil {
 		return nil
 	}
 
-	return serviceError(service.Tasks.Shutdown(ctx), "shutdown agent task service")
+	return serviceError(service.tasks.Shutdown(ctx), "shutdown agent task service")
 }

--- a/internal/di/assistant_service.go
+++ b/internal/di/assistant_service.go
@@ -11,8 +11,9 @@ import (
 
 // AssistantService exposes the assistant runtime.
 type AssistantService struct {
-	Runtime *assistant.Runtime
-	Agents  *agent.Catalog
+	Runtime      *assistant.Runtime
+	Agents       *agent.Catalog
+	capabilities *runtimeCapabilities
 }
 
 // NewAssistantService wires the assistant runtime.
@@ -58,19 +59,23 @@ func NewAssistantService(injector do.Injector) (*AssistantService, error) {
 	}
 
 	agents := agent.Load(cwd)
+	capabilities := newRuntimeCapabilities()
 
 	return &AssistantService{
 		Runtime: assistant.NewRuntime(&assistant.RuntimeOptions{
-			Config:      configService.Get(),
-			Sessions:    databaseService.Sessions,
-			Extensions:  extensionService.Manager,
-			Cache:       cache.Responses,
-			Models:      models.Registry,
-			Client:      nil,
-			Logger:      loggerService.SlogLogger,
-			SkillsCache: skills.Cache,
-			Agents:      agents,
+			Config:            configService.Get(),
+			Sessions:          databaseService.Sessions,
+			Extensions:        extensionService.Manager,
+			Cache:             cache.Responses,
+			Models:            models.Registry,
+			Client:            nil,
+			Logger:            loggerService.SlogLogger,
+			SkillsCache:       skills.Cache,
+			Agents:            agents,
+			AgentTasks:        capabilities,
+			WorkflowSubmitter: capabilities,
 		}),
-		Agents: agents,
+		Agents:       agents,
+		capabilities: capabilities,
 	}, nil
 }

--- a/internal/di/assistant_service_internal_test.go
+++ b/internal/di/assistant_service_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/samber/do/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite" // register SQLite driver for assistant service wiring tests.
 
@@ -24,19 +25,21 @@ func TestNewAssistantServiceWiresRuntimeOptions(t *testing.T) {
 	t.Parallel()
 
 	injector := do.New()
-	do.ProvideValue(injector, newTestDatabaseService(t))
-	provideTestAssistantDependencies(t, injector)
+	databaseService := newTestDatabaseService(t)
+	do.ProvideValue(injector, databaseService)
+	modelRegistry := provideTestAssistantDependencies(t, injector)
 
 	service, err := NewAssistantService(injector)
 
 	require.NoError(t, err)
 	require.NotNil(t, service.Runtime)
 	require.NotNil(t, service.Agents)
-	require.NotNil(t, service.Runtime.SessionRepository())
-	require.NotNil(t, service.Runtime.ModelRegistry())
+	assert.Same(t, databaseService.Sessions, service.Runtime.SessionRepository())
+	assert.Same(t, modelRegistry, service.Runtime.ModelRegistry())
+	assertRuntimeCapabilitiesUnavailable(t, service)
 }
 
-func provideTestAssistantDependencies(t *testing.T, injector do.Injector) {
+func provideTestAssistantDependencies(t *testing.T, injector do.Injector) *model.Registry {
 	t.Helper()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -47,7 +50,9 @@ func provideTestAssistantDependencies(t *testing.T, injector do.Injector) {
 		State:   extension.ManagerState{Configured: nil, Loaded: nil},
 	})
 	do.ProvideValue(injector, &CacheService{Responses: nil})
-	do.ProvideValue(injector, &ModelService{Registry: newTestModelRegistry(t)})
+
+	modelRegistry := newTestModelRegistry(t)
+	do.ProvideValue(injector, &ModelService{Registry: modelRegistry})
 	do.ProvideValue(injector, &SkillsService{Cache: core.NewSkillsCache()})
 	do.ProvideValue(injector, &LoggerService{
 		SlogLogger:    logger,
@@ -58,6 +63,8 @@ func provideTestAssistantDependencies(t *testing.T, injector do.Injector) {
 			skills.Cache.Close()
 		}
 	})
+
+	return modelRegistry
 }
 
 func newTestDatabaseService(t *testing.T) *DatabaseService {

--- a/internal/di/chat_workflow_service.go
+++ b/internal/di/chat_workflow_service.go
@@ -3,20 +3,22 @@ package di
 import (
 	"context"
 	"log/slog"
+	"sync"
 
 	"github.com/samber/do/v2"
+	"github.com/samber/oops"
 
 	"github.com/omarluq/librecode/internal/workflow"
 )
 
 // ChatWorkflowService owns the in-process workflow dispatcher used by interactive chat.
 type ChatWorkflowService struct {
-	Runs       *workflow.Service
-	Dispatcher *workflow.Dispatcher
+	runs       *workflow.Service
+	dispatcher *workflow.Dispatcher
 	workflows  *WorkflowService
 	database   *DatabaseService
-	assistant  *AssistantService
 	logger     *slog.Logger
+	lifecycle  sync.Mutex
 }
 
 // NewChatWorkflowService enables model-authored workflows for interactive chat.
@@ -31,48 +33,79 @@ func NewChatWorkflowService(injector do.Injector) (*ChatWorkflowService, error) 
 		return nil, serviceError(err, "resolve database service")
 	}
 
-	assistantService, err := do.Invoke[*AssistantService](injector)
-	if err != nil {
-		return nil, serviceError(err, "resolve assistant service")
-	}
-
 	loggerService, err := do.Invoke[*LoggerService](injector)
 	if err != nil {
 		return nil, serviceError(err, "resolve logger service")
 	}
 
 	return &ChatWorkflowService{
-		Runs: nil, Dispatcher: nil, workflows: workflows, database: databaseService,
-		assistant: assistantService, logger: loggerService.SlogLogger,
+		runs: nil, dispatcher: nil, workflows: workflows, database: databaseService,
+		logger: loggerService.SlogLogger, lifecycle: sync.Mutex{},
 	}, nil
 }
 
-// Start starts the in-process workflow dispatcher.
+// Runs returns the durable workflow service, if startup reached that stage.
+func (service *ChatWorkflowService) Runs() *workflow.Service {
+	service.lifecycle.Lock()
+	defer service.lifecycle.Unlock()
+
+	return service.runs
+}
+
+// Dispatcher returns the constructed workflow dispatcher, if startup reached that stage.
+func (service *ChatWorkflowService) Dispatcher() *workflow.Dispatcher {
+	service.lifecycle.Lock()
+	defer service.lifecycle.Unlock()
+
+	return service.dispatcher
+}
+
+// Start constructs the in-process workflow dispatcher without starting workers.
 func (service *ChatWorkflowService) Start(ctx context.Context) error {
-	if service.Dispatcher != nil {
+	service.lifecycle.Lock()
+	defer service.lifecycle.Unlock()
+
+	if service.dispatcher != nil {
 		return nil
 	}
 
-	dispatcher, err := workflow.NewDispatcher(ctx, workflow.DispatcherOptions{
-		Service: service.workflows.Runs, Tasks: service.database.Tasks, Logger: service.logger,
+	runs := service.workflows.Runs()
+
+	dispatcher, err := workflow.NewStoppedDispatcher(ctx, workflow.DispatcherOptions{
+		Service: runs, Tasks: service.database.Tasks, Logger: service.logger,
 		Concurrency: 0, Buffer: 0, Interval: 0,
 	})
 	if err != nil {
 		return serviceError(err, "create chat workflow dispatcher")
 	}
 
-	service.Runs = service.workflows.Runs
-	service.Dispatcher = dispatcher
-	service.assistant.Runtime.SetWorkflowSubmitter(dispatcher)
+	service.runs = runs
+	service.dispatcher = dispatcher
 
 	return nil
 }
 
+// StartWorkers starts workflow workers after runtime capabilities are published.
+func (service *ChatWorkflowService) StartWorkers() error {
+	service.lifecycle.Lock()
+	defer service.lifecycle.Unlock()
+
+	if service.dispatcher == nil {
+		return oops.In("di").Code("workflow_dispatcher_not_constructed").
+			Errorf("workflow dispatcher is not constructed")
+	}
+
+	return serviceError(service.dispatcher.Start(), "start chat workflow dispatcher")
+}
+
 // Shutdown stops workflow workers before their dependencies are closed.
 func (service *ChatWorkflowService) Shutdown(ctx context.Context) error {
-	if service.Dispatcher == nil {
+	service.lifecycle.Lock()
+	defer service.lifecycle.Unlock()
+
+	if service.dispatcher == nil {
 		return nil
 	}
 
-	return serviceError(service.Dispatcher.Shutdown(ctx), "shutdown chat workflow dispatcher")
+	return serviceError(service.dispatcher.Shutdown(ctx), "shutdown chat workflow dispatcher")
 }

--- a/internal/di/chat_workflow_service.go
+++ b/internal/di/chat_workflow_service.go
@@ -86,7 +86,7 @@ func (service *ChatWorkflowService) Start(ctx context.Context) error {
 }
 
 // StartWorkers starts workflow workers after runtime capabilities are published.
-func (service *ChatWorkflowService) StartWorkers() error {
+func (service *ChatWorkflowService) StartWorkers(ctx context.Context) error {
 	service.lifecycle.Lock()
 	defer service.lifecycle.Unlock()
 
@@ -95,7 +95,7 @@ func (service *ChatWorkflowService) StartWorkers() error {
 			Errorf("workflow dispatcher is not constructed")
 	}
 
-	return serviceError(service.dispatcher.Start(), "start chat workflow dispatcher")
+	return serviceError(service.dispatcher.Start(ctx), "start chat workflow dispatcher")
 }
 
 // Shutdown stops workflow workers before their dependencies are closed.

--- a/internal/di/container.go
+++ b/internal/di/container.go
@@ -91,6 +91,9 @@ func (c *Container) shutdownLocked(ctx context.Context) *do.ShutdownReport {
 	}
 
 	c.closed = true
+	if c.runtime != nil {
+		c.runtime.Assistant.capabilities.revoke()
+	}
 
 	return c.injector.ShutdownWithContext(ctx)
 }
@@ -123,6 +126,10 @@ func (c *Container) StartRuntime() (*RuntimeServices, error) {
 	}
 
 	if contextErr := ctx.Err(); contextErr != nil {
+		if runtimeServices != nil && runtimeServices.Assistant != nil {
+			runtimeServices.Assistant.capabilities.revoke()
+		}
+
 		return nil, c.runtimeStartErrorLocked(contextErr)
 	}
 
@@ -149,6 +156,34 @@ func (c *Container) constructRuntime(ctx context.Context) (*RuntimeServices, err
 	if err := services.ChatWorkflows.Start(ctx); err != nil {
 		return nil, err
 	}
+
+	if err := services.Assistant.capabilities.publish(
+		services.AgentTasks.Tasks(),
+		services.ChatWorkflows.Dispatcher(),
+	); err != nil {
+		return nil, serviceError(err, "publish runtime capabilities")
+	}
+
+	published := true
+	defer func() {
+		if published {
+			services.Assistant.capabilities.revoke()
+		}
+	}()
+
+	if err := services.AgentTasks.StartWorkers(ctx); err != nil {
+		return nil, err
+	}
+
+	if err := services.ChatWorkflows.StartWorkers(); err != nil {
+		return nil, err
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, oops.In("di").Code("runtime_start_canceled").Wrapf(err, "start runtime services")
+	}
+
+	published = false
 
 	return services, nil
 }

--- a/internal/di/container.go
+++ b/internal/di/container.go
@@ -175,7 +175,7 @@ func (c *Container) constructRuntime(ctx context.Context) (*RuntimeServices, err
 		return nil, err
 	}
 
-	if err := services.ChatWorkflows.StartWorkers(); err != nil {
+	if err := services.ChatWorkflows.StartWorkers(ctx); err != nil {
 		return nil, err
 	}
 

--- a/internal/di/runtime_capabilities.go
+++ b/internal/di/runtime_capabilities.go
@@ -1,0 +1,216 @@
+package di
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/samber/oops"
+
+	"github.com/omarluq/librecode/internal/assistant"
+	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/workflow"
+)
+
+type runtimeCapabilitySet struct {
+	agentTasks assistant.AgentTaskController
+	workflows  assistant.WorkflowSubmitter
+}
+
+type runtimeCapabilities struct {
+	set atomic.Pointer[runtimeCapabilitySet]
+}
+
+func newRuntimeCapabilities() *runtimeCapabilities {
+	return new(runtimeCapabilities)
+}
+
+func (capabilities *runtimeCapabilities) publish(
+	agentTasks assistant.AgentTaskController,
+	workflows assistant.WorkflowSubmitter,
+) error {
+	if agentTasks == nil {
+		return oops.In("di").Code("nil_agent_task_controller").Errorf("agent task controller is nil")
+	}
+
+	if workflows == nil {
+		return oops.In("di").Code("nil_workflow_submitter").Errorf("workflow submitter is nil")
+	}
+
+	published := &runtimeCapabilitySet{agentTasks: agentTasks, workflows: workflows}
+	if !capabilities.set.CompareAndSwap(nil, published) {
+		return oops.In("di").Code("runtime_capabilities_published").Errorf("runtime capabilities are already published")
+	}
+
+	return nil
+}
+
+func (capabilities *runtimeCapabilities) revoke() {
+	capabilities.set.Store(new(runtimeCapabilitySet))
+}
+
+func (capabilities *runtimeCapabilities) load() (*runtimeCapabilitySet, error) {
+	set := capabilities.set.Load()
+	if set == nil || set.agentTasks == nil || set.workflows == nil {
+		return nil, oops.In("assistant").Code("runtime_capabilities_unavailable").
+			Errorf("runtime capabilities are unavailable")
+	}
+
+	return set, nil
+}
+
+func unavailableAgentTasks(err error) error {
+	return oops.In("assistant").Code("agent_task_service_unavailable").
+		Wrapf(err, "agent task service is unavailable")
+}
+
+func unavailableWorkflows(err error) error {
+	return oops.In("assistant").Code("workflow_service_unavailable").
+		Wrapf(err, "workflow service is unavailable")
+}
+
+func (capabilities *runtimeCapabilities) SubmitAgentTask(
+	ctx context.Context,
+	request *assistant.AgentTaskRequest,
+) (*database.AgentTaskEntity, error) {
+	set, err := capabilities.load()
+	if err != nil {
+		return nil, unavailableAgentTasks(err)
+	}
+
+	result, err := set.agentTasks.SubmitAgentTask(ctx, request)
+	if err != nil {
+		return nil, oops.In("di").Code("submit_agent_task").Wrapf(err, "submit agent task")
+	}
+
+	return result, nil
+}
+
+func (capabilities *runtimeCapabilities) Get(
+	ctx context.Context,
+	taskID string,
+) (*database.AgentTaskEntity, bool, error) {
+	set, err := capabilities.load()
+	if err != nil {
+		return nil, false, unavailableAgentTasks(err)
+	}
+
+	result, found, err := set.agentTasks.Get(ctx, taskID)
+	if err != nil {
+		return nil, false, oops.In("di").Code("get_agent_task").Wrapf(err, "get agent task")
+	}
+
+	return result, found, nil
+}
+
+func (capabilities *runtimeCapabilities) List(
+	ctx context.Context,
+	ownerSessionID string,
+	limit int,
+) ([]database.AgentTaskEntity, error) {
+	set, err := capabilities.load()
+	if err != nil {
+		return nil, unavailableAgentTasks(err)
+	}
+
+	result, err := set.agentTasks.List(ctx, ownerSessionID, limit)
+	if err != nil {
+		return nil, oops.In("di").Code("list_agent_tasks").Wrapf(err, "list agent tasks")
+	}
+
+	return result, nil
+}
+
+func (capabilities *runtimeCapabilities) Cancel(
+	ctx context.Context,
+	ownerSessionID string,
+	taskID string,
+) (*database.TaskEntity, bool, error) {
+	set, err := capabilities.load()
+	if err != nil {
+		return nil, false, unavailableAgentTasks(err)
+	}
+
+	result, found, err := set.agentTasks.Cancel(ctx, ownerSessionID, taskID)
+	if err != nil {
+		return nil, false, oops.In("di").Code("cancel_agent_task").Wrapf(err, "cancel agent task")
+	}
+
+	return result, found, nil
+}
+
+func (capabilities *runtimeCapabilities) Await(
+	ctx context.Context,
+	taskID string,
+) (*database.AgentTaskEntity, error) {
+	set, err := capabilities.load()
+	if err != nil {
+		return nil, unavailableAgentTasks(err)
+	}
+
+	result, err := set.agentTasks.Await(ctx, taskID)
+	if err != nil {
+		return nil, oops.In("di").Code("await_agent_task").Wrapf(err, "await agent task")
+	}
+
+	return result, nil
+}
+
+func (capabilities *runtimeCapabilities) SubscribeAgentTask(
+	taskID string,
+) (events <-chan database.TaskEventEntity, cancel func(), err error) {
+	set, err := capabilities.load()
+	if err != nil {
+		return nil, nil, unavailableAgentTasks(err)
+	}
+
+	events, cancel, err = set.agentTasks.SubscribeAgentTask(taskID)
+	if err != nil {
+		return nil, nil, oops.In("di").Code("subscribe_agent_task").Wrapf(err, "subscribe agent task")
+	}
+
+	return events, cancel, nil
+}
+
+func (capabilities *runtimeCapabilities) Events(
+	ctx context.Context,
+	taskID string,
+	after int64,
+	limit int,
+) ([]database.TaskEventEntity, error) {
+	set, err := capabilities.load()
+	if err != nil {
+		return nil, unavailableAgentTasks(err)
+	}
+
+	reader, ok := set.agentTasks.(interface {
+		Events(context.Context, string, int64, int) ([]database.TaskEventEntity, error)
+	})
+	if !ok {
+		return nil, oops.In("assistant").Code("agent_task_events_unavailable").
+			Errorf("agent task events are unavailable")
+	}
+
+	result, err := reader.Events(ctx, taskID, after, limit)
+	if err != nil {
+		return nil, oops.In("di").Code("list_agent_task_events").Wrapf(err, "list agent task events")
+	}
+
+	return result, nil
+}
+
+func (capabilities *runtimeCapabilities) Submit(
+	ctx context.Context,
+	request *workflow.ServiceRequest,
+) (*database.WorkflowRunEntity, error) {
+	set, err := capabilities.load()
+	if err != nil {
+		return nil, unavailableWorkflows(err)
+	}
+
+	result, err := set.workflows.Submit(ctx, request)
+	if err != nil {
+		return nil, oops.In("di").Code("submit_workflow").Wrapf(err, "submit workflow")
+	}
+
+	return result, nil
+}

--- a/internal/di/runtime_capabilities_internal_test.go
+++ b/internal/di/runtime_capabilities_internal_test.go
@@ -1,0 +1,280 @@
+package di
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/omarluq/librecode/internal/assistant"
+	"github.com/omarluq/librecode/internal/database"
+	"github.com/omarluq/librecode/internal/workflow"
+)
+
+type capabilityAgentStub struct {
+	err error
+}
+
+func (stub *capabilityAgentStub) SubmitAgentTask(
+	context.Context,
+	*assistant.AgentTaskRequest,
+) (*database.AgentTaskEntity, error) {
+	return testAgentTask(), stub.err
+}
+
+func (stub *capabilityAgentStub) Get(
+	context.Context,
+	string,
+) (*database.AgentTaskEntity, bool, error) {
+	return testAgentTask(), true, stub.err
+}
+
+func (stub *capabilityAgentStub) List(
+	context.Context,
+	string,
+	int,
+) ([]database.AgentTaskEntity, error) {
+	return []database.AgentTaskEntity{*testAgentTask()}, stub.err
+}
+
+func (stub *capabilityAgentStub) Cancel(
+	context.Context,
+	string,
+	string,
+) (*database.TaskEntity, bool, error) {
+	return testTask("task"), true, stub.err
+}
+
+func (stub *capabilityAgentStub) Await(
+	context.Context,
+	string,
+) (*database.AgentTaskEntity, error) {
+	return testAgentTask(), stub.err
+}
+
+func (stub *capabilityAgentStub) SubscribeAgentTask(
+	string,
+) (events <-chan database.TaskEventEntity, cancel func(), err error) {
+	if stub.err != nil {
+		return nil, nil, stub.err
+	}
+
+	channel := make(chan database.TaskEventEntity)
+	close(channel)
+
+	return channel, func() {}, nil
+}
+
+func (stub *capabilityAgentStub) Events(
+	context.Context,
+	string,
+	int64,
+	int,
+) ([]database.TaskEventEntity, error) {
+	return []database.TaskEventEntity{*testTaskEvent()}, stub.err
+}
+
+type capabilityWorkflowStub struct {
+	err error
+}
+
+func (stub *capabilityWorkflowStub) Submit(
+	context.Context,
+	*workflow.ServiceRequest,
+) (*database.WorkflowRunEntity, error) {
+	return testWorkflowRun(), stub.err
+}
+
+func TestRuntimeCapabilitiesDelegateSuccessfulOperations(t *testing.T) {
+	t.Parallel()
+
+	capabilities := newRuntimeCapabilities()
+	require.NoError(t, capabilities.publish(new(capabilityAgentStub), new(capabilityWorkflowStub)))
+
+	submitted, err := capabilities.SubmitAgentTask(t.Context(), new(assistant.AgentTaskRequest))
+	require.NoError(t, err)
+	assert.Equal(t, "agent-task", submitted.Task.ID)
+
+	got, found, err := capabilities.Get(t.Context(), "agent-task")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "agent-task", got.Task.ID)
+
+	listed, err := capabilities.List(t.Context(), "owner", 1)
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.Equal(t, "agent-task", listed[0].Task.ID)
+
+	canceled, found, err := capabilities.Cancel(t.Context(), "owner", "task")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "task", canceled.ID)
+
+	awaited, err := capabilities.Await(t.Context(), "agent-task")
+	require.NoError(t, err)
+	assert.Equal(t, "agent-task", awaited.Task.ID)
+
+	subscription, cancel, err := capabilities.SubscribeAgentTask("agent-task")
+	require.NoError(t, err)
+	require.NotNil(t, cancel)
+	cancel()
+
+	_, open := <-subscription
+	assert.False(t, open)
+
+	events, err := capabilities.Events(t.Context(), "task", 0, 1)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, int64(1), events[0].Sequence)
+
+	run, err := capabilities.Submit(t.Context(), new(workflow.ServiceRequest))
+	require.NoError(t, err)
+	assert.Equal(t, "workflow", run.Task.ID)
+}
+
+func TestRuntimeCapabilitiesRejectAgentEventsWithoutReader(t *testing.T) {
+	t.Parallel()
+
+	capabilities := newRuntimeCapabilities()
+	require.NoError(t, capabilities.publish(
+		&capabilityAgentWithoutEvents{AgentTaskController: new(capabilityAgentStub)},
+		new(capabilityWorkflowStub),
+	))
+
+	_, err := capabilities.Events(t.Context(), "task", 0, 1)
+	requireOopsCode(t, err, "agent_task_events_unavailable")
+}
+
+type capabilityAgentWithoutEvents struct {
+	assistant.AgentTaskController
+}
+
+type capabilityErrorTest struct {
+	call     func(*runtimeCapabilities) error
+	name     string
+	wantCode string
+}
+
+func TestRuntimeCapabilitiesWrapDelegationErrors(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("operation failed")
+
+	for _, test := range runtimeCapabilityErrorTests(t) {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			capabilities := newRuntimeCapabilities()
+			require.NoError(t, capabilities.publish(
+				&capabilityAgentStub{err: expectedErr},
+				&capabilityWorkflowStub{err: expectedErr},
+			))
+
+			err := test.call(capabilities)
+			require.ErrorIs(t, err, expectedErr)
+			requireOopsCode(t, err, test.wantCode)
+		})
+	}
+}
+
+func runtimeCapabilityErrorTests(t *testing.T) []capabilityErrorTest {
+	t.Helper()
+
+	return []capabilityErrorTest{
+		{
+			name: "submit agent task", wantCode: "submit_agent_task",
+			call: func(capabilities *runtimeCapabilities) error {
+				_, err := capabilities.SubmitAgentTask(t.Context(), new(assistant.AgentTaskRequest))
+
+				return err
+			},
+		},
+		{
+			name: "get agent task", wantCode: "get_agent_task",
+			call: func(capabilities *runtimeCapabilities) error {
+				_, _, err := capabilities.Get(t.Context(), "task")
+
+				return err
+			},
+		},
+		{
+			name: "list agent tasks", wantCode: "list_agent_tasks",
+			call: func(capabilities *runtimeCapabilities) error {
+				_, err := capabilities.List(t.Context(), "owner", 1)
+
+				return err
+			},
+		},
+		{
+			name: "cancel agent task", wantCode: "cancel_agent_task",
+			call: func(capabilities *runtimeCapabilities) error {
+				_, _, err := capabilities.Cancel(t.Context(), "owner", "task")
+
+				return err
+			},
+		},
+		{
+			name: "await agent task", wantCode: "await_agent_task",
+			call: func(capabilities *runtimeCapabilities) error {
+				_, err := capabilities.Await(t.Context(), "task")
+
+				return err
+			},
+		},
+		{
+			name: "subscribe agent task", wantCode: "subscribe_agent_task",
+			call: func(capabilities *runtimeCapabilities) error {
+				_, _, err := capabilities.SubscribeAgentTask("task")
+
+				return err
+			},
+		},
+		{
+			name: "list agent task events", wantCode: "list_agent_task_events",
+			call: func(capabilities *runtimeCapabilities) error {
+				_, err := capabilities.Events(t.Context(), "task", 0, 1)
+
+				return err
+			},
+		},
+		{
+			name: "submit workflow", wantCode: "submit_workflow",
+			call: func(capabilities *runtimeCapabilities) error {
+				_, err := capabilities.Submit(t.Context(), new(workflow.ServiceRequest))
+
+				return err
+			},
+		},
+	}
+}
+
+func testAgentTask() *database.AgentTaskEntity {
+	return &database.AgentTaskEntity{
+		Task: *testTask("agent-task"), ChildSessionID: "", AgentName: "", Prompt: "", Model: "", Provider: "",
+		PolicyJSON: "", UsageJSON: "", Depth: 0,
+	}
+}
+
+func testTask(id string) *database.TaskEntity {
+	return &database.TaskEntity{
+		CreatedAt: time.Time{}, StartedAt: nil, FinishedAt: nil, UpdatedAt: time.Time{}, LeaseExpiresAt: nil,
+		ID: id, Kind: "", ParentTaskID: "", OwnerSessionID: "", ConcurrencyKey: "", LeaseOwner: "",
+		State: "", Result: "", ErrorCode: "", ErrorMessage: "",
+	}
+}
+
+func testTaskEvent() *database.TaskEventEntity {
+	return &database.TaskEventEntity{
+		Event:  database.EventEntity{CreatedAt: time.Time{}, ID: "", Kind: "", PayloadJSON: ""},
+		TaskID: "task", Sequence: 1,
+	}
+}
+
+func testWorkflowRun() *database.WorkflowRunEntity {
+	return &database.WorkflowRunEntity{
+		Task: *testTask("workflow"), Name: "", Source: "", SourceHash: "", SourceVersion: "", ArgumentsJSON: "",
+	}
+}

--- a/internal/di/service_constructors_internal_test.go
+++ b/internal/di/service_constructors_internal_test.go
@@ -3,6 +3,7 @@ package di
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -12,14 +13,35 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/samber/do/v2"
+	"github.com/samber/oops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/omarluq/librecode/internal/agenttask"
+	"github.com/omarluq/librecode/internal/assistant"
 	"github.com/omarluq/librecode/internal/config"
+	"github.com/omarluq/librecode/internal/workflow"
 )
 
 func provideTestApplicationContext(injector do.Injector) {
 	do.ProvideNamedValue(injector, applicationContextKey, context.Background())
+}
+
+func newIsolatedContainer(ctx context.Context, t *testing.T, overrides ConfigOverrides) *Container {
+	t.Helper()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	databasePath := filepath.Join(t.TempDir(), "librecode.db")
+	require.NoError(t, os.WriteFile(
+		configPath,
+		fmt.Appendf(nil, "database:\n  path: %q\n", databasePath),
+		0o600,
+	))
+
+	container, err := NewContainer(ctx, configPath, overrides)
+	require.NoError(t, err)
+
+	return container
 }
 
 func TestNewCacheServiceUsesConfiguredCache(t *testing.T) {
@@ -63,7 +85,9 @@ func TestNewAgentTaskServiceRejectsIncompleteWiring(t *testing.T) {
 	do.ProvideValue(injector, &DatabaseService{
 		DB: nil, Sessions: nil, Documents: nil, Tasks: nil, AgentTasks: nil, Workflows: nil, path: "",
 	})
-	do.ProvideValue(injector, &AssistantService{Runtime: nil, Agents: nil})
+	do.ProvideValue(injector, &AssistantService{
+		Runtime: nil, Agents: nil, capabilities: nil,
+	})
 
 	do.ProvideValue(injector, &LoggerService{SlogLogger: nil, ZerologLogger: zerolog.Logger{}})
 
@@ -96,14 +120,14 @@ func TestAgentTaskServiceWiresAndShutsDown(t *testing.T) {
 	injector := do.New()
 	provideTestApplicationContext(injector)
 	do.ProvideValue(injector, newTestDatabaseService(t))
-	assistant := newTestAssistantService(t, injector)
-	do.ProvideValue(injector, assistant)
+	assistantService := newTestAssistantService(t, injector)
+	do.ProvideValue(injector, assistantService)
 
 	service, err := NewAgentTaskService(injector)
 	require.NoError(t, err)
-	require.Nil(t, service.Tasks)
+	require.Nil(t, service.Tasks())
 	require.NoError(t, service.Start(t.Context()))
-	require.NotNil(t, service.Tasks)
+	require.NotNil(t, service.Tasks())
 	require.NoError(t, service.Shutdown(context.Background()))
 }
 
@@ -124,7 +148,7 @@ func TestNewContainerRejectsNilContext(t *testing.T) {
 
 	container, err := NewContainer(ctx, "", ConfigOverrides{DisableExtensions: false, Interactive: false})
 	assert.Nil(t, container)
-	assert.ErrorContains(t, err, "application context is required")
+	requireOopsCode(t, err, "nil_application_context")
 }
 
 func TestContainerAccessorReturnsConstructionError(t *testing.T) {
@@ -154,11 +178,10 @@ func TestStartRuntimeRejectsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	container, err := NewContainer(ctx, "", ConfigOverrides{
+	container := newIsolatedContainer(ctx, t, ConfigOverrides{
 		DisableExtensions: true,
 		Interactive:       false,
 	})
-	require.NoError(t, err)
 
 	services, err := container.StartRuntime()
 	require.ErrorIs(t, err, context.Canceled)
@@ -168,40 +191,40 @@ func TestStartRuntimeRejectsCanceledContext(t *testing.T) {
 func TestAssistantServiceAccessorDoesNotStartWorkers(t *testing.T) {
 	t.Parallel()
 
-	container, err := NewContainer(context.Background(), "", ConfigOverrides{
+	container := newIsolatedContainer(context.Background(), t, ConfigOverrides{
 		DisableExtensions: true,
 		Interactive:       false,
 	})
-	require.NoError(t, err)
 	t.Cleanup(func() {
 		report := container.ShutdownWithContext(context.Background())
 		assert.Empty(t, report.Errors)
 	})
 
-	_, err = container.AssistantService()
+	assistantService, err := container.AssistantService()
 	require.NoError(t, err)
+
+	assertRuntimeCapabilitiesUnavailable(t, assistantService)
 
 	agentTasks, err := container.AgentTaskService()
 	require.NoError(t, err)
-	assert.Nil(t, agentTasks.Tasks)
+	assert.Nil(t, agentTasks.Tasks())
 
 	workflows, err := container.WorkflowService()
 	require.NoError(t, err)
-	assert.Nil(t, workflows.Runs)
+	assert.Nil(t, workflows.Runs())
 
 	chatWorkflows, err := container.ChatWorkflowService()
 	require.NoError(t, err)
-	assert.Nil(t, chatWorkflows.Dispatcher)
+	assert.Nil(t, chatWorkflows.Dispatcher())
 }
 
 func TestStartRuntimeCleansUpPartialConstruction(t *testing.T) {
 	t.Parallel()
 
-	container, err := NewContainer(context.Background(), "", ConfigOverrides{
+	container := newIsolatedContainer(context.Background(), t, ConfigOverrides{
 		DisableExtensions: true,
 		Interactive:       false,
 	})
-	require.NoError(t, err)
 
 	recorder := new(shutdownRecorder)
 	do.ProvideValue(container.injector, recorder)
@@ -217,10 +240,15 @@ func TestStartRuntimeCleansUpPartialConstruction(t *testing.T) {
 		return nil, expectedErr
 	}
 
+	assistantService, err := container.AssistantService()
+	require.NoError(t, err)
+	assertRuntimeCapabilitiesUnavailable(t, assistantService)
+
 	runtimeServices, err := container.StartRuntime()
 	require.ErrorIs(t, err, expectedErr)
 	assert.Nil(t, runtimeServices)
 	assert.Equal(t, []string{"child", "parent"}, recorder.snapshot())
+	assertRuntimeCapabilitiesUnavailable(t, assistantService)
 
 	_, err = container.DatabaseService()
 	assert.Error(t, err)
@@ -284,40 +312,123 @@ func (resource *bootstrapChild) Shutdown(context.Context) error {
 	return nil
 }
 
-func TestStartRuntimeDoesNotPublishAfterCancellation(t *testing.T) {
+func TestStartRuntimeRevokesCapabilitiesAfterCancellation(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	container, err := NewContainer(ctx, "", ConfigOverrides{
+	container := newIsolatedContainer(ctx, t, ConfigOverrides{
 		DisableExtensions: true,
 		Interactive:       false,
 	})
+
+	assistantService, err := container.AssistantService()
 	require.NoError(t, err)
 
 	container.buildRuntime = func(context.Context) (*RuntimeServices, error) {
+		require.NoError(t, assistantService.capabilities.publish(
+			new(agenttask.Service),
+			new(workflow.Dispatcher),
+		))
 		cancel()
 
-		return new(RuntimeServices), nil
+		return &RuntimeServices{
+			Config:        nil,
+			Database:      nil,
+			Auth:          nil,
+			Models:        nil,
+			Extensions:    nil,
+			Assistant:     assistantService,
+			AgentTasks:    nil,
+			Workflows:     nil,
+			ChatWorkflows: nil,
+		}, nil
 	}
 
 	runtimeServices, err := container.StartRuntime()
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Nil(t, runtimeServices)
+	assertRuntimeCapabilitiesUnavailable(t, assistantService)
 
 	_, err = container.ConfigService()
-	assert.Error(t, err)
+	requireOopsCode(t, err, "container_closed")
+}
+
+func TestRuntimeCapabilitiesPublicationLifecycle(t *testing.T) {
+	t.Parallel()
+
+	capabilities := newRuntimeCapabilities()
+	agentTasks := new(agenttask.Service)
+	workflows := new(workflow.Dispatcher)
+
+	assertRuntimeCapabilitySetUnavailable(t, capabilities)
+	require.NoError(t, capabilities.publish(agentTasks, workflows))
+
+	published, err := capabilities.load()
+	require.NoError(t, err)
+	assert.Same(t, agentTasks, published.agentTasks)
+	assert.Same(t, workflows, published.workflows)
+
+	requireOopsCode(t, capabilities.publish(agentTasks, workflows), "runtime_capabilities_published")
+
+	capabilities.revoke()
+	assertRuntimeCapabilitySetUnavailable(t, capabilities)
+}
+
+func TestRuntimeCapabilitiesRejectIncompleteSet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		agentTasks assistant.AgentTaskController
+		workflows  assistant.WorkflowSubmitter
+		wantCode   string
+	}{
+		{
+			name: "agent tasks", agentTasks: nil, workflows: new(workflow.Dispatcher),
+			wantCode: "nil_agent_task_controller",
+		},
+		{name: "workflows", agentTasks: new(agenttask.Service), workflows: nil, wantCode: "nil_workflow_submitter"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			capabilities := newRuntimeCapabilities()
+			requireOopsCode(t, capabilities.publish(test.agentTasks, test.workflows), test.wantCode)
+			assertRuntimeCapabilitySetUnavailable(t, capabilities)
+		})
+	}
+}
+
+func assertRuntimeCapabilitySetUnavailable(t *testing.T, capabilities *runtimeCapabilities) {
+	t.Helper()
+
+	_, err := capabilities.List(t.Context(), "missing", 1)
+	requireOopsCode(t, err, "runtime_capabilities_unavailable")
+
+	_, err = capabilities.Submit(t.Context(), nil)
+	requireOopsCode(t, err, "runtime_capabilities_unavailable")
+}
+
+func requireOopsCode(t *testing.T, err error, want string) {
+	t.Helper()
+	require.Error(t, err)
+
+	var coded oops.OopsError
+	require.ErrorAs(t, err, &coded)
+	assert.Equal(t, want, coded.Code())
 }
 
 func TestStartRuntimeStartsWorkersExplicitly(t *testing.T) {
 	t.Parallel()
 
-	container, err := NewContainer(context.Background(), "", ConfigOverrides{
+	container := newIsolatedContainer(context.Background(), t, ConfigOverrides{
 		DisableExtensions: true,
 		Interactive:       false,
 	})
-	require.NoError(t, err)
 	t.Cleanup(func() {
 		report := container.ShutdownWithContext(context.Background())
 		assert.Empty(t, report.Errors)
@@ -333,73 +444,110 @@ func TestStartRuntimeStartsWorkersExplicitly(t *testing.T) {
 
 	agentTasks, err := container.AgentTaskService()
 	require.NoError(t, err)
-	require.NotNil(t, agentTasks.Tasks)
+	require.NotNil(t, agentTasks.Tasks())
 
 	workflows, err := container.WorkflowService()
 	require.NoError(t, err)
-	require.NotNil(t, workflows.Runs)
+	require.NotNil(t, workflows.Runs())
 
 	chatWorkflows, err := container.ChatWorkflowService()
 	require.NoError(t, err)
-	require.NotNil(t, chatWorkflows.Dispatcher)
+	require.NotNil(t, chatWorkflows.Dispatcher())
+
+	tasks, err := runtimeServices.Assistant.Runtime.AgentTasks(t.Context(), "missing", 1)
+	require.NoError(t, err)
+	assert.Empty(t, tasks)
+
+	_, found, err := runtimeServices.Assistant.Runtime.AgentTask(t.Context(), "missing")
+	require.NoError(t, err)
+	assert.False(t, found)
+
+	published := runtimeServices.Assistant.capabilities.set.Load()
+	require.NotNil(t, published)
+	assert.Same(t, runtimeServices.AgentTasks.Tasks(), published.agentTasks)
+	assert.Same(t, runtimeServices.ChatWorkflows.Dispatcher(), published.workflows)
+
+	report := container.ShutdownWithContext(t.Context())
+	require.Empty(t, report.Errors)
+	assertRuntimeCapabilitiesUnavailable(t, runtimeServices.Assistant)
+}
+
+func assertRuntimeCapabilitiesUnavailable(t *testing.T, service *AssistantService) {
+	t.Helper()
+
+	tasks, err := service.Runtime.AgentTasks(t.Context(), "missing", 1)
+	requireOopsCode(t, err, "runtime_capabilities_unavailable")
+	assert.Nil(t, tasks)
+
+	_, err = service.capabilities.Submit(t.Context(), nil)
+	requireOopsCode(t, err, "runtime_capabilities_unavailable")
 }
 
 func TestContainerRejectsResolutionAfterShutdown(t *testing.T) {
 	t.Parallel()
 
-	container, err := NewContainer(context.Background(), "", ConfigOverrides{
+	container := newIsolatedContainer(context.Background(), t, ConfigOverrides{
 		DisableExtensions: true,
 		Interactive:       false,
 	})
-	require.NoError(t, err)
-	assert.True(t, container.ShutdownWithContext(context.Background()).Succeed)
-	assert.True(t, container.ShutdownWithContext(context.Background()).Succeed)
+	require.True(t, container.ShutdownWithContext(context.Background()).Succeed)
+	require.True(t, container.ShutdownWithContext(context.Background()).Succeed)
 
 	runtimeServices, err := container.StartRuntime()
 	assert.Nil(t, runtimeServices)
-	require.ErrorContains(t, err, "container is closed")
+	requireOopsCode(t, err, "container_closed")
 
-	services := containerServiceAccessors(container)
-	for _, resolve := range services {
-		service, resolveErr := resolve()
-		assert.Nil(t, service)
-		assert.ErrorContains(t, resolveErr, "container is closed")
+	for _, service := range containerServiceAccessors(container) {
+		t.Run(service.name, func(t *testing.T) {
+			t.Parallel()
+
+			resolved, resolveErr := service.resolve()
+			assert.Nil(t, resolved)
+			requireOopsCode(t, resolveErr, "container_closed")
+		})
 	}
 }
 
 func TestContainerServiceAccessors(t *testing.T) {
 	t.Parallel()
 
-	container, err := NewContainer(context.Background(), "", ConfigOverrides{
+	container := newIsolatedContainer(context.Background(), t, ConfigOverrides{
 		DisableExtensions: false,
 		Interactive:       false,
 	})
-	require.NoError(t, err)
 	t.Cleanup(func() {
 		report := container.ShutdownWithContext(context.Background())
 		assert.Empty(t, report.Errors)
 	})
 
-	services := containerServiceAccessors(container)
-	for _, resolve := range services {
-		service, resolveErr := resolve()
-		require.NoError(t, resolveErr)
-		require.NotNil(t, service)
+	for _, service := range containerServiceAccessors(container) {
+		t.Run(service.name, func(t *testing.T) {
+			t.Parallel()
+
+			resolved, resolveErr := service.resolve()
+			require.NoError(t, resolveErr)
+			require.NotNil(t, resolved)
+		})
 	}
 }
 
-func containerServiceAccessors(container *Container) []func() (any, error) {
-	return []func() (any, error){
-		func() (any, error) { return container.ConfigService() },
-		func() (any, error) { return container.AuthService() },
-		func() (any, error) { return container.DatabaseService() },
-		func() (any, error) { return container.ExtensionService() },
-		func() (any, error) { return container.ModelService() },
-		func() (any, error) { return container.AssistantService() },
-		func() (any, error) { return container.AgentTaskService() },
-		func() (any, error) { return container.WorkflowService() },
-		func() (any, error) { return container.ChatWorkflowService() },
-		func() (any, error) { return container.ToolService() },
-		func() (any, error) { return container.SkillsService() },
+type containerServiceAccessor struct {
+	resolve func() (any, error)
+	name    string
+}
+
+func containerServiceAccessors(container *Container) []containerServiceAccessor {
+	return []containerServiceAccessor{
+		{name: "config", resolve: func() (any, error) { return container.ConfigService() }},
+		{name: "auth", resolve: func() (any, error) { return container.AuthService() }},
+		{name: "database", resolve: func() (any, error) { return container.DatabaseService() }},
+		{name: "extension", resolve: func() (any, error) { return container.ExtensionService() }},
+		{name: "model", resolve: func() (any, error) { return container.ModelService() }},
+		{name: "assistant", resolve: func() (any, error) { return container.AssistantService() }},
+		{name: "agent task", resolve: func() (any, error) { return container.AgentTaskService() }},
+		{name: "workflow", resolve: func() (any, error) { return container.WorkflowService() }},
+		{name: "chat workflow", resolve: func() (any, error) { return container.ChatWorkflowService() }},
+		{name: "tool", resolve: func() (any, error) { return container.ToolService() }},
+		{name: "skills", resolve: func() (any, error) { return container.SkillsService() }},
 	}
 }

--- a/internal/di/service_constructors_internal_test.go
+++ b/internal/di/service_constructors_internal_test.go
@@ -114,6 +114,16 @@ func TestNewAgentTaskServiceWrapsSchedulerError(t *testing.T) {
 	require.ErrorContains(t, err, "create agent task service")
 }
 
+func TestWorkflowServiceRejectsUnconstructedAgentTaskService(t *testing.T) {
+	t.Parallel()
+
+	service := &WorkflowService{
+		runner: nil, runs: nil, database: nil, assistant: nil, agentTasks: new(AgentTaskService),
+		lifecycle: sync.Mutex{},
+	}
+	requireOopsCode(t, service.Start(t.Context()), "agent_task_service_not_constructed")
+}
+
 func TestAgentTaskServiceWiresAndShutsDown(t *testing.T) {
 	t.Parallel()
 

--- a/internal/di/workflow_service.go
+++ b/internal/di/workflow_service.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/samber/do/v2"
+	"github.com/samber/oops"
 
 	"github.com/omarluq/librecode/internal/assistant"
 	"github.com/omarluq/librecode/internal/workflow"
@@ -69,6 +70,10 @@ func (service *WorkflowService) Start(ctx context.Context) error {
 	}
 
 	tasks := service.agentTasks.Tasks()
+	if tasks == nil {
+		return oops.In("di").Code("agent_task_service_not_constructed").
+			Errorf("agent task service is not constructed")
+	}
 
 	submitter, err := assistant.NewAgentSubmitter(
 		tasks,

--- a/internal/di/workflow_service.go
+++ b/internal/di/workflow_service.go
@@ -2,6 +2,7 @@ package di
 
 import (
 	"context"
+	"sync"
 
 	"github.com/samber/do/v2"
 
@@ -11,11 +12,12 @@ import (
 
 // WorkflowService owns script-driven durable agent orchestration.
 type WorkflowService struct {
-	Runner     *workflow.Runner
-	Runs       *workflow.Service
+	runner     *workflow.Runner
+	runs       *workflow.Service
 	database   *DatabaseService
 	assistant  *AssistantService
 	agentTasks *AgentTaskService
+	lifecycle  sync.Mutex
 }
 
 // NewWorkflowService wires workflow execution to the durable agent scheduler.
@@ -36,18 +38,40 @@ func NewWorkflowService(injector do.Injector) (*WorkflowService, error) {
 	}
 
 	return &WorkflowService{
-		Runner: nil, Runs: nil, database: databaseService, assistant: assistantService, agentTasks: agentTaskService,
+		runner: nil, runs: nil, database: databaseService, assistant: assistantService, agentTasks: agentTaskService,
+		lifecycle: sync.Mutex{},
 	}, nil
+}
+
+// Runner returns the constructed workflow runner, if startup reached that stage.
+func (service *WorkflowService) Runner() *workflow.Runner {
+	service.lifecycle.Lock()
+	defer service.lifecycle.Unlock()
+
+	return service.runner
+}
+
+// Runs returns the constructed durable workflow service, if startup reached that stage.
+func (service *WorkflowService) Runs() *workflow.Service {
+	service.lifecycle.Lock()
+	defer service.lifecycle.Unlock()
+
+	return service.runs
 }
 
 // Start constructs workflow orchestration and recovers interrupted runs.
 func (service *WorkflowService) Start(ctx context.Context) error {
-	if service.Runs != nil {
+	service.lifecycle.Lock()
+	defer service.lifecycle.Unlock()
+
+	if service.runs != nil {
 		return nil
 	}
 
+	tasks := service.agentTasks.Tasks()
+
 	submitter, err := assistant.NewAgentSubmitter(
-		service.agentTasks.Tasks,
+		tasks,
 		service.assistant.Agents,
 	)
 	if err != nil {
@@ -56,7 +80,7 @@ func (service *WorkflowService) Start(ctx context.Context) error {
 
 	controller, err := assistant.NewWorkflowController(
 		submitter,
-		service.agentTasks.Tasks,
+		tasks,
 		service.database.Sessions,
 	)
 	if err != nil {
@@ -77,8 +101,8 @@ func (service *WorkflowService) Start(ctx context.Context) error {
 		return serviceError(recoverErr, "recover interrupted workflows")
 	}
 
-	service.Runner = runner
-	service.Runs = runs
+	service.runner = runner
+	service.runs = runs
 
 	return nil
 }

--- a/internal/terminal/agent_tasks.go
+++ b/internal/terminal/agent_tasks.go
@@ -371,7 +371,13 @@ func (app *App) watchActiveAgentTasks(ctx context.Context) {
 			continue
 		}
 
-		events, cancelSubscription := app.runtime.SubscribeAgentTask(taskID)
+		events, cancelSubscription, err := app.runtime.SubscribeAgentTask(taskID)
+		if err != nil {
+			app.postAgentTaskWatchError(ctx, taskID, "failed to subscribe to agent task activity: "+err.Error())
+
+			continue
+		}
+
 		watchCtx, cancelWatch := context.WithCancel(ctx)
 		app.agentTaskWatches[taskID] = func() {
 			cancelWatch()
@@ -550,7 +556,13 @@ func (app *App) forwardAgentTaskEventWithRuntime(
 func (app *App) watchInspectedAgentTask(ctx context.Context, taskID string) {
 	app.stopAgentTaskWatch(taskID)
 
-	events, cancelSubscription := app.runtime.SubscribeAgentTask(taskID)
+	events, cancelSubscription, err := app.runtime.SubscribeAgentTask(taskID)
+	if err != nil {
+		app.postAgentTaskWatchError(ctx, taskID, "failed to subscribe to agent task activity: "+err.Error())
+
+		return
+	}
+
 	watchCtx, cancelWatch := context.WithCancel(ctx)
 	app.agentTaskWatches[taskID] = func() {
 		cancelWatch()
@@ -638,10 +650,13 @@ func (app *App) postAgentTaskWatchClosed(ctx context.Context, taskID string) {
 }
 
 func (app *App) postAgentTaskReplayError(ctx context.Context, taskID string, err error) {
+	app.postAgentTaskWatchError(ctx, taskID, "failed to replay agent task activity: "+err.Error())
+}
+
+func (app *App) postAgentTaskWatchError(ctx context.Context, taskID, message string) {
 	app.postAsyncEvent(ctx, &asyncEvent{
 		Response: nil, ToolCallEvent: nil, ToolEvent: nil, Usage: nil,
-		Kind: asyncEventAgentTaskReplayError, Provider: taskID,
-		Text: "failed to replay agent task activity: " + err.Error(), PromptID: 0,
+		Kind: asyncEventAgentTaskReplayError, Provider: taskID, Text: message, PromptID: 0,
 	})
 }
 

--- a/internal/terminal/agent_tasks_behavior_internal_test.go
+++ b/internal/terminal/agent_tasks_behavior_internal_test.go
@@ -35,15 +35,16 @@ const (
 )
 
 type agentTaskControllerStub struct {
-	listErr     error
-	getErr      error
-	cancelErr   error
-	tasks       map[string]*database.AgentTaskEntity
-	subscribe   map[string]chan database.TaskEventEntity
-	canceled    map[string]bool
-	list        []database.AgentTaskEntity
-	cancelCalls []string
-	mu          sync.Mutex
+	listErr      error
+	getErr       error
+	cancelErr    error
+	subscribeErr error
+	tasks        map[string]*database.AgentTaskEntity
+	subscribe    map[string]chan database.TaskEventEntity
+	canceled     map[string]bool
+	list         []database.AgentTaskEntity
+	cancelCalls  []string
+	mu           sync.Mutex
 }
 
 func (stub *agentTaskControllerStub) SubmitAgentTask(
@@ -58,15 +59,16 @@ func newAgentTaskControllerStub(
 	list []database.AgentTaskEntity,
 ) *agentTaskControllerStub {
 	return &agentTaskControllerStub{
-		listErr:     nil,
-		getErr:      nil,
-		cancelErr:   nil,
-		tasks:       tasks,
-		subscribe:   nil,
-		canceled:    make(map[string]bool),
-		list:        list,
-		cancelCalls: nil,
-		mu:          sync.Mutex{},
+		listErr:      nil,
+		getErr:       nil,
+		cancelErr:    nil,
+		subscribeErr: nil,
+		tasks:        tasks,
+		subscribe:    nil,
+		canceled:     make(map[string]bool),
+		list:         list,
+		cancelCalls:  nil,
+		mu:           sync.Mutex{},
 	}
 }
 
@@ -116,9 +118,13 @@ func (stub *agentTaskControllerStub) Await(context.Context, string) (*database.A
 
 func (stub *agentTaskControllerStub) SubscribeAgentTask(
 	taskID string,
-) (events <-chan database.TaskEventEntity, cancel func()) {
+) (events <-chan database.TaskEventEntity, cancel func(), err error) {
 	stub.mu.Lock()
 	defer stub.mu.Unlock()
+
+	if stub.subscribeErr != nil {
+		return nil, nil, stub.subscribeErr
+	}
 
 	if stub.subscribe == nil {
 		stub.subscribe = map[string]chan database.TaskEventEntity{}
@@ -135,7 +141,7 @@ func (stub *agentTaskControllerStub) SubscribeAgentTask(
 		defer stub.mu.Unlock()
 
 		stub.canceled[taskID] = true
-	}
+	}, nil
 }
 
 func (stub *agentTaskControllerStub) wasCanceled(taskID string) bool {
@@ -148,8 +154,9 @@ func (stub *agentTaskControllerStub) wasCanceled(taskID string) bool {
 func newAgentTaskBehaviorApp(t *testing.T, stub *agentTaskControllerStub) *App {
 	t.Helper()
 
-	runtime := assistant.NewRuntimeForTest(nil)
-	runtime.SetAgentTaskController(stub)
+	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.AgentTasks = stub
+	})
 
 	app := newRenderTestApp(t)
 	app.runtime = runtime
@@ -203,8 +210,8 @@ func newAgentTaskSessionTestApp(
 	app := newRenderTestApp(t)
 	app.runtime = assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
 		options.Sessions = fixture.sessions
+		options.AgentTasks = stub
 	})
-	app.runtime.SetAgentTaskController(stub)
 	app.sessionID = fixture.parent.ID
 
 	return fixture, task, app
@@ -223,6 +230,41 @@ func newActivePromptInspectionTestApp(
 	app.working = true
 
 	return fixture, task, app
+}
+
+func TestAgentTaskWatchSkipsFailedSubscription(t *testing.T) {
+	t.Parallel()
+
+	stub := newAgentTaskControllerStub(nil, nil)
+	stub.subscribeErr = errors.New("subscription unavailable")
+	app := newAgentTaskBehaviorApp(t, stub)
+	app.screen = newClipboardScreen()
+	app.agentTasks = []database.AgentTaskEntity{behaviorAgentTask(behaviorTaskID, database.TaskRunning)}
+
+	app.watchActiveAgentTasks(t.Context())
+	assert.NotContains(t, app.agentTaskWatches, behaviorTaskID)
+	assertAgentTaskSubscriptionError(t, app)
+
+	app.watchInspectedAgentTask(t.Context(), behaviorTaskID)
+	assert.NotContains(t, app.agentTaskWatches, behaviorTaskID)
+	assertAgentTaskSubscriptionError(t, app)
+}
+
+func assertAgentTaskSubscriptionError(t *testing.T, app *App) {
+	t.Helper()
+
+	select {
+	case event := <-app.screen.EventQ():
+		interrupt, ok := event.(*tcell.EventInterrupt)
+		require.True(t, ok)
+		payload, ok := interrupt.Data().(*asyncEvent)
+		require.True(t, ok)
+		assert.Equal(t, asyncEventAgentTaskReplayError, payload.Kind)
+		assert.Contains(t, payload.Text, "failed to subscribe to agent task activity")
+		assert.Contains(t, payload.Text, "subscription unavailable")
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for subscription error")
+	}
 }
 
 func TestAgentTaskPureBehavior(t *testing.T) {
@@ -597,8 +639,10 @@ func TestAgentTaskSummaryEnterInspectsSelectedSubagent(t *testing.T) {
 		first.Task.ID:    &first,
 		selected.Task.ID: &selected,
 	}, nil)
-	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) { options.Sessions = sessions })
-	runtime.SetAgentTaskController(stub)
+	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.Sessions = sessions
+		options.AgentTasks = stub
+	})
 
 	app := newRenderTestApp(t)
 	app.runtime = runtime
@@ -646,8 +690,10 @@ func TestInspectAndLeaveAgentTaskSession(t *testing.T) {
 	task.Task.OwnerSessionID = parent.ID
 	task.ChildSessionID = child.ID
 	stub := newAgentTaskControllerStub(map[string]*database.AgentTaskEntity{behaviorTaskID: &task}, nil)
-	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) { options.Sessions = sessions })
-	runtime.SetAgentTaskController(stub)
+	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.Sessions = sessions
+		options.AgentTasks = stub
+	})
 
 	_, err := sessions.AppendMessage(t.Context(), child.ID, nil, &database.MessageEntity{
 		Timestamp: time.Now().UTC(),
@@ -835,8 +881,10 @@ func TestInspectAgentTaskSwitchesBetweenSiblingSessions(t *testing.T) {
 		first.Task.ID:  &first,
 		second.Task.ID: &second,
 	}, nil)
-	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) { options.Sessions = sessions })
-	runtime.SetAgentTaskController(stub)
+	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.Sessions = sessions
+		options.AgentTasks = stub
+	})
 
 	app := newRenderTestApp(t)
 	app.runtime = runtime
@@ -878,8 +926,10 @@ func TestInspectAgentTaskRecoversRetainedSummaryOwner(t *testing.T) {
 	second.Task.OwnerSessionID = parent.ID
 	second.ChildSessionID = secondChild.ID
 	stub := newAgentTaskControllerStub(map[string]*database.AgentTaskEntity{second.Task.ID: &second}, nil)
-	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) { options.Sessions = sessions })
-	runtime.SetAgentTaskController(stub)
+	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.Sessions = sessions
+		options.AgentTasks = stub
+	})
 
 	app := newRenderTestApp(t)
 	app.runtime = runtime
@@ -1023,10 +1073,13 @@ func TestAgentTaskCompletionRoutesToParentWhileChildIsInspected(t *testing.T) {
 
 	fixture, task, app := newActivePromptInspectionTestApp(t, database.TaskSucceeded, nil)
 	task.Task.Result = "parent completion"
-	app.runtime.SetAgentTaskController(newAgentTaskControllerStub(
-		map[string]*database.AgentTaskEntity{task.Task.ID: &task},
-		nil,
-	))
+	app.runtime = assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.Sessions = fixture.sessions
+		options.AgentTasks = newAgentTaskControllerStub(
+			map[string]*database.AgentTaskEntity{task.Task.ID: &task},
+			nil,
+		)
+	})
 
 	require.NoError(t, app.inspectAgentTask(t.Context(), behaviorTaskID))
 	defer app.stopAgentTaskWatches()
@@ -1063,13 +1116,16 @@ func TestActivePromptInspectionAllowsNestedTaskSelection(t *testing.T) {
 	nestedTask := behaviorAgentTask("nested-task", database.TaskRunning)
 	nestedTask.Task.OwnerSessionID = fixture.child.ID
 	nestedTask.ChildSessionID = "nested-session"
-	app.runtime.SetAgentTaskController(newAgentTaskControllerStub(
-		map[string]*database.AgentTaskEntity{
-			behaviorTaskID: &parentTask,
-			"nested-task":  &nestedTask,
-		},
-		nil,
-	))
+	app.runtime = assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.Sessions = fixture.sessions
+		options.AgentTasks = newAgentTaskControllerStub(
+			map[string]*database.AgentTaskEntity{
+				behaviorTaskID: &parentTask,
+				"nested-task":  &nestedTask,
+			},
+			nil,
+		)
+	})
 
 	require.NoError(t, app.inspectAgentTask(t.Context(), behaviorTaskID))
 	defer app.stopAgentTaskWatches()
@@ -1221,8 +1277,8 @@ func TestInspectAgentTaskRejectsLeavingPromptOwningInspectedSession(t *testing.T
 	app := newRenderTestApp(t)
 	app.runtime = assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
 		options.Sessions = fixture.sessions
+		options.AgentTasks = stub
 	})
-	app.runtime.SetAgentTaskController(stub)
 	app.sessionID = fixture.child.ID
 	app.agentTaskSessionStack = []string{fixture.parent.ID}
 	app.activePrompt = newTestActivePrompt(nil)
@@ -1421,8 +1477,9 @@ func TestInspectAgentTaskLookupFailureDoesNotMutateState(t *testing.T) {
 				nil,
 			)
 			stub.getErr = testCase.getErr
-			app.runtime = assistant.NewRuntimeForTest(nil)
-			app.runtime.SetAgentTaskController(stub)
+			app.runtime = assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+				options.AgentTasks = stub
+			})
 
 			err := app.inspectAgentTask(t.Context(), behaviorTaskID)
 			require.Error(t, err)
@@ -1477,8 +1534,8 @@ func TestInspectAgentTaskLoadFailureDoesNotSwitchSession(t *testing.T) {
 			stub := newAgentTaskControllerStub(map[string]*database.AgentTaskEntity{behaviorTaskID: &task}, nil)
 			runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
 				options.Sessions = sessions
+				options.AgentTasks = stub
 			})
-			runtime.SetAgentTaskController(stub)
 
 			app := newRenderTestApp(t)
 			app.runtime = runtime

--- a/internal/terminal/agent_tasks_behavior_internal_test.go
+++ b/internal/terminal/agent_tasks_behavior_internal_test.go
@@ -683,17 +683,9 @@ func TestInspectAgentTaskWithoutRuntimeDoesNotMutateState(t *testing.T) {
 func TestInspectAndLeaveAgentTaskSession(t *testing.T) {
 	t.Parallel()
 
-	fixture := newAgentTaskSessionPair(t)
-	connection, sessions, parent, child := fixture.connection, fixture.sessions, fixture.parent, fixture.child
-
-	task := behaviorAgentTask(behaviorTaskID, database.TaskRunning)
-	task.Task.OwnerSessionID = parent.ID
-	task.ChildSessionID = child.ID
-	stub := newAgentTaskControllerStub(map[string]*database.AgentTaskEntity{behaviorTaskID: &task}, nil)
-	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
-		options.Sessions = sessions
-		options.AgentTasks = stub
-	})
+	fixture, task, app := newAgentTaskSessionTestApp(t, database.TaskRunning)
+	connection, sessions := fixture.connection, fixture.sessions
+	parent, child := fixture.parent, fixture.child
 
 	_, err := sessions.AppendMessage(t.Context(), child.ID, nil, &database.MessageEntity{
 		Timestamp: time.Now().UTC(),
@@ -714,8 +706,6 @@ func TestInspectAndLeaveAgentTaskSession(t *testing.T) {
 			`"hide_thinking":true,"tools_expanded":true}`,
 	}))
 
-	app := newRenderTestApp(t)
-	app.runtime = runtime
 	app.settings = settings
 	app.cfg = promptSendTestConfig()
 	app.cfg.Assistant.Provider = "parent-provider"
@@ -1525,22 +1515,10 @@ func TestInspectAgentTaskLoadFailureDoesNotSwitchSession(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			fixture := newAgentTaskSessionPair(t)
-			connection, sessions, parent, child := fixture.connection, fixture.sessions, fixture.parent, fixture.child
-
-			task := behaviorAgentTask(behaviorTaskID, database.TaskRunning)
-			task.Task.OwnerSessionID = parent.ID
-			task.ChildSessionID = child.ID
-			stub := newAgentTaskControllerStub(map[string]*database.AgentTaskEntity{behaviorTaskID: &task}, nil)
-			runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
-				options.Sessions = sessions
-				options.AgentTasks = stub
-			})
-
-			app := newRenderTestApp(t)
-			app.runtime = runtime
+			fixture, task, app := newAgentTaskSessionTestApp(t, database.TaskRunning)
+			connection, sessions := fixture.connection, fixture.sessions
+			parent, child := fixture.parent, fixture.child
 			app.settings = testutil.DocumentRepository(t, connection)
-			app.sessionID = parent.ID
 			snapshot := seedInspectFailureState(app, &task)
 
 			testCase.arrangeFail(t, app, sessions, child.ID)

--- a/internal/terminal/agent_tasks_live_internal_test.go
+++ b/internal/terminal/agent_tasks_live_internal_test.go
@@ -38,8 +38,8 @@ func TestInspectedAgentTaskRendersLiveStreamAndReloadsOnCompletion(t *testing.T)
 	stub := newAgentTaskControllerStub(map[string]*database.AgentTaskEntity{task.Task.ID: &task}, nil)
 	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
 		options.Sessions = sessions
+		options.AgentTasks = stub
 	})
-	runtime.SetAgentTaskController(stub)
 
 	app := newRenderTestApp(t)
 	app.runtime = runtime
@@ -190,8 +190,8 @@ func TestInspectRunningAgentTaskReplaysActivityEmittedBeforeSubscription(t *test
 	}
 	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
 		options.Sessions = sessions
+		options.AgentTasks = controller
 	})
-	runtime.SetAgentTaskController(controller)
 
 	screen := newClipboardScreen()
 	app := newRenderTestApp(t)
@@ -247,8 +247,10 @@ func TestNestedAgentTaskReturnResumesAndReplaysParentActivity(t *testing.T) {
 			Kind: assistant.StreamEventTextDelta, Text: "parent resumed activity",
 		})},
 	}
-	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) { options.Sessions = sessions })
-	runtime.SetAgentTaskController(controller)
+	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.Sessions = sessions
+		options.AgentTasks = controller
+	})
 
 	screen := newClipboardScreen()
 	app := newRenderTestApp(t)
@@ -298,8 +300,9 @@ func TestAgentTaskWatcherReplaysLiveSequenceGap(t *testing.T) {
 		calls: 0,
 		mu:    sync.Mutex{},
 	}
-	runtime := assistant.NewRuntimeForTest(nil)
-	runtime.SetAgentTaskController(controller)
+	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.AgentTasks = controller
+	})
 
 	screen := newClipboardScreen()
 	app := newRenderTestApp(t)
@@ -341,8 +344,9 @@ func TestAgentTaskSequenceGapReplaysDurableEvents(t *testing.T) {
 			}),
 		},
 	}
-	runtime := assistant.NewRuntimeForTest(nil)
-	runtime.SetAgentTaskController(controller)
+	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.AgentTasks = controller
+	})
 
 	screen := newClipboardScreen()
 	app := newRenderTestApp(t)
@@ -371,8 +375,9 @@ func TestAgentTaskGapReplayErrorStopsBeforeOutOfOrderEvent(t *testing.T) {
 		calls:                   0,
 		mu:                      sync.Mutex{},
 	}
-	runtime := assistant.NewRuntimeForTest(nil)
-	runtime.SetAgentTaskController(controller)
+	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.AgentTasks = controller
+	})
 
 	screen := newClipboardScreen()
 	app := newRenderTestApp(t)
@@ -414,8 +419,9 @@ func TestAgentTaskReplayQueryErrorIsSurfaced(t *testing.T) {
 		calls:                   0,
 		mu:                      sync.Mutex{},
 	}
-	runtime := assistant.NewRuntimeForTest(nil)
-	runtime.SetAgentTaskController(controller)
+	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.AgentTasks = controller
+	})
 
 	screen := newClipboardScreen()
 	app := newRenderTestApp(t)
@@ -592,8 +598,9 @@ func TestAgentTaskReplayErrorDoesNotImmediatelyRestartFailedWatch(t *testing.T) 
 		calls: 0,
 		mu:    sync.Mutex{},
 	}
-	runtime := assistant.NewRuntimeForTest(nil)
-	runtime.SetAgentTaskController(controller)
+	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.AgentTasks = controller
+	})
 
 	screen := newClipboardScreen()
 	app := newRenderTestApp(t)
@@ -644,8 +651,9 @@ func TestOrdinaryAgentTaskWatchReplaysPersistedTerminalEvent(t *testing.T) {
 			},
 		}},
 	}
-	runtime := assistant.NewRuntimeForTest(nil)
-	runtime.SetAgentTaskController(controller)
+	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.AgentTasks = controller
+	})
 
 	screen := newClipboardScreen()
 	app := newRenderTestApp(t)
@@ -688,8 +696,9 @@ func TestAgentTaskSequenceGapReplaysTerminalInOrder(t *testing.T) {
 			},
 		},
 	}
-	runtime := assistant.NewRuntimeForTest(nil)
-	runtime.SetAgentTaskController(controller)
+	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.AgentTasks = controller
+	})
 
 	screen := newClipboardScreen()
 	app := newRenderTestApp(t)
@@ -729,8 +738,9 @@ func TestUnexpectedAgentTaskWatchClosureClearsRegistration(t *testing.T) {
 		agentTaskControllerStub: newAgentTaskControllerStub(nil, nil),
 		events:                  nil,
 	}
-	runtime := assistant.NewRuntimeForTest(nil)
-	runtime.SetAgentTaskController(controller)
+	runtime := assistant.NewRuntimeForTest(func(options *assistant.RuntimeTestOptions) {
+		options.AgentTasks = controller
+	})
 
 	screen := newClipboardScreen()
 	app := newRenderTestApp(t)

--- a/internal/workflow/dispatcher.go
+++ b/internal/workflow/dispatcher.go
@@ -98,6 +98,10 @@ func NewStoppedDispatcher(ctx context.Context, options DispatcherOptions) (*Disp
 
 // Start launches workflow workers and polling.
 func (dispatcher *Dispatcher) Start(ctx context.Context) error {
+	if ctx == nil {
+		return oops.In("workflow").Code("nil_start_context").Errorf("start context is required")
+	}
+
 	dispatcher.mu.Lock()
 	defer dispatcher.mu.Unlock()
 

--- a/internal/workflow/dispatcher.go
+++ b/internal/workflow/dispatcher.go
@@ -30,21 +30,38 @@ type DispatcherOptions struct {
 
 // Dispatcher polls durable queued workflows and executes atomically claimed runs.
 type Dispatcher struct {
-	service  *Service
-	tasks    *database.TaskRepository
-	logger   *slog.Logger
-	queue    chan string
-	cancel   context.CancelFunc
-	done     <-chan struct{}
-	wg       sync.WaitGroup
-	submits  sync.WaitGroup
-	interval time.Duration
-	mu       sync.Mutex
-	closed   bool
+	service     *Service
+	tasks       *database.TaskRepository
+	logger      *slog.Logger
+	queue       chan string
+	cancel      context.CancelFunc
+	done        <-chan struct{}
+	ctx         context.Context
+	wg          sync.WaitGroup
+	submits     sync.WaitGroup
+	mu          sync.Mutex
+	interval    time.Duration
+	concurrency int
+	closed      bool
+	started     bool
 }
 
-// NewDispatcher starts durable workflow workers.
+// NewDispatcher creates and starts durable workflow workers.
 func NewDispatcher(ctx context.Context, options DispatcherOptions) (*Dispatcher, error) {
+	dispatcher, err := NewStoppedDispatcher(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := dispatcher.Start(); err != nil {
+		return nil, err
+	}
+
+	return dispatcher, nil
+}
+
+// NewStoppedDispatcher creates a dispatcher without starting its workers.
+func NewStoppedDispatcher(ctx context.Context, options DispatcherOptions) (*Dispatcher, error) {
 	if ctx == nil || options.Service == nil || options.Tasks == nil {
 		return nil, oops.In("workflow").Code("invalid_dispatcher_dependencies").
 			Errorf("process context, workflow service, and task repository are required")
@@ -74,18 +91,37 @@ func NewDispatcher(ctx context.Context, options DispatcherOptions) (*Dispatcher,
 	dispatcher := &Dispatcher{
 		service: options.Service, tasks: options.Tasks, logger: logger,
 		queue: make(chan string, buffer), cancel: cancel, done: dispatchCtx.Done(),
-		wg: sync.WaitGroup{}, submits: sync.WaitGroup{}, interval: interval, mu: sync.Mutex{}, closed: false,
+		wg: sync.WaitGroup{}, submits: sync.WaitGroup{}, interval: interval,
+		concurrency: concurrency, ctx: dispatchCtx, mu: sync.Mutex{}, closed: false, started: false,
 	}
 
-	for range concurrency {
+	return dispatcher, nil
+}
+
+// Start launches workflow workers and polling.
+func (dispatcher *Dispatcher) Start() error {
+	dispatcher.mu.Lock()
+	defer dispatcher.mu.Unlock()
+
+	if dispatcher.closed {
+		return oops.In("workflow").Code("dispatcher_shutdown").Errorf("workflow dispatcher is shut down")
+	}
+
+	if dispatcher.started {
+		return nil
+	}
+
+	for range dispatcher.concurrency {
 		dispatcher.wg.Add(1)
-		go dispatcher.worker(dispatchCtx)
+		go dispatcher.worker(dispatcher.ctx)
 	}
 
 	dispatcher.wg.Add(1)
-	go dispatcher.poll(dispatchCtx)
+	go dispatcher.poll(dispatcher.ctx)
 
-	return dispatcher, nil
+	dispatcher.started = true
+
+	return nil
 }
 
 // Submit persists and schedules a workflow run.

--- a/internal/workflow/dispatcher.go
+++ b/internal/workflow/dispatcher.go
@@ -36,7 +36,6 @@ type Dispatcher struct {
 	queue       chan string
 	cancel      context.CancelFunc
 	done        <-chan struct{}
-	ctx         context.Context
 	wg          sync.WaitGroup
 	submits     sync.WaitGroup
 	mu          sync.Mutex
@@ -53,7 +52,7 @@ func NewDispatcher(ctx context.Context, options DispatcherOptions) (*Dispatcher,
 		return nil, err
 	}
 
-	if err := dispatcher.Start(); err != nil {
+	if err := dispatcher.Start(ctx); err != nil {
 		return nil, err
 	}
 
@@ -87,19 +86,18 @@ func NewStoppedDispatcher(ctx context.Context, options DispatcherOptions) (*Disp
 		logger = slog.Default()
 	}
 
-	dispatchCtx, cancel := context.WithCancel(ctx)
 	dispatcher := &Dispatcher{
 		service: options.Service, tasks: options.Tasks, logger: logger,
-		queue: make(chan string, buffer), cancel: cancel, done: dispatchCtx.Done(),
-		wg: sync.WaitGroup{}, submits: sync.WaitGroup{}, interval: interval,
-		concurrency: concurrency, ctx: dispatchCtx, mu: sync.Mutex{}, closed: false, started: false,
+		queue: make(chan string, buffer), cancel: nil, done: nil,
+		wg: sync.WaitGroup{}, submits: sync.WaitGroup{},
+		interval: interval, concurrency: concurrency, mu: sync.Mutex{}, closed: false, started: false,
 	}
 
 	return dispatcher, nil
 }
 
 // Start launches workflow workers and polling.
-func (dispatcher *Dispatcher) Start() error {
+func (dispatcher *Dispatcher) Start(ctx context.Context) error {
 	dispatcher.mu.Lock()
 	defer dispatcher.mu.Unlock()
 
@@ -111,13 +109,17 @@ func (dispatcher *Dispatcher) Start() error {
 		return nil
 	}
 
+	workerCtx, cancel := context.WithCancel(ctx)
+	dispatcher.cancel = cancel
+	dispatcher.done = workerCtx.Done()
+
 	for range dispatcher.concurrency {
 		dispatcher.wg.Add(1)
-		go dispatcher.worker(dispatcher.ctx)
+		go dispatcher.worker(workerCtx)
 	}
 
 	dispatcher.wg.Add(1)
-	go dispatcher.poll(dispatcher.ctx)
+	go dispatcher.poll(workerCtx)
 
 	dispatcher.started = true
 
@@ -160,7 +162,10 @@ func (dispatcher *Dispatcher) Await(ctx context.Context, runID string) (*databas
 func (dispatcher *Dispatcher) Shutdown(ctx context.Context) error {
 	dispatcher.mu.Lock()
 	dispatcher.closed = true
-	dispatcher.cancel()
+
+	if dispatcher.cancel != nil {
+		dispatcher.cancel()
+	}
 	dispatcher.mu.Unlock()
 
 	done := make(chan struct{})

--- a/internal/workflow/dispatcher_test.go
+++ b/internal/workflow/dispatcher_test.go
@@ -128,6 +128,35 @@ func TestDispatcherShutdownDoesNotHoldLifecycleLockAcrossSubmitIO(t *testing.T) 
 	require.NoError(t, dispatcher.Shutdown(context.Background()))
 }
 
+func TestStoppedDispatcherWaitsForStart(t *testing.T) {
+	t.Parallel()
+
+	service, repository, owner := newWorkflowService(t, newFakeController())
+	run, err := service.Submit(t.Context(), &workflow.ServiceRequest{
+		Name: "recovered", Source: "2 + 2", SourceVersion: "v1", ArgumentsJSON: "{}",
+		OwnerSessionID: owner,
+	})
+	require.NoError(t, err)
+
+	dispatcher, err := workflow.NewStoppedDispatcher(t.Context(), workflow.DispatcherOptions{
+		Service: service, Tasks: repository.Tasks(), Logger: nil, Concurrency: 1,
+		Buffer: 1, Interval: time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, dispatcher.Shutdown(context.Background())) })
+
+	persisted, found, err := repository.Get(t.Context(), run.Task.ID)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, database.TaskQueued, persisted.Task.State)
+
+	require.NoError(t, dispatcher.Start())
+	require.NoError(t, dispatcher.Start())
+	completed, err := dispatcher.Await(t.Context(), run.Task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, database.TaskSucceeded, completed.Task.State)
+}
+
 func TestDispatcherExecutesSubmittedWorkflow(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workflow/dispatcher_test.go
+++ b/internal/workflow/dispatcher_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/oops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -143,6 +144,16 @@ func TestStoppedDispatcherWaitsForStart(t *testing.T) {
 		Buffer: 1, Interval: time.Millisecond,
 	})
 	require.NoError(t, err)
+
+	var (
+		nilContext context.Context
+		coded      oops.OopsError
+	)
+
+	err = dispatcher.Start(nilContext)
+	require.ErrorAs(t, err, &coded)
+	assert.Equal(t, "nil_start_context", coded.Code())
+
 	t.Cleanup(func() { require.NoError(t, dispatcher.Shutdown(context.Background())) })
 
 	persisted, found, err := repository.Get(t.Context(), run.Task.ID)

--- a/internal/workflow/dispatcher_test.go
+++ b/internal/workflow/dispatcher_test.go
@@ -150,8 +150,8 @@ func TestStoppedDispatcherWaitsForStart(t *testing.T) {
 	require.True(t, found)
 	assert.Equal(t, database.TaskQueued, persisted.Task.State)
 
-	require.NoError(t, dispatcher.Start())
-	require.NoError(t, dispatcher.Start())
+	require.NoError(t, dispatcher.Start(t.Context()))
+	require.NoError(t, dispatcher.Start(t.Context()))
 	completed, err := dispatcher.Await(t.Context(), run.Task.ID)
 	require.NoError(t, err)
 	assert.Equal(t, database.TaskSucceeded, completed.Task.State)


### PR DESCRIPTION
## Summary
- publish agent-task and workflow capabilities atomically after bootstrap
- introduce stopped worker construction so work cannot run before capability publication
- revoke capabilities during failed startup and shutdown
- distinguish subscription failures from closed streams and handle them in the terminal
- add comprehensive lifecycle, delegation, race, and regression coverage

## Validation
- mise exec -- go test ./...
- mise exec -- task build
- mise exec -- task ci
- mise exec -- task lint
- git diff --check